### PR TITLE
Small fix in the dataframe._binner

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5245,7 +5245,7 @@ class DataFrameLocal(DataFrame):
         4  2015-01-29 00:00:00   87
 
 
-        :param dict, list or agg agg: Aggregate operation in the form of a string, vaex.agg object, a dictionary 
+        :param dict, list or agg agg: Aggregate operation in the form of a string, vaex.agg object, a dictionary
             where the keys indicate the target column names, and the values the operations, or the a list of aggregates.
             When not given, it will return the groupby object.
         :return: :class:`DataFrame` or :class:`GroupBy` object.
@@ -5264,7 +5264,7 @@ class DataFrameLocal(DataFrame):
         in the form of an xarray.
 
 
-        :param dict, list or agg agg: Aggregate operation in the form of a string, vaex.agg object, a dictionary 
+        :param dict, list or agg agg: Aggregate operation in the form of a string, vaex.agg object, a dictionary
             where the keys indicate the target column names, and the values the operations, or the a list of aggregates.
             When not given, it will return the binby object.
         :return: :class:`DataArray` or :class:`BinBy` object.
@@ -5298,7 +5298,7 @@ class DataFrameLocal(DataFrame):
 
     def _binner(self, expression, limits=None, shape=None, delay=False):
         expression = str(expression)
-        if limits is not None and not isinstance(limits, tuple):
+        if limits is not None and not isinstance(limits, (tuple, str)):
             limits = tuple(limits)
         key = (expression, limits, shape)
         if key not in self._binners:

--- a/tests/count_test.py
+++ b/tests/count_test.py
@@ -1,5 +1,25 @@
 from common import *
 
+
+def test_count_1d():
+    ds = vaex.example()
+    binned_values = ds.count(binby=ds.x, limits=[-50, 50], shape=16)
+    assert len(binned_values) == 16
+    binned_values = ds.count(binby=ds.x, limits='minmax', shape=16)
+    assert len(binned_values) == 16
+    binned_values = ds.count(binby=ds.x, limits='95%', shape=16)
+    assert len(binned_values) == 16
+
+def test_count_2d():
+    ds = vaex.example()
+    binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=['minmax', '95%'])
+    assert list(binned_values.shape) == [32, 32]
+    binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=None)
+    assert list(binned_values.shape) == [32, 32]
+    binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=[[-50, 50],[-50, 50]])
+    assert list(binned_values.shape) == [32, 32]
+
+
 # def test_count_edges():
 #     ds = vaex.from_arrays(x=[-2, -1, 0, 1, 2, 3, np.nan])
 #     # 1 missing, 2 to the left, 1 in the range, two to the right


### PR DESCRIPTION
Small fix in the `dataframe._binner```, causing string based limits to be parsed weirdly, if they are of string type (like percentages, minmax etc.). 