### PR TITLE
Travis CI: Look for Python syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,10 @@ before_install:
 install:
   - source activate test-environment
   - pip install flake8
+  # stop the build if there are Python syntax errors
+  - flake8 . --count --select=E9,F63,F72 --show-source --statistics
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  #- flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   - (cd packages/vaex-core; pip install -v .)
   - (cd packages/vaex-hdf5; pip install .)
   - (cd packages/vaex-arrow; pip install .)

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ before_install:
 #  - pip install -r requirements.txt
 install:
   - source activate test-environment
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   - (cd packages/vaex-core; pip install -v .)
   - (cd packages/vaex-hdf5; pip install .)
   - (cd packages/vaex-arrow; pip install .)

--- a/packages/vaex-ui/vaex/ui/layers.py
+++ b/packages/vaex-ui/vaex/ui/layers.py
@@ -302,7 +302,7 @@ class LayerTable(object):
             unit = self.dataset.unit(unit_expression)
             if unit:
                 what_units = unit.to_string('latex_inline')
-        label = "%s(%s)" % (self.statistic, self.weight if self.statistic is not "count" else self.weight_count)
+        label = "%s(%s)" % (self.statistic, self.weight if self.statistic != "count" else self.weight_count)
         label = self.amplitude.replace("grid", label)
         if what_units:
             label += " (%s)" % what_units


### PR DESCRIPTION
* Python 2: 3 files with syntax errors
* Python 3: 13 files with syntax errors.  See #210

To be [compatible with Python 2](https://travis-ci.org/vaexio/vaex/jobs/519204913#L1192), "`from __future__ import print_function`" would need to be added to the following files before all other __import__ statements:
* ./packages/vaex-core/vendor/string-view-lite/script/create-vcpkg.py
* ./packages/vaex-core/vendor/pybind11/tools/mkdoc.py