### PR TITLE
Move import fcntl inside if statement.

### DIFF
--- a/packages/vaex-core/vaex/dataset_mmap.py
+++ b/packages/vaex-core/vaex/dataset_mmap.py
@@ -20,7 +20,6 @@ import vaex.dataset
 import vaex.file
 from vaex.expression import Expression
 import struct
-import fcntl
 
 logger = logging.getLogger("vaex.file")
 
@@ -45,6 +44,7 @@ if no_mmap:
 
     from cachetools import LRUCache
     import threading
+    import fcntl
     GB = 1024**3
     def getsizeof(ar):
         return ar.nbytes


### PR DESCRIPTION
`fcntl` is only used inside the `if _nommap:` statement, therefore the import statement can be moved inside the if statement to prevent it from importing when it is not used (which is the case for Windows users).

Fixes #93