### PR TITLE
Remove deprecation warning due to collection.abc import

### DIFF
--- a/packages/vaex-core/vaex/settings.py
+++ b/packages/vaex-core/vaex/settings.py
@@ -1,8 +1,6 @@
-import logging
-import yaml
-from yaml import Loader, Dumper
-import vaex.utils
 import os
+import logging
+import vaex.utils
 import collections
 
 try:

--- a/packages/vaex-core/vaex/settings.py
+++ b/packages/vaex-core/vaex/settings.py
@@ -4,9 +4,9 @@ import vaex.utils
 import collections
 
 try:
-    collectionsAbc = collections.abc
+    collections_abc = collections.abc
 except AttributeError:
-    collectionsAbc = collections
+    collections_abc = collections
 
 logger = logging.getLogger("vaex.settings")
 
@@ -68,7 +68,7 @@ class Settings(object):
 settings = {}
 
 
-class AutoStoreDict(collectionsAbc.MutableMapping):
+class AutoStoreDict(collections_abc.MutableMapping):
     def __init__(self, settings, store):
         self.store = store
         self.settings = settings

--- a/packages/vaex-core/vaex/settings.py
+++ b/packages/vaex-core/vaex/settings.py
@@ -5,6 +5,11 @@ import vaex.utils
 import os
 import collections
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 logger = logging.getLogger("vaex.settings")
 
 
@@ -65,7 +70,7 @@ class Settings(object):
 settings = {}
 
 
-class AutoStoreDict(collections.MutableMapping):
+class AutoStoreDict(collectionsAbc.MutableMapping):
     def __init__(self, settings, store):
         self.store = store
         self.settings = settings


### PR DESCRIPTION
Small fix to remove the deprecation warning from vaex-core/vaex/settings.py to remove the deprecation warning coming from importing the `collections.abc` module. 

The same fix was already applied in vaex-core/vaex/expression.py