### PR TITLE
Unit-test for fillna() when the expression is virtual.

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3269,7 +3269,7 @@ class DataFrame(object):
         """
         type = "change" if name in self.virtual_columns else "add"
         expression = _ensure_string_from_expression(expression)
-        if name in self.get_column_names(virtual=False):
+        if name in self.get_column_names():
             renamed = '__' +vaex.utils.find_valid_name(name, used=self.get_column_names())
             expression = self._rename(name, renamed, expression)[0].expression
 

--- a/tests/fillna_test.py
+++ b/tests/fillna_test.py
@@ -39,3 +39,14 @@ def test_fillna(ds_local):
     df_copy.state_set(state)
     np.testing.assert_array_equal(df_copy['nm'].values, df_filled['nm'].values)
     np.testing.assert_array_equal(df_copy['mi'].values, df_filled['mi'].values)
+
+
+def test_fillna_virtual():
+    # this might be a duplicate or rename_test.py/test_reassign_virtual
+    x = [1, 2, 3, 5, np.nan, -1, -7, 10]
+    df = vaex.from_arrays(x=x)
+    # create a virtual column that will have nans due to the calculations
+    df['r'] = np.log(df.x)
+    df['r'] = df.r.fillna(value=0xdeadbeef)
+    assert df.r.tolist()[:4] == [0.0, 0.6931471805599453, 1.0986122886681098, 1.6094379124341003]
+    assert df.r.tolist()[4:7] == [0xdeadbeef, 0xdeadbeef, 0xdeadbeef]

--- a/tests/fillna_test.py
+++ b/tests/fillna_test.py
@@ -2,40 +2,40 @@ from common import *
 
 
 def test_fillna_column(ds_local):
-    ds = ds_local
-    ds['ok'] = ds['obj'].fillna(value='NA')
-    assert ds.ok.values[5] == 'NA'
-    ds['obj'] = ds['obj'].fillna(value='NA')
-    assert ds.obj.values[5] == 'NA'
+    df = ds_local
+    df['ok'] = df['obj'].fillna(value='NA')
+    assert df.ok.values[5] == 'NA'
+    df['obj'] = df['obj'].fillna(value='NA')
+    assert df.obj.values[5] == 'NA'
 
 
 def test_fillna(ds_local):
-    ds = ds_local
-    ds_copy = ds.copy()
+    df = ds_local
+    df_copy = df.copy()
 
-    ds_string_filled = ds.fillna(value='NA')
-    assert ds_string_filled.obj.values[5] == 'NA'
+    df_string_filled = df.fillna(value='NA')
+    assert df_string_filled.obj.values[5] == 'NA'
 
-    ds_filled = ds.fillna(value=0)
-    assert ds_filled.obj.values[5] == 0
+    df_filled = df.fillna(value=0)
+    assert df_filled.obj.values[5] == 0
 
-    assert ds_filled.to_pandas_df(virtual=True).isna().any().any() == False
-    assert ds_filled.to_pandas_df(virtual=True).isna().any().any() == False
+    assert df_filled.to_pandas_df(virtual=True).isna().any().any() == False
+    assert df_filled.to_pandas_df(virtual=True).isna().any().any() == False
 
-    ds_filled = ds.fillna(value=10, fill_masked=False)
-    assert ds_filled.n.values[6] == 10.
-    assert ds_filled.nm.values[6] == 10.
+    df_filled = df.fillna(value=10, fill_masked=False)
+    assert df_filled.n.values[6] == 10.
+    assert df_filled.nm.values[6] == 10.
 
-    ds_filled = ds.fillna(value=-15, fill_nan=False)
-    assert ds_filled.m.values[7] == -15.
-    assert ds_filled.nm.values[7] == -15.
-    assert ds_filled.mi.values[7] == -15.
+    df_filled = df.fillna(value=-15, fill_nan=False)
+    assert df_filled.m.values[7] == -15.
+    assert df_filled.nm.values[7] == -15.
+    assert df_filled.mi.values[7] == -15.
 
-    ds_filled = ds.fillna(value=-11, column_names=['nm', 'mi'])
-    assert ds_filled.to_pandas_df(virtual=True).isna().any().any() == True
-    assert ds_filled.to_pandas_df(column_names=['nm', 'mi']).isna().any().any() == False
+    df_filled = df.fillna(value=-11, column_names=['nm', 'mi'])
+    assert df_filled.to_pandas_df(virtual=True).isna().any().any() == True
+    assert df_filled.to_pandas_df(column_names=['nm', 'mi']).isna().any().any() == False
 
-    state = ds_filled.state_get()
-    ds_copy.state_set(state)
-    np.testing.assert_array_equal(ds_copy['nm'].values, ds_filled['nm'].values)
-    np.testing.assert_array_equal(ds_copy['mi'].values, ds_filled['mi'].values)
+    state = df_filled.state_get()
+    df_copy.state_set(state)
+    np.testing.assert_array_equal(df_copy['nm'].values, df_filled['nm'].values)
+    np.testing.assert_array_equal(df_copy['mi'].values, df_filled['mi'].values)

--- a/tests/rename_test.py
+++ b/tests/rename_test.py
@@ -13,6 +13,15 @@ def test_rename(ds_filtered):
     assert ds.r.values.tolist() == xvalues
     assert ds.q.values.tolist() == qvalues
 
+
+def test_reassign_virtual(ds):
+    df = ds
+    x = df.x.values
+    df['r'] = df.x+1
+    df['r'] = df.x+1
+    assert df.r.tolist() == (x+2).tolist()
+
+
 def test_rename_state_transfer():
     ds = vaex.from_scalars(x=3, y=4)
     ds['r'] = (ds.x**2 + ds.y**2)**0.5


### PR DESCRIPTION
A unit-test exposing a potential problem when the `fillna()` method is used on a virtual expression, where the virtual expression contains `nan` values as a result of the calculationnot tri.

Note that the unit-test does trigger a failure: due to the nature of the problem `pytest` does not register the test at all, but looking at the logs one can easily spot the problem.