### PR TITLE
New feature: Initial Parquet support

### DIFF
--- a/packages/vaex-arrow/vaex_arrow/dataset.py
+++ b/packages/vaex-arrow/vaex_arrow/dataset.py
@@ -2,6 +2,7 @@ __author__ = 'maartenbreddels'
 import logging
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 
 import vaex.dataset
 import vaex.file.other
@@ -28,6 +29,7 @@ class DatasetArrow(vaex.dataset.DatasetLocal):
     
     def _load_table(self, table):
         self._length_unfiltered =  self._length_original = table.num_rows
+        self._index_end =  self._length_original = table.num_rows
         for col in table.columns:
             name = col.name
             # TODO: keep the arrow columns, and support and test chunks
@@ -51,5 +53,13 @@ class DatasetArrow(vaex.dataset.DatasetLocal):
     def option_to_args(cls, option):
         return []
 
+class DatasetParquet(DatasetArrow):
+    def _load(self):
+        # might not be optimal, but it works, we can always see if we can
+        # do mmapping later on
+        table = pq.read_table(self.path)
+        self._load_table(table)
+
 vaex.file.other.dataset_type_map["arrow"] = DatasetArrow
+vaex.file.other.dataset_type_map["parquet"] = DatasetParquet
 

--- a/packages/vaex-arrow/vaex_arrow/opener.py
+++ b/packages/vaex-arrow/vaex_arrow/opener.py
@@ -10,5 +10,16 @@ class ArrowOpener:
         from .dataset import DatasetArrow
         return DatasetArrow(path, *args, **kwargs)
 
+class ParquetOpener:
+    @staticmethod
+    def can_open(path, *args, **kwargs):
+        return path.rpartition('.')[2] == 'parquet'
+
+    @staticmethod
+    def open(path, *args, **kwargs):
+        from .dataset import DatasetParquet
+        return DatasetParquet(path, *args, **kwargs)
+
 def register_opener():
     vaex.file.register(ArrowOpener)
+    vaex.file.register(ParquetOpener)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4948,8 +4948,10 @@ class DataFrameLocal(DataFrame):
             self.export_arrow(path, column_names, byteorder, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
         elif path.endswith('.hdf5'):
             self.export_hdf5(path, column_names, byteorder, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
-        if path.endswith('.fits'):
+        elif path.endswith('.fits'):
             self.export_fits(path, column_names, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
+        if path.endswith('.parquet'):
+            self.export_parquet(path, column_names, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
     def export_arrow(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
         """Exports the DataFrame to a file written with arrow
@@ -4969,6 +4971,25 @@ class DataFrameLocal(DataFrame):
         """
         import vaex_arrow.export
         vaex_arrow.export.export(self, path, column_names, byteorder, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
+
+    def export_parquet(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
+        """Exports the DataFrame to a parquet file
+
+        :param DataFrameLocal df: DataFrame to export
+        :param str path: path for file
+        :param lis[str] column_names: list of column names to export or None for all columns
+        :param str byteorder: = for native, < for little endian and > for big endian
+        :param bool shuffle: export rows in random order
+        :param bool selection: export selection or not
+        :param progress: progress callback that gets a progress fraction as argument and should return True to continue,
+                or a default progress bar when progress=True
+        :param: bool virtual: When True, export virtual columns
+        :param str sort: expression used for sorting the output
+        :param bool ascending: sort ascending (True) or descending
+        :return:
+        """
+        import vaex_arrow.export
+        vaex_arrow.export.export_parquet(self, path, column_names, byteorder, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
     def export_hdf5(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
         """Exports the DataFrame to a vaex hdf5 file

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -1762,7 +1762,7 @@ class TestDataset(unittest.TestCase):
 						for shuffle in [False, True]:
 							for selection in [False, True, "named"]:
 								for virtual in [False, True]:
-									for export in [dataset.export_fits, dataset.export_hdf5, dataset.export_arrow]: #if byteorder == ">" else [dataset.export_hdf5]:
+									for export in [dataset.export_fits, dataset.export_hdf5, dataset.export_arrow, dataset.export_parquet]: #if byteorder == ">" else [dataset.export_hdf5]:
 										#print (">>>", dataset, path, column_names, byteorder, shuffle, selection, fraction, dataset.length_unfiltered(), virtual)
 										#byteorder = "<"
 										if export == dataset.export_fits and byteorder != ">":
@@ -1776,6 +1776,7 @@ class TestDataset(unittest.TestCase):
 										# same issue on windows for arrow, closing the mmapped file does not help
 										# for the moment we create a new temp file
 										path_arrow = tempfile.mktemp(".arrow")
+										path_parquet = tempfile.mktemp(".parquet")
 										#print dataset.length_unfiltered()
 										#print len(dataset)
 										if export == dataset.export_hdf5:
@@ -1783,6 +1784,9 @@ class TestDataset(unittest.TestCase):
 											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False)
 										elif export == dataset.export_arrow:
 											path = path_arrow
+											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False)
+										elif export == dataset.export_parquet:
+											path = path_parquet
 											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False)
 										else:
 											path = path_fits

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -11,6 +11,9 @@ def test_export(ds_local, tmpdir):
 	path = str(tmpdir.join('sample.hdf5'))
 	ds.export_hdf5(path)
 
+	path = str(tmpdir.join('sample.parquet'))
+	ds.export(path)
+	df = vaex.open(path)
 
 def test_export_string_mask(tmpdir):
 	df = vaex.from_arrays(s=vaex.string_column(['aap', None, 'mies']))


### PR DESCRIPTION
This allows exporting to parquet support, which is useful when if we want to benchmark against spark for instance.
Reading will be all in memory, so it may not yet be good for large datasets.
Once we have a usecase for a really large datasets in Parquet, for instance partitioned datasets, we can take another look at reading efficiently.