### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,8 +250,8 @@ Regards,
 
 The vaex.io team
 
-.. |Travis| image:: https://travis-ci.org/maartenbreddels/vaex.svg?branch=master
-   :target: https://travis-ci.org/maartenbreddels/vaex
+.. |Travis| image:: https://travis-ci.org/vaexio/vaex.svg?branch=master
+   :target: https://travis-ci.org/vaexio/vaex.svg?branch=master
 .. |Chat| image:: https://badges.gitter.im/maartenbreddels/vaex.svg
    :alt: Join the chat at https://gitter.im/maartenbreddels/vaex
    :target: https://gitter.im/maartenbreddels/vaex?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
Fix travis ci badge url. Can confirm here:
https://github.com/alimcmaster1/vaex/tree/patch-2

Thanks,

Ali