### PR TITLE
Adding support for "unmapped" values in map method.

### DIFF
--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -640,7 +640,7 @@ def f({0}):
             if use_masked_array:
                 expr = '_choose_masked(_ordinal_values({}, {}), {})'.format(self, key_set_name, choices_name)
             else:
-                expr = '_choose(_ordinal_values({}, {}), {}, {})'.format(self, key_set_name, choices_name, default_value)
+                expr = '_choose(_ordinal_values({}, {}), {}, {!r})'.format(self, key_set_name, choices_name, default_value)
         else:
             expr = '_choose(_ordinal_values({}, {}), {})'.format(self, key_set_name, choices_name)
         return Expression(df, expr)

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -579,7 +579,18 @@ def f({0}):
         3       2  user
         4       2  user
         5     nan  unknown
-
+        >>> import vaex
+        >>> import numpy as np
+        >>> df = vaex.from_arrays(type=[0, 1, 2, 2, 2, 4])
+        >>> df['role'] = df['type'].map({0: 'admin', 1: 'maintainer', 2: 'user'}, default_value='unknown')
+        >>> df
+        #    type  role
+        0       0  admin
+        1       1  maintainer
+        2       2  user
+        3       2  user
+        4       2  user
+        5       4  unknown
         :param mapper: dict like object used to map the values from keys to values
         :param nan_value: value to be used when a nan is present (and not in the mapper)
         :param null_value: value to use used when there is a missing value

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -1767,7 +1767,7 @@ def _choose(ar, choices, default=None):
     if default is not None:
         mask = ar == -1
         ar[mask] == 0  # we fill it in with some values, doesn't matter, since it will be replaced
-    ar = np.choose(ar, choices)
+    ar = choices[ar]
     if default is not None:
         ar[mask] = default
     return ar
@@ -1778,7 +1778,7 @@ def _choose_masked(ar, choices):
     from vaex.column import _to_string_sequence
     mask = ar == -1
     ar[mask] == 0  # we fill it in with some values, doesn't matter, since it is masked
-    ar = np.choose(ar, choices)
+    ar = choices[ar]
     return np.ma.array(ar, mask=mask)
 
 

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -1760,12 +1760,26 @@ def _ordinal_values(x, ordered_set):
     return ordered_set.map_ordinal(x)
 
 @register_function()
-def _choose(ar, choices):
+def _choose(ar, choices, default=None):
     from vaex.column import _to_string_sequence
     # if not isinstance(choices, np.ndarray) or choices.dtype.kind in 'US':
     #     choices = _to_string_sequence(choices)
-    return np.choose(ar, choices)
+    if default is not None:
+        mask = ar == -1
+        ar[mask] == 0  # we fill it in with some values, doesn't matter, since it will be replaced
+    ar = np.choose(ar, choices)
+    if default is not None:
+        ar[mask] = default
+    return ar
 
+@register_function()
+def _choose_masked(ar, choices):
+    """Similar to _choose, but -1 maps to NA"""
+    from vaex.column import _to_string_sequence
+    mask = ar == -1
+    ar[mask] == 0  # we fill it in with some values, doesn't matter, since it is masked
+    ar = np.choose(ar, choices)
+    return np.ma.array(ar, mask=mask)
 
 
 @register_function(name='float')

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -41,9 +41,12 @@ def test_map():
 
     # missing keys
     with pytest.raises(ValueError):
-        ds.colour.map({'ret': 1, 'blue': 2, 'green': 3})
+        ds.colour.map({'ret': 1, 'blue': 2, 'green': 3}, unmapped='raise')
     with pytest.raises(ValueError):
-        ds.colour.map({'blue': 2, 'green': 3})
+        ds.colour.map({'blue': 2, 'green': 3}, unmapped='raise')
+    # missing keys but user-handled
+    ds['colour_unmapped'] = ds.colour.map({'blue': 2, 'green': 3}, unmapped=-1)
+    assert ds.colour_unmapped.values.tolist() == [-1, -1, 2, -1, 3, 3, -1, 2, 2, 3]
     # extra is ok
     ds.colour.map({'red': 1, 'blue': 2, 'green': 3, 'orange': 4})
 

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -1,7 +1,11 @@
-import vaex
 import numpy as np
+
 import pandas as pd
+
 import pytest
+
+import vaex
+
 
 def test_map():
     # Generate the test data
@@ -53,7 +57,31 @@ def test_map():
     # check masked arrays
     assert ds.colour.map({'blue': 2, 'green': 3}, allow_missing=True).tolist() == [None, None, 2, None, 3, 3, None, 2, 2, 3]
 
+
 def test_map_to_string():
     df = vaex.from_arrays(type=[0, 1, 2, 2, 2, np.nan])
     df['role'] = df['type'].map({0: 'admin', 1: 'maintainer', 2: 'user', np.nan: 'unknown'})
     assert df['role'].tolist() == ['admin', 'maintainer', 'user', 'user', 'user', 'unknown']
+
+
+def test_map_long_mapper():
+    german = np.array(['eins', 'zwei', 'drei', 'vier', 'fünf', 'sechs', 'sieben', 'acht', 'neun', 'zehn', 'elf', 'zwölf',
+                       'dreizehn', 'vierzehn', 'fünfzehn', 'sechzehn', 'siebzehn', 'achtzehn', 'neunzehn', 'zwanzig',
+                       'einundzwanzig', 'zweiundzwanzig', 'dreiundzwanzig', 'vierundzwanzig', 'fünfundzwanzig', 'sechsundzwanzig',
+                       'siebenundzwanzig', 'achtundzwanzig', 'neunundzwanzig', 'dreiβig', 'einunddreiβig', 'zweiunddreißig',
+                       'dreiunddreißig', 'vierunddreißig', 'fünfunddreißig', 'sechsunddreißig', 'siebenunddreißig',
+                       'achtunddreißig', 'neununddreißig', 'vierzig', 'einundvierzig', 'zweiundvierzig', 'dreiundvierzig',
+                       'vierundvierzig', 'fünfundvierzig', 'sechsundvierzig', 'siebenundvierzig', 'achtundvierzig',
+                       'neunundvierzig', 'fünfzig'])
+
+    english = np.array(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve',
+                        'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen', 'twenty', 'twentyone',
+                        'twentytwo', 'twentythree', 'twentyfour', 'twentyfive', 'twentysix', 'twentyseven', 'twentyeight',
+                        'twentynine', 'thirty', 'thirtyone', 'thirtytwo', 'thirtythree', 'thirtyfour', 'thirtyfive', 'thirtysix',
+                        'thirtyseven', 'thirtyeight', 'thirtynine', 'forty', 'fortyone', 'fortytwo', 'fortythree', 'fortyfour',
+                        'fortyfive', 'fortysix', 'fortyseven', 'fortyeight', 'fortynine', 'fifty'])
+
+    mapper = dict(zip(english, german))  # enlish to german
+    df = vaex.from_arrays(english=english)
+    df['german'] = df.english.map(mapper=mapper)
+    assert df['german'].tolist() == german

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -84,4 +84,4 @@ def test_map_long_mapper():
     mapper = dict(zip(english, german))  # enlish to german
     df = vaex.from_arrays(english=english)
     df['german'] = df.english.map(mapper=mapper)
-    assert df['german'].tolist() == german
+    assert df['german'].tolist() == german.tolist()

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -23,7 +23,7 @@ def test_map():
     ds['colour_'] = ds.colour.map(mapper['colour'])
     ds['animal_'] = ds.animal.map(mapper['animal'])
     # ds['number_'] = ds.number.map(lambda x: mapper['number'][x])  # test with a function, not just with a dict
-    ds['floats_'] = ds.floats.map(mapper['floats'], nan_mapping=np.nan)
+    ds['floats_'] = ds.floats.map(mapper['floats'], nan_value=np.nan)
 
     # Map in pandas
     df['colour_'] = df.colour.map(mapper['colour'])
@@ -41,14 +41,17 @@ def test_map():
 
     # missing keys
     with pytest.raises(ValueError):
-        ds.colour.map({'ret': 1, 'blue': 2, 'green': 3}, unmapped='raise')
+        ds.colour.map({'ret': 1, 'blue': 2, 'green': 3})
     with pytest.raises(ValueError):
-        ds.colour.map({'blue': 2, 'green': 3}, unmapped='raise')
+        ds.colour.map({'blue': 2, 'green': 3})
     # missing keys but user-handled
-    ds['colour_unmapped'] = ds.colour.map({'blue': 2, 'green': 3}, unmapped=-1)
+    ds['colour_unmapped'] = ds.colour.map({'blue': 2, 'green': 3}, default_value=-1)
     assert ds.colour_unmapped.values.tolist() == [-1, -1, 2, -1, 3, 3, -1, 2, 2, 3]
     # extra is ok
     ds.colour.map({'red': 1, 'blue': 2, 'green': 3, 'orange': 4})
+
+    # check masked arrays
+    assert ds.colour.map({'blue': 2, 'green': 3}, allow_missing=True).tolist() == [None, None, 2, None, 3, 3, None, 2, 2, 3]
 
 def test_map_to_string():
     df = vaex.from_arrays(type=[0, 1, 2, 2, 2, np.nan])

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -3,7 +3,17 @@ import numpy as np
 import pandas as pd
 import pytest
 import vaex
+import math
 
+def test_nan_madness():
+    x = [np.nan, math.nan, np.nan/2, math.nan/3, 0, 1]
+    df = vaex.from_arrays(x=x)
+    mapper = {np.nan/5: -1, 0: 10, 1: 20}
+    assert df.x.map(mapper).tolist() == [-1, -1, -1, -1, 10, 20]
+
+    mapper = {np.nan/5: -1, np.nan/10:-2, 0: 10, 1: 20}
+    with pytest.raises(ValueError):
+        df.x.map(mapper).tolist()
 
 def test_map():
     # Generate the test data

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -3,10 +3,11 @@ import numpy as np
 import pandas as pd
 import pytest
 import vaex
-import math
+
 
 def test_nan_madness():
-    x = [np.nan, math.nan, np.nan/2, math.nan/3, 0, 1]
+    nan = float('NaN')
+    x = [np.nan, nan, np.nan/2, nan/3, 0, 1]
     df = vaex.from_arrays(x=x)
     mapper = {np.nan/5: -1, 0: 10, 1: 20}
     assert df.x.map(mapper).tolist() == [-1, -1, -1, -1, 10, 20]
@@ -14,6 +15,7 @@ def test_nan_madness():
     mapper = {np.nan/5: -1, np.nan/10:-2, 0: 10, 1: 20}
     with pytest.raises(ValueError):
         df.x.map(mapper).tolist()
+
 
 def test_map():
     # Generate the test data

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -1,9 +1,7 @@
+# -*- coding: utf-8 -*-
 import numpy as np
-
 import pandas as pd
-
 import pytest
-
 import vaex
 
 


### PR DESCRIPTION
This give the user support to pre-define how values not defined in the mapper are to be handled. By default, and exception is raised, but any other default values can be specified. 