### PR TITLE
Timedelta operations

### DIFF
--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -92,6 +92,9 @@ class Meta(type):
                     if isinstance(b, Expression):
                         assert b.ds == a.ds
                         b = b.expression
+                    elif isinstance(b, (np.timedelta64)):
+                        df = a.ds
+                        b = df.add_variable('var_time_delta', b, unique=True)
                     expression = '({0} {1} {2})'.format(a.expression, op['code'], b)
                     return Expression(self.ds, expression=expression)
                 attrs['__%s__' % op['name']] = f

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -55,3 +55,21 @@ def test_datetime_stats():
     # df['deltax'] = df.x - x1
     # assert df['deltax'].astype('datetime64[D]') == []
     # print(repr(df['deltax']))  # coverage
+
+def test_timedelta_arithmetics():
+    x = np.array(['2019-01-04T21:23:00', '2019-02-04T05:00:10', '2019-03-04T15:15:15'], dtype=np.datetime64)
+    y = np.array(['2018-06-14T12:11:00', '2019-02-02T22:19:00', '2017-11-18T10:11:19'], dtype=np.datetime64)
+    df = vaex.from_arrays(x=x, y=y)
+    df['diff'] = df.x-df.y
+    df['diff_dev_hours'] = df.diff / np.timedelta64(1, 'h')
+    df['diff_add_days'] = df.diff + np.timedelta64(5, 'D')
+
+    # to compare
+    diff = df.x.values-df.y.values
+    diff_dev_hours = diff / np.timedelta64(1, 'h')
+    diff_add_days = diff + np.timedelta64(5, 'D')
+
+    # assert
+    assert diff_dev_hours.tolist() == df['diff_dev_hours'].values.tolist()
+    assert diff_add_days.tolist() == df['diff_add_days'].values.tolist()
+

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -1,14 +1,14 @@
 from common import *
 import numpy as np
-import pytest
+
 
 def test_datetime_operations():
     date = np.array([np.datetime64('2009-10-12T03:31:00'),
-        np.datetime64('2016-02-11T10:17:34'),
-        np.datetime64('2015-11-12T11:34:22'),
-        np.datetime64('2003-03-03T00:33:15'),
-        np.datetime64('2014-07-23T15:08:05'),
-        np.datetime64('2011-01-01T07:02:01')], dtype='<M8[ns]')
+                    np.datetime64('2016-02-11T10:17:34'),
+                    np.datetime64('2015-11-12T11:34:22'),
+                    np.datetime64('2003-03-03T00:33:15'),
+                    np.datetime64('2014-07-23T15:08:05'),
+                    np.datetime64('2011-01-01T07:02:01')], dtype='<M8[ns]')
 
     df = vaex.from_arrays(date=date)._readonly()
     pandas_df = df.to_pandas_df()
@@ -27,19 +27,21 @@ def test_datetime_operations():
     assert df.date.dt.dayofyear.values.tolist() == pandas_df.date.dt.dayofyear.values.tolist()
     assert df.date.dt.dayofweek.values.tolist() == pandas_df.date.dt.dayofweek.values.tolist()
 
+
 def test_datetime_agg():
     date = [np.datetime64('2009-10-12T03:31:00'),
-        np.datetime64('2016-02-11T10:17:34'),
-        np.datetime64('2015-11-12T11:34:22'),
-        np.datetime64('2003-03-03T00:33:15'),
-        np.datetime64('2014-07-23T15:08:05'),
-        np.datetime64('2011-01-01T07:02:01')]
+            np.datetime64('2016-02-11T10:17:34'),
+            np.datetime64('2015-11-12T11:34:22'),
+            np.datetime64('2003-03-03T00:33:15'),
+            np.datetime64('2014-07-23T15:08:05'),
+            np.datetime64('2011-01-01T07:02:01')]
 
     df = vaex.from_arrays(date=date)
     assert df.count(df.date) == len(date)
     assert df.max(df.date) == np.datetime64('2016-02-11T10:17:34')
     assert df.mean(df.date) < np.datetime64('2016-02-11T10:17:34')
     assert df.mean(df.date) > date[0]
+
 
 def test_datetime_stats():
     x1 = np.datetime64('2005-01-01')
@@ -55,6 +57,7 @@ def test_datetime_stats():
     # df['deltax'] = df.x - x1
     # assert df['deltax'].astype('datetime64[D]') == []
     # print(repr(df['deltax']))  # coverage
+
 
 def test_timedelta_arithmetics():
     x = np.array(['2019-01-04T21:23:00', '2019-02-04T05:00:10', '2019-03-04T15:15:15'], dtype=np.datetime64)
@@ -72,4 +75,3 @@ def test_timedelta_arithmetics():
     # assert
     assert diff_dev_hours.tolist() == df['diff_dev_hours'].values.tolist()
     assert diff_add_days.tolist() == df['diff_add_days'].values.tolist()
-

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -67,11 +67,11 @@ def test_timedelta_arithmetics():
     df['diff_dev_hours'] = df.diff / np.timedelta64(1, 'h')
     df['diff_add_days'] = df.diff + np.timedelta64(5, 'D')
 
-    # to compare
+    # normal numerical/numpy values
     diff = df.x.values-df.y.values
     diff_dev_hours = diff / np.timedelta64(1, 'h')
     diff_add_days = diff + np.timedelta64(5, 'D')
 
-    # assert
+    # compare vaex to numerical results
     assert diff_dev_hours.tolist() == df['diff_dev_hours'].values.tolist()
     assert diff_add_days.tolist() == df['diff_add_days'].values.tolist()


### PR DESCRIPTION
This PR adds a unit-test checking the basic arithmetic operations between a `vaex.Expression` of type `timedelta64` and `numpy.timedelta64`. 