### PR TITLE
remove pandas dependency in formatting

### DIFF
--- a/packages/vaex-core/vaex/formatting.py
+++ b/packages/vaex-core/vaex/formatting.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numbers
 import six
-import pandas as pd
+import datetime
 
 
 MAX_LENGTH = 50
@@ -15,9 +15,24 @@ def _format_value(value):
     elif isinstance(value, np.ma.core.MaskedConstant):
         value = str(value)
     if isinstance(value, np.datetime64):
-        value = str(pd.to_datetime(value))
+        value = ' '.join(str(value).split('T'))
     if isinstance(value, np.timedelta64):
-        value = str(pd.to_timedelta(value))
+        tmp = datetime.timedelta(seconds=value / np.timedelta64(1, 's'))
+        ms = tmp.microseconds
+        s = np.mod(tmp.seconds, 60)
+        m = np.mod(tmp.seconds//60, 60)
+        h = tmp.seconds // 3600
+        d = tmp.days
+        if d<0:
+            if ms:
+                value = str('%i days +%02i:%02i:%02i.%i' % (d,h,m,s,ms))
+            else:
+                value = str('%i days +%02i:%02i:%02i' % (d,h,m,s))
+        else:
+            if ms:
+                value = str('%i days %02i:%02i:%02i.%i' % (d,h,m,s,ms))
+            else:
+                value = str('%i days %02i:%02i:%02i' % (d,h,m,s))
     elif not isinstance(value, numbers.Number):
         value = str(value)
     if isinstance(value, float):

--- a/packages/vaex-core/vaex/formatting.py
+++ b/packages/vaex-core/vaex/formatting.py
@@ -15,24 +15,24 @@ def _format_value(value):
     elif isinstance(value, np.ma.core.MaskedConstant):
         value = str(value)
     if isinstance(value, np.datetime64):
-        value = ' '.join(str(value).split('T'))
-    if isinstance(value, np.timedelta64):
-        tmp = datetime.timedelta(seconds=value / np.timedelta64(1, 's'))
-        ms = tmp.microseconds
-        s = np.mod(tmp.seconds, 60)
-        m = np.mod(tmp.seconds//60, 60)
-        h = tmp.seconds // 3600
-        d = tmp.days
-        if d<0:
-            if ms:
-                value = str('%i days +%02i:%02i:%02i.%i' % (d,h,m,s,ms))
-            else:
-                value = str('%i days +%02i:%02i:%02i' % (d,h,m,s))
+        if np.isnat(value):
+            value = 'NaT'
         else:
+            value = ' '.join(str(value).split('T'))
+    if isinstance(value, np.timedelta64):
+        if np.isnat(value):
+            value = 'NaT'
+        else:
+            tmp = datetime.timedelta(seconds=value / np.timedelta64(1, 's'))
+            ms = tmp.microseconds
+            s = np.mod(tmp.seconds, 60)
+            m = np.mod(tmp.seconds//60, 60)
+            h = tmp.seconds // 3600
+            d = tmp.days
             if ms:
-                value = str('%i days %02i:%02i:%02i.%i' % (d,h,m,s,ms))
+                value = str('%i days %+02i:%02i:%02i.%i' % (d,h,m,s,ms))
             else:
-                value = str('%i days %02i:%02i:%02i' % (d,h,m,s))
+                value = str('%i days %+02i:%02i:%02i' % (d,h,m,s))
     elif not isinstance(value, numbers.Number):
         value = str(value)
     if isinstance(value, float):


### PR DESCRIPTION
 The printing of `datetime` and `timedelta` data types is no longer dependent on `pandas`.
Thus, `pandas` is no longer a hard dependency for `vaex`, which fixes #209 

This is how the printing looks like after the update:
![image](https://user-images.githubusercontent.com/18574951/56197471-33cd3680-6039-11e9-8167-fa4b0b5b80e6.png)
