### PR TITLE
Manually import underscored symbols from .dataframe to .dataset

### DIFF
--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -1,4 +1,32 @@
 from .dataframe import *
+from .dataframe import (
+    # .dataframe imports from .utils
+    _ensure_strings_from_expressions,
+    _ensure_string_from_expression,
+    _ensure_list,
+    _is_limit,
+    _isnumber,
+    _issequence,
+    _is_string,
+    _parse_reduction,
+    _parse_n,
+    _normalize_selection_name,
+    _normalize,
+    _parse_f,
+    _expand,
+    _expand_shape,
+    _expand_limits,
+    _split_and_combine_mask,
+    # dataframe definitions
+    _ColumnConcatenatedLazy,
+    _doc_snippets,
+    _functions_statistics_1d,
+    _hidden,
+    _is_array_type_ok,
+    _is_dtype_ok,
+    _requires
+)
+
 # alias kept for backward compatibility
 Dataset = DataFrame
 DatasetLocal = DataFrameLocal


### PR DESCRIPTION
`from X import *` doesn't import under underscored symbols, so we have
to do this by hand. It would be  better to put this in `.dataframe.__all__`,
but this is less work and `.dataset` is (about to be) deprecated I think.

Fixes #170.