### PR TITLE
Unit-test for str.slice, checking for repr.

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -1318,10 +1318,10 @@ def str_slice(x, start=0, stop=None):  # TODO: support n
     4   y.
     """
     if stop is None:
-        sll = _to_string_sequence(x).slice_string_end(start)
+        ss = _to_string_sequence(x).slice_string_end(start)
     else:
-        sll = _to_string_sequence(x).slice_string(start, stop)
-    return sll
+        ss = _to_string_sequence(x).slice_string(start, stop)
+    return column.ColumnStringArrow.from_string_sequence(ss)
 
 # TODO: slice_replace (not sure it this makes sense)
 # TODO: n argument and rsplit

--- a/tests/rename_test.py
+++ b/tests/rename_test.py
@@ -14,11 +14,11 @@ def test_rename(ds_filtered):
     assert ds.q.values.tolist() == qvalues
 
 
-def test_reassign_virtual(ds):
-    df = ds
+def test_reassign_virtual(ds_local):
+    df = ds_local
     x = df.x.values
     df['r'] = df.x+1
-    df['r'] = df.x+1
+    df['r'] = df.r+1
     assert df.r.tolist() == (x+2).tolist()
 
 

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -339,3 +339,10 @@ def test_string_strip_special_case2():
 	strings = ['ɐa', 'aap']
 	df = vaex.from_arrays(s=vaex.string_column(strings))
 	assert df.s.str.capitalize().tolist() == df.s.str_pandas.capitalize().tolist()
+
+
+def test_string_slice_repr():
+	s = ['Here', 'is', 'a', 'simple', 'unit-test']
+	df = vaex.from_arrays(s=s)
+	df['sliced_s'] = df.s.str.slice(start=2, stop=5)
+	repr(df['sliced_s'])


### PR DESCRIPTION
This is a simple check for `repr` for `str.slice`. Currently this is not supported, but I think it would be great to support it, and check preview of operations. 