### PR TITLE
Remove kapteyn dependency for vaex-astro

### DIFF
--- a/packages/vaex-astro/setup.py
+++ b/packages/vaex-astro/setup.py
@@ -12,7 +12,7 @@ author_email= 'maartenbreddels@gmail.com'
 license     = 'MIT'
 version     = version.__version__
 url         = 'https://www.github.com/maartenbreddels/vaex'
-install_requires_astro = ['vaex-core>=0.1', 'kapteyn']
+install_requires_astro = ['vaex-core>=0.1']
 
 setup(name=name + '-astro',
       version=version,

--- a/packages/vaex-astro/vaex/astro/transformations.py
+++ b/packages/vaex-astro/vaex/astro/transformations.py
@@ -260,10 +260,10 @@ def add_virtual_columns_equatorial_to_galactic_cartesian(self, alpha, delta, dis
 
 
 @patch
-def add_virtual_columns_celestial(self, long_in, lat_in, long_out, lat_out, input=None, output=None, name_prefix="__celestial", radians=False, _matrix):
+def add_virtual_columns_celestial(self, long_in, lat_in, long_out, lat_out, input=None, output=None, name_prefix="__celestial", radians=False, _matrix=comat['eq2gal']):
     #import kapteyn.celestial as c
-    input = input if input is not None
-    output = output if output is not None
+    input = input
+    output = output
     matrix = _matrix
     if not radians:
         long_in = "pi/180.*%s" % long_in

--- a/packages/vaex-astro/vaex/astro/transformations.py
+++ b/packages/vaex-astro/vaex/astro/transformations.py
@@ -32,7 +32,7 @@ def add_virtual_columns_eq2ecl(self, long_in="ra", lat_in="dec", long_out="lambd
     :return:
     """
 
-    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix=comat['eq2ecl'])
+    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix='eq2ecl')
 
 
 @patch
@@ -48,7 +48,7 @@ def add_virtual_columns_eq2gal(self, long_in="ra", lat_in="dec", long_out="l", l
     :return:
     """
 
-    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix=comat['eq2gal'])
+    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix='eq2gal')
 
 
 @patch
@@ -63,7 +63,7 @@ def add_virtual_columns_gal2eq(self, long_in='l', lat_in='b', long_out='ra', lat
     :param radians: input and output in radians (True), or degrees (False)
     """
 
-    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix=comat['gal2eq'])
+    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix='gal2eq')
 
 
 @patch
@@ -253,7 +253,10 @@ def add_virtual_columns_equatorial_to_galactic_cartesian(self, alpha, delta, dis
 
 @patch
 def add_virtual_columns_celestial(self, long_in, lat_in, long_out, lat_out, name_prefix="__celestial", radians=False, _matrix=None):
-    matrix = _matrix
+    #TODO: return wrapped angle, currently returning angles between [-2pi:2pi]. Need modulo arhitmetics on vaex add_virtual_column expressions.
+    #      for example see http://docs.astropy.org/en/stable/_modules/astropy/coordinates/angles.html#Angle.wrap_at
+
+    matrix = comat[_matrix]
     if not radians:
         long_in = "pi/180.*%s" % long_in
         lat_in = "pi/180.*%s" % lat_in

--- a/packages/vaex-astro/vaex/astro/transformations.py
+++ b/packages/vaex-astro/vaex/astro/transformations.py
@@ -8,8 +8,7 @@ def patch(f):
     Dataset.__hidden__[name] = f
     return f
 
-
-# All assume j2000
+# All assume equinox J2000
 comat = {'eq2ecl': [[0.9999999999999928, 1.1102233723050031e-07, 4.411803426976324e-08],
                      [-1.1941015020086788e-07, 0.9174821814419274, 0.39777688059582816],
                      [3.684608657254395e-09, -0.39777688059583055, 0.9174821814419342]],
@@ -21,56 +20,50 @@ comat = {'eq2ecl': [[0.9999999999999928, 1.1102233723050031e-07, 4.4118034269763
                      [-0.48383507361641837, 0.7469821839845096, 0.45598381369115243]]}
 
 @patch
-def add_virtual_columns_eq2ecl(self, long_in="ra", lat_in="dec", long_out="lambda_", lat_out="beta", input=None, output=None, name_prefix="__celestial_eq2ecl", radians=False):
+def add_virtual_columns_eq2ecl(self, long_in="ra", lat_in="dec", long_out="lambda_", lat_out="beta", name_prefix="__celestial_eq2ecl", radians=False):
     """Add ecliptic coordates (long_out, lat_out) from equatorial coordinates.
 
     :param long_in: Name/expression for right ascension
     :param lat_in: Name/expression for declination
     :param long_out:  Output name for lambda coordinate
     :param lat_out: Output name for beta coordinate
-    :param input:
-    :param output:
     :param name_prefix:
     :param radians: input and output in radians (True), or degrees (False)
     :return:
     """
 
-    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, input=input, output=output, name_prefix=name_prefix, radians=radians, _matrix=comat['eq2ecl'])
+    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix=comat['eq2ecl'])
 
 
 @patch
-def add_virtual_columns_eq2gal(self, long_in="ra", lat_in="dec", long_out="l", lat_out="b", input=None, output=None, name_prefix="__celestial_eq2gal", radians=False):
+def add_virtual_columns_eq2gal(self, long_in="ra", lat_in="dec", long_out="l", lat_out="b", name_prefix="__celestial_eq2gal", radians=False):
     """Add galactic coordates (long_out, lat_out) from equatorial coordinates.
 
     :param long_in: Name/expression for right ascension
     :param lat_in: Name/expression for declination
     :param long_out:  Output name for galactic longitude
     :param lat_out: Output name for galactic latitude
-    :param input:
-    :param output:
     :param name_prefix:
     :param radians: input and output in radians (True), or degrees (False)
     :return:
     """
 
-    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, input=input, output=output, name_prefix=name_prefix, radians=radians, _matrix=comat['eq2gal'])
+    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix=comat['eq2gal'])
 
 
 @patch
-def add_virtual_columns_gal2eq(self, long_in='l', lat_in='b', long_out='ra', lat_out='dec', input=None, output=None, name_prefix="__celestial_gal2eq", radians=False):
+def add_virtual_columns_gal2eq(self, long_in='l', lat_in='b', long_out='ra', lat_out='dec', name_prefix="__celestial_gal2eq", radians=False):
     """
     Convert from galactic (l,b) to equatorial (ra,dec) spherical coordinate system.
     :param long_in: longitudinal angle l
     :param lat_in: latitudinal angle b
     :param long_out: right ascension
     :param lat_out: declination
-    :param input:
-    :param output:
     :param name_prefix:
     :param radians: input and output in radians (True), or degrees (False)
     """
 
-    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, input=input, output=output, name_prefix=name_prefix, radians=radians, _matrix=comat['gal2eq'])
+    self.add_virtual_columns_celestial(long_in, lat_in, long_out, lat_out, name_prefix=name_prefix, radians=radians, _matrix=comat['gal2eq'])
 
 
 @patch
@@ -166,7 +159,6 @@ def add_virtual_columns_proper_motion_eq2gal(self, long_in="ra", lat_in="dec", p
     :parap inverse: (For internal use) convert from galactic to equatorial instead
     :return:
     """
-    # import kapteyn.celestial as c
     """mu_gb =  mu_dec*(cdec*sdp-sdec*cdp*COS(ras))/cgb $
       - mu_ra*cdp*SIN(ras)/cgb"""
     long_in_original = long_in = self._expr(long_in)
@@ -260,10 +252,7 @@ def add_virtual_columns_equatorial_to_galactic_cartesian(self, alpha, delta, dis
 
 
 @patch
-def add_virtual_columns_celestial(self, long_in, lat_in, long_out, lat_out, input=None, output=None, name_prefix="__celestial", radians=False, _matrix=comat['eq2gal']):
-    #import kapteyn.celestial as c
-    input = input
-    output = output
+def add_virtual_columns_celestial(self, long_in, lat_in, long_out, lat_out, name_prefix="__celestial", radians=False, _matrix=None):
     matrix = _matrix
     if not radians:
         long_in = "pi/180.*%s" % long_in

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -1091,7 +1091,7 @@ class TestDataset(unittest.TestCase):
 		self.assertAlmostEqual(r, 1)
 
 
-		dataset.add_virtual_columns_celestial("alpha", "delta", "l", "b")
+		dataset.add_virtual_columns_celestial("alpha", "delta", "l", "b", _matrix='eq2gal')
 		# TODO: properly test, with and without radians
 		dataset.evaluate("l")
 		dataset.evaluate("b")

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class DevelopCmd(develop):
     def run(self):
         for package in packages:
             with cwd(os.path.join('packages', package)):
-                os.system('python -m pip install -e . --user')
+                os.system('python -m pip install -e .')
             # we need to make symbolic links from vaex-core/vaex/<name> to vaex-<name>/vaex/<name
             # otherwise development install do not work
             if package != 'vaex-core':
@@ -42,10 +42,10 @@ class InstallCmd(install):
     def run(self):
         for package in packages:
             with cwd(os.path.join('packages', package)):
-                os.system('python -m pip install --no-deps . --user')
+                os.system('python -m pip install --no-deps .')
         for package in packages:
             with cwd(os.path.join('packages', package)):
-                os.system('python -m pip install --upgrade . --user')
+                os.system('python -m pip install --upgrade .')
         if on_rtd:
             os.system('python -m pip install vaex-ml==0.3.2')
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class DevelopCmd(develop):
     def run(self):
         for package in packages:
             with cwd(os.path.join('packages', package)):
-                os.system('python -m pip install -e .')
+                os.system('python -m pip install -e . --user')
             # we need to make symbolic links from vaex-core/vaex/<name> to vaex-<name>/vaex/<name
             # otherwise development install do not work
             if package != 'vaex-core':
@@ -42,10 +42,10 @@ class InstallCmd(install):
     def run(self):
         for package in packages:
             with cwd(os.path.join('packages', package)):
-                os.system('python -m pip install --no-deps .')
+                os.system('python -m pip install --no-deps . --user')
         for package in packages:
             with cwd(os.path.join('packages', package)):
-                os.system('python -m pip install --upgrade .')
+                os.system('python -m pip install --upgrade . --user')
         if on_rtd:
             os.system('python -m pip install vaex-ml==0.3.2')
 


### PR DESCRIPTION
The kapteyn package is failing to build for python >= 3.7 due to some CYTHON issue in their WCSLib. That breaks the install of vaex-astro.

I propose removing the dependency on kapteyn by assuming static rotation matrices for the coordinate transformations, since the change of Equinox was not even implemented in the first place. 

PS: I changed the setup.py to allow force the --user flag to be passed to subpackages, but I am not sure how to remove it from the pull request. 