### PR TITLE
Adding a from_json method

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -419,6 +419,34 @@ def from_ascii(path, seperator=None, names=True, skip_lines=0, skip_after=0, **k
     return ds
 
 
+def from_json(path_or_buffer, orient=None, precise_float=False, lines=False, copy_index=True, **kwargs):
+    """ A method to read a JSON file using pandas, and convert to a DataFrame directly.
+
+    :param str path_or_buffer: a valid JSON string or file-like, default: None
+    The string could be a URL. Valid URL schemes include http, ftp, s3,
+    gcs, and file. For file URLs, a host is expected. For instance, a local
+    file could be ``file://localhost/path/to/table.json``
+    :param str orient: Indication of expected JSON string format. Allowed values are
+    ``split``, ``records``, ``index``, ``columns``, and ``values``.
+    :param bool precise_float: Set to enable usage of higher precision (strtod) function when
+    decoding string to double values. Default (False) is to use fast but less precise builtin functionality
+    :param bool lines: Read the file as a json object per line.
+
+    :rtype: DataFrame
+    """
+    # Check for unsupported kwargs
+    if kwargs.get('typ') == 'series':
+        raise ValueError('`typ` must be set to `"frame"`.')
+    if kwargs.get('numpy') == True:
+        raise ValueError('`numpy` must be set to `False`.')
+    if kwargs.get('chunksize') is not None:
+        raise ValueError('`chunksize` must be `None`.')
+
+    import pandas as pd
+    return from_pandas(pd.read_json(path_or_buffer, orient=orient, precise_float=precise_float, lines=lines, **kwargs),
+                       copy_index=copy_index)
+
+
 def from_csv(filename_or_buffer, copy_index=True, **kwargs):
     """Shortcut to read a csv file using pandas and convert to a DataFrame directly.
 

--- a/tests/from_json_test.py
+++ b/tests/from_json_test.py
@@ -13,7 +13,7 @@ def test_from_json(ds_local):
 
     tmp_df = vaex.from_json(tmp, copy_index=False)
 
-    assert tmp_df.column_names == df.column_names
+    assert set(tmp_df.column_names) == set(df.column_names)
     assert len(tmp_df) == len(df)
     assert tmp_df.x.tolist() == df.x.tolist()
     assert tmp_df.bool.tolist() == df.bool.tolist()

--- a/tests/from_json_test.py
+++ b/tests/from_json_test.py
@@ -1,0 +1,19 @@
+from common import *
+import tempfile
+
+
+def test_from_json(ds_local):
+    df = ds_local
+
+    # Create temporary json files
+    pandas_df = df.to_pandas_df(df)
+    tmp = tempfile.mktemp('.json')
+    with open(tmp, 'w') as f:
+        f.write(pandas_df.to_json())
+
+    tmp_df = vaex.from_json(tmp, copy_index=False)
+
+    assert tmp_df.column_names == df.column_names
+    assert len(tmp_df) == len(df)
+    assert tmp_df.x.tolist() == df.x.tolist()
+    assert tmp_df.bool.tolist() == df.bool.tolist()


### PR DESCRIPTION
Adding a `from_json` method, allowing to read JSON files directly into a `vaex` DataFrame.
