### PR TITLE
Unit-test for datetime/timedelta arithmetic and filtering

### DIFF
--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -75,3 +75,22 @@ def test_timedelta_arithmetics():
     # compare vaex to numerical results
     assert diff_dev_hours.tolist() == df['diff_dev_hours'].values.tolist()
     assert diff_add_days.tolist() == df['diff_add_days'].values.tolist()
+
+
+def test_timedelta_arithmetics_filter():
+    x = np.array(['2019-01-04T21:23:00', '2019-02-04T05:00:10', '2019-03-04T15:15:15'], dtype=np.datetime64)
+    y = np.array(['2018-06-14T12:11:00', '2019-02-02T22:19:00', '2017-11-18T10:11:19'], dtype=np.datetime64)
+
+    df = vaex.from_arrays(x=x, y=y)
+    df['diff'] = df.x-df.y  # creates a timedelta64 column
+    df['diff_dev_hours'] = df.diff / np.timedelta64(1, 'h')  # this creates a float column
+    # Create a filter
+    df = df[df.diff_dev_hours > 100]
+    print(df)
+
+    # normal numerical/numpy values
+    diff = df.x.values-df.y.values
+    diff_dev_hours = diff / np.timedelta64(1, 'h')
+
+    # compare vaex to numpy
+    assert diff_dev_hours[diff_dev_hours > 100].tolist() == df[['diff_dev_hours']].values[:, 0].tolist()


### PR DESCRIPTION
Adding a unit-test for testing the behaviour of a filtered DataFrame which contains arithmetic with datetime and timedelta inputs. 

Note that the test as it is exposes some weird bug, and this test itself is not registered py `pytest`, however the logfiles register that something has gone wrong. 