### PR TITLE
Big filter performance improvements

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4706,7 +4706,7 @@ class DataFrameLocal(DataFrame):
                 if key == FILTER_SELECTION_NAME:
                     df._selection_masks[key] = self._selection_masks[key]
                 else:
-                    df._selection_masks[key] = vaex.superutils.Mask(df._length_unfiltered)
+                    df._selection_masks[key] = vaex.superutils.Mask(df._length_original)
                 # and make sure the mask is consistent with the cache chunks
                 np.asarray(df._selection_masks[key])[:] = np.asarray(self._selection_masks[key])
         for key, value in self.selection_history_indices.items():

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -82,7 +82,7 @@ class Executor(object):
     def run(self, task):
         # with self.lock:
         if 1:
-            logger.debug("added task: %r" % task)
+            logger.debug("added task: %r", task)
             previous_queue = self.task_queue
             try:
                 self.task_queue = [task]

--- a/packages/vaex-core/vaex/scopes.py
+++ b/packages/vaex-core/vaex/scopes.py
@@ -171,6 +171,7 @@ class _BlockScopeSelection(object):
                 # logger.debug("selection cache: %r" % cache)
                 full_mask = self.df._selection_masks[variable]
                 selection_in_cache, mask = cache.get(key, (None, None))
+
                 # logger.debug("mask for %r is %r", variable, mask)
                 if selection_in_cache == selection:
                     return mask

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -208,6 +208,7 @@ class TestDataset(unittest.TestCase):
 		with small_buffer(ds):
 			ds1 = ds.copy()
 			ds1.select(ds1.x > 4, name=vaex.dataset.FILTER_SELECTION_NAME, mode='and')
+			ds1._invalidate_caches()
 
 			ds2 = ds[ds.x > 4]
 			ds1.x.evaluate()
@@ -1176,12 +1177,13 @@ class TestDataset(unittest.TestCase):
 		self.dataset_local.columns["x"] = self.dataset_local.columns["x"] * 1.
 		self.dataset_local.columns["x"][self.zero_index] = np.nan
 		if self.dataset.is_local():
-			self.dataset._invalidate_selection_cache()
+			self.dataset._invalidate_caches()
 		else:
 			if hasattr(self, 'webserver1'):
-				self.webserver1.dfs[0]._invalidate_selection_cache()
-				self.webserver2.dfs[0]._invalidate_selection_cache()
-			self.dataset_local._invalidate_selection_cache()
+				self.webserver1.dfs[0]._invalidate_caches()
+				self.webserver2.dfs[0]._invalidate_caches()
+			self.dataset_local._invalidate_caches()
+
 		self.df = self.dataset_local.to_pandas_df()
 		self.dataset.select("x < 5")
 		ds = self.dataset[self.dataset.x < 5]

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -18,3 +18,21 @@ def test_slice(ds_local):
     assert ds_sliced.length_original() == ds_sliced.length_unfiltered() == 3
     assert ds_sliced.get_active_range() == (0, ds_sliced.length_original()) == (0, 3)
     assert ds_sliced.x.tolist() == np.arange(6, 9.).tolist()
+
+
+def test_head(ds_local):
+    ds = ds_local
+    df = ds.head(5)
+    assert len(df) == 5
+
+
+def test_tail(ds_local):
+    ds = ds_local
+    df = ds.tail(5)
+    assert len(df) == 5
+
+
+def test_head_with_selection():
+    df = vaex.example()
+    df.select(df.x > 0, name='test')
+    df.head()


### PR DESCRIPTION
First, because of an issue in using the logger, repr(df) was being called for each tasked added to the executor (even when no logging was done). This will improve performance of filtered datasets a lot.

Second, selections, and especially filter are more efficient to use. Since filter will not be modified, they can share the filter mask and cache when a shall copy is made (`df.copy()` which is used a lot internally in vaex). Also, the selections chunck caches (filtering also makes use of that) gets (shallowly) copied into the new dataframe, allowing copies to not have to recompute the masks.

```python
df = df[df.x>0] # nothing is done
print(len(df)) # now the mask is filled
df = df[df.x < 10]
print(len(df)) # now only the new filter is computed (df.x < 10)
# and logically compiled with the cached mask from the previous step.
```

If you do all filtering without executing something in between, no cache will be filled of the previous dataframes, and the will filter (could be 3 expressions) will be executed and logically combined.

Since now filters masks are shared, it uses less memory. Beware that selections (since they can be mutated), will need to be copied for each dataframe. I would say, a bad pattern would be to create a lot of selections, and then filter the dataframe over and over again.

Needs a rebase after #247 is merged.