### PR TITLE
Get columns based on types

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4416,8 +4416,8 @@ class DataFrame(object):
             return df
         elif isinstance(item, (tuple, list)):
             # check if list or tuple contains types
-            if all([True if type(i)==type else False for i in item ]):
-                columns = [column for dt in item for column in self if self.dtype(column) == dt]
+            if all([type(i) == type for i in item ]):
+                columns = [column for dt in item for column in self if self._type_match(dt, self.dtype(column))]
                 if columns:
                     return self[columns]
             # otherwise treat as column names
@@ -4426,7 +4426,7 @@ class DataFrame(object):
                     df = self.copy(column_names=item)
                 return df
         elif type(item) == type:
-            columns = [column for column in self if self.dtype(column)==item]
+            columns = [column for column in self if self._type_match(item, self.dtype(column))]
             if columns:
                 return self[columns]
         elif isinstance(item, slice):
@@ -4446,6 +4446,17 @@ class DataFrame(object):
                 df = self.extract()
                 df.set_active_range(start, stop)
             return df.trim()
+
+    def _type_match(self, type, dtype):
+        if hasattr(dtype, 'kind'):
+            if type == int:
+                return dtype.kind in 'ui'
+            elif type == float:
+                return dtype.kind == 'f'
+            else:
+                return dtype == type
+        else:
+            return dtype == type
 
     def __delitem__(self, item):
         '''Removes a (virtual) column from the DataFrame.

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4415,8 +4415,15 @@ class DataFrame(object):
             df._selection_masks[FILTER_SELECTION_NAME] = vaex.superutils.Mask(df._length_unfiltered)
             return df
         elif isinstance(item, (tuple, list)):
-            df = self.copy(column_names=item)
-            return df
+            # check if list or tuple contains types
+            if all([True if type(i)==type else False for i in item ]):
+                return self[[column for dt in item for column in self if self.dtype(column) == dt]]
+            # otherwise treat as column names
+            else:
+                df = self.copy(column_names=item)
+                return df
+        elif type(item) == type:
+            return self[[column for column in self if self.dtype(column)==item]]
         elif isinstance(item, slice):
             start, stop, step = item.start, item.stop, item.step
             start = start or 0

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4422,7 +4422,8 @@ class DataFrame(object):
                     return self[columns]
             # otherwise treat as column names
             else:
-                df = self.copy(column_names=item)
+                if item:
+                    df = self.copy(column_names=item)
                 return df
         elif type(item) == type:
             columns = [column for column in self if self.dtype(column)==item]

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4417,13 +4417,17 @@ class DataFrame(object):
         elif isinstance(item, (tuple, list)):
             # check if list or tuple contains types
             if all([True if type(i)==type else False for i in item ]):
-                return self[[column for dt in item for column in self if self.dtype(column) == dt]]
+                columns = [column for dt in item for column in self if self.dtype(column) == dt]
+                if columns:
+                    return self[columns]
             # otherwise treat as column names
             else:
                 df = self.copy(column_names=item)
                 return df
         elif type(item) == type:
-            return self[[column for column in self if self.dtype(column)==item]]
+            columns = [column for column in self if self.dtype(column)==item]
+            if columns:
+                return self[columns]
         elif isinstance(item, slice):
             start, stop, step = item.start, item.stop, item.step
             start = start or 0

--- a/tests/get_item_test.py
+++ b/tests/get_item_test.py
@@ -1,0 +1,31 @@
+import vaex
+
+
+def test_get_item_type():
+    x = [1, 2, 3]
+    y = [3, 2, 1]
+    s = ['a', 'ab', 'abc']
+    b = [True, False, True]
+    f = [1.2, 2.3, 5.5]
+    df = vaex.from_arrays(x=x, y=y, f=f, s=s, b=b)
+
+    df_sel = df[int]
+    assert df_sel.column_names == ['x', 'y']
+
+    df_sel = df[str]
+    assert df_sel.column_names == ['s']
+
+    df_sel = df[bool]
+    assert df_sel.column_names == ['b']
+
+    df_sel = df[float]
+    assert df_sel.column_names == ['f']
+
+    df_sel = df[float, int]
+    assert df_sel.column_names == ['f', 'x', 'y']
+
+    df_sel = df[str, bool]
+    assert df_sel.column_names == ['s', 'b']
+
+    df_sel = df[str, float]
+    assert df_sel.column_names == ['s', 'f']

--- a/tests/get_item_test.py
+++ b/tests/get_item_test.py
@@ -13,28 +13,28 @@ def test_get_item_type():
     df = vaex.from_arrays(x=x, y=y, f=f, s=s, b=b, g=g)
 
     df_sel = df[np.int16]
-    assert df_sel.column_names == ['x']
+    assert set(df_sel.column_names) == set(['x'])
 
     df_sel = df[np.float32]
-    assert df_sel.column_names == ['f']
+    assert set(df_sel.column_names) == set(['f'])
 
     df_sel = df[int]
-    assert df_sel.column_names == ['x', 'y']
+    assert set(df_sel.column_names) == set(['x', 'y'])
 
     df_sel = df[str]
-    assert df_sel.column_names == ['s']
+    assert set(df_sel.column_names) == set(['s'])
 
     df_sel = df[bool]
-    assert df_sel.column_names == ['b']
+    assert set(df_sel.column_names) == set(['b'])
 
     df_sel = df[float]
-    assert df_sel.column_names == ['f', 'g']
+    assert set(df_sel.column_names) == set(['f', 'g'])
 
     df_sel = df[float, int]
-    assert df_sel.column_names == ['f', 'g', 'x', 'y']
+    assert set(df_sel.column_names) == set(['f', 'g', 'x', 'y'])
 
     df_sel = df[str, bool]
-    assert df_sel.column_names == ['s', 'b']
+    assert set(df_sel.column_names) == set(['s', 'b'])
 
     df_sel = df[str, float]
-    assert df_sel.column_names == ['s', 'f', 'g']
+    assert set(df_sel.column_names) == set(['s', 'f', 'g'])

--- a/tests/get_item_test.py
+++ b/tests/get_item_test.py
@@ -1,31 +1,40 @@
 import vaex
+import numpy as np
 
 
 def test_get_item_type():
-    x = [1, 2, 3]
-    y = [3, 2, 1]
+    x = np.array([1, 2, 3], dtype=np.int16)
+    y = np.array([3, 2, 1], dtype=np.int64)
     s = ['a', 'ab', 'abc']
-    b = [True, False, True]
-    f = [1.2, 2.3, 5.5]
-    df = vaex.from_arrays(x=x, y=y, f=f, s=s, b=b)
+    b = np.array([True, False, True], dtype=np.bool)
+    f = np.array([1.2, 2.3, 5.5], dtype=np.float32)
+    g = np.array([1.5, 2.5, 5.5], dtype=np.float)
+
+    df = vaex.from_arrays(x=x, y=y, f=f, s=s, b=b, g=g)
+
+    df_sel = df[np.int16]
+    assert df_sel.column_names == ['x']
+
+    df_sel = df[np.float32]
+    assert df_sel.column_names == ['f']
 
     df_sel = df[int]
-    assert set(df_sel.column_names) == set(['x', 'y'])
+    assert df_sel.column_names == ['x', 'y']
 
     df_sel = df[str]
-    assert set(df_sel.column_names) == set(['s'])
+    assert df_sel.column_names == ['s']
 
     df_sel = df[bool]
-    assert set(df_sel.column_names) == set(['b'])
+    assert df_sel.column_names == ['b']
 
     df_sel = df[float]
-    assert set(df_sel.column_names) == set(['f'])
+    assert df_sel.column_names == ['f', 'g']
 
     df_sel = df[float, int]
-    assert set(df_sel.column_names) == set(['f', 'x', 'y'])
+    assert df_sel.column_names == ['f', 'g', 'x', 'y']
 
     df_sel = df[str, bool]
-    assert set(df_sel.column_names) == set(['s', 'b'])
+    assert df_sel.column_names == ['s', 'b']
 
     df_sel = df[str, float]
-    assert set(df_sel.column_names) == set(['s', 'f'])
+    assert df_sel.column_names == ['s', 'f', 'g']

--- a/tests/get_item_test.py
+++ b/tests/get_item_test.py
@@ -10,22 +10,22 @@ def test_get_item_type():
     df = vaex.from_arrays(x=x, y=y, f=f, s=s, b=b)
 
     df_sel = df[int]
-    assert df_sel.column_names == ['x', 'y']
+    assert set(df_sel.column_names) == set(['x', 'y'])
 
     df_sel = df[str]
-    assert df_sel.column_names == ['s']
+    assert set(df_sel.column_names) == set(['s'])
 
     df_sel = df[bool]
-    assert df_sel.column_names == ['b']
+    assert set(df_sel.column_names) == set(['b'])
 
     df_sel = df[float]
-    assert df_sel.column_names == ['f']
+    assert set(df_sel.column_names) == set(['f'])
 
     df_sel = df[float, int]
-    assert df_sel.column_names == ['f', 'x', 'y']
+    assert set(df_sel.column_names) == set(['f', 'x', 'y'])
 
     df_sel = df[str, bool]
-    assert df_sel.column_names == ['s', 'b']
+    assert set(df_sel.column_names) == set(['s', 'b'])
 
     df_sel = df[str, float]
-    assert df_sel.column_names == ['s', 'f']
+    assert set(df_sel.column_names) == set(['s', 'f'])


### PR DESCRIPTION
This is regarding #240.
This is a proposal PR that enables one to select columns based in types. An example use case is shown below.

```
s = ['a', 'ab', 'abc']  
b = [True, False, True]
f = [1.2, 2.3, 5.5]
display(df)
df = vaex.from_arrays(s=s, b=b, f=f)
display(df[str])
display(df[float, bool])
```
<img width="165" alt="image" src="https://user-images.githubusercontent.com/18574951/57575406-e8485580-7449-11e9-95c2-2476423c498c.png">
