### PR TITLE
Fix datetime state serialize

### DIFF
--- a/packages/vaex-core/vaex/json.py
+++ b/packages/vaex-core/vaex/json.py
@@ -1,0 +1,76 @@
+import json
+import numpy as np
+import datetime
+import re
+
+serializers = []
+
+
+def register(cls):
+    serializers.append(cls)
+    return cls
+
+
+@register
+class DateTime64Serializer:
+    @staticmethod
+    def can_encode(obj):
+        return isinstance(obj, (np.datetime64, np.timedelta64))
+
+    @staticmethod
+    def encode(obj):
+        value = int(obj.astype(int))
+        typename = obj.dtype.name
+        type, unit = re.match('(\w*)\[(\w*)\]', obj.dtype.name).groups()
+        return {
+            'type': type,
+            'data': {
+                'value': value,
+                'unit': unit
+            }
+        }
+
+    @staticmethod
+    def can_decode(data):
+        return data.get('type') in ['datetime64', 'timedelta64']
+
+    @staticmethod
+    def decode(data):
+        dtype = np.dtype("%s[%s]" % (data['type'], data['data']['unit']))
+        value = np.int64(data['data']['value']).astype(dtype)
+        return value
+
+
+def encode(obj):
+    for serializer in serializers:
+        if serializer.can_encode(obj):
+            return serializer.encode(obj)
+
+
+class VaexJsonEncoder(json.JSONEncoder):
+    def default(self, obj):
+        encoded = encode(obj)
+        if obj is not None and encoded is not None:
+            return encoded
+        elif isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        elif isinstance(obj, np.bytes_):
+            return obj.decode('UTF-8')
+        elif isinstance(obj, bytes):
+            return str(obj, encoding='utf-8');
+        else:
+            return super(VaexJsonEncoder, self).default(obj)
+
+class VaexJsonDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+    
+    def object_hook(self, dct):
+        for serializer in serializers:
+            if serializer.can_decode(dct):
+                return serializer.decode(dct)
+        return dct

--- a/packages/vaex-core/vaex/json.py
+++ b/packages/vaex-core/vaex/json.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import json
 import numpy as np
 import datetime

--- a/packages/vaex-core/vaex/remote.py
+++ b/packages/vaex-core/vaex/remote.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 __author__ = 'breddels'
 import numpy as np
 import logging

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import collections
 import concurrent.futures
 import contextlib

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -20,6 +20,7 @@ import six
 import yaml
 
 from .column import str_type
+from .json import VaexJsonEncoder, VaexJsonDecoder
 
 
 is_frozen = getattr(sys, 'frozen', False)
@@ -437,28 +438,11 @@ def yaml_load(f):
     return yaml.safe_load(f)
 
 
-class NumpyEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, np.floating):
-            return float(obj)
-        elif isinstance(obj, np.ndarray):
-            return obj.tolist()
-        elif isinstance(obj, np.bytes_):
-            return obj.decode('UTF-8')
-        elif isinstance(obj, bytes):
-            return str(obj, encoding='utf-8');
-
-        else:
-            return super(NumpyEncoder, self).default(obj)
-
-
 def write_json_or_yaml(filename, data):
     base, ext = os.path.splitext(filename)
     if ext == ".json":
         with open(filename, "w") as f:
-            json.dump(data, f, indent=2, cls=NumpyEncoder)
+            json.dump(data, f, indent=2, cls=VaexJsonEncoder)
     elif ext == ".yaml":
         with open(filename, "w") as f:
             yaml_dump(f, data)
@@ -470,7 +454,7 @@ def read_json_or_yaml(filename):
     base, ext = os.path.splitext(filename)
     if ext == ".json":
         with open(filename, "r") as f:
-            return json.load(f) or {}
+            return json.load(f, cls=VaexJsonDecoder) or {}
     elif ext == ".yaml":
         with open(filename, "r") as f:
             return yaml_load(f) or {}

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -15,3 +15,22 @@ def test_state_get_set(ds_local):
     assert ds_copy.copy().v.values.tolist() == ds.v.values.tolist()
     assert 'v' in ds_copy.get_column_names()
 
+def test_state_variables(ds_local, tmpdir):
+    filename = str(tmpdir.join('state.json'))
+    df = ds_local
+    df_copy = df.copy()
+    t_test = np.datetime64('2005-01-01')
+    df.add_variable('dt_var', t_test)
+    variables = df.variables.copy()
+
+    # this virtual column will add a variable (the timedelta)
+    df['seconds'] = df.timedelta / np.timedelta64(1, 's')
+    assert len(df.variables) == len(variables) + 1
+    var_name = list(set(df.variables) - set(variables))[0]
+
+    df.state_write(filename)
+
+    df_copy.state_load(filename)
+    assert isinstance(df_copy.variables[var_name], np.timedelta64)
+    assert df.seconds.tolist() == df_copy.seconds.tolist()
+    assert df_copy.variables['dt_var'] == t_test


### PR DESCRIPTION
This allows datatime64 and timedelta64 objects to be serialized. It should be easy to extend this for other types using the `@register` decorator.