### PR TITLE
support for np.isnan and np.isinf

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -101,6 +101,8 @@ minimum
 maximum
 clip
 searchsorted
+isnan
+isinf
 """.strip().split()]
 for name, numpy_name in numpy_function_mapping:
     if not hasattr(np, numpy_name):

--- a/tests/functions_test.py
+++ b/tests/functions_test.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+import vaex
+
+
+def test_numpy_function_isnan():
+    x = np.array([-1, 2, 3, 4, np.nan, np.nan, np.nan, -2, -3, 5, 10])
+    ds = vaex.from_arrays(x=x)
+    assert ds.selected_length('isnan(x)') == 3
+    assert ds.selected_length('~(isnan(x))') == 8
+    assert ds[(ds.x > 3) | (np.isnan(ds.x))].x.tolist() == [4., np.nan, np.nan, np.nan,  5., 10.]
+
+
+def test_numpy_function_isinf():
+    x = np.array([-1, 2, 3, 4, np.inf, np.inf, np.inf, -2, -3, 5, 10])
+    ds = vaex.from_arrays(x=x)
+    assert ds.selected_length('isinf(x)') == 3
+    assert ds.selected_length('~(isinf(x))') == 8
+    assert ds[(ds.x > 3) | (np.isinf(ds.x))].x.tolist() == [4., np.inf, np.inf, np.inf,  5., 10.]

--- a/tests/functions_test.py
+++ b/tests/functions_test.py
@@ -9,6 +9,9 @@ def test_numpy_function_isnan():
     assert ds.selected_length('isnan(x)') == 3
     assert ds.selected_length('~(isnan(x))') == 8
     assert ds[(ds.x > 3) | (np.isnan(ds.x))].x.tolist() == [4., np.nan, np.nan, np.nan,  5., 10.]
+    result = ds[(ds.x.isnan()) | (ds.x > 3)].x.values  # save to an in memory array for convenience
+    assert all(np.isnan(result[1:4]))  # check the given elements are all nans
+    assert result[[0, 4, 5]].tolist() == [4., 5., 10.]  # check non-nan elements
 
 
 def test_numpy_function_isinf():
@@ -17,3 +20,4 @@ def test_numpy_function_isinf():
     assert ds.selected_length('isinf(x)') == 3
     assert ds.selected_length('~(isinf(x))') == 8
     assert ds[(ds.x > 3) | (np.isinf(ds.x))].x.tolist() == [4., np.inf, np.inf, np.inf,  5., 10.]
+    assert ds[(ds.x.isinf()) | (ds.x > 3)].x.tolist() == [4., np.inf, np.inf, np.inf,  5., 10.]


### PR DESCRIPTION
This PR adds and tests the support for `np.isnan` and `np.isinf`. This was initially added by #161 , but since the significant changes to `vaex` that can no longer me merged. Credit and thanks goes to @DougRzz for initiating this. 

