### PR TITLE
isna(), notna(), countna() methods for `vaex.expression`

### DIFF
--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -482,6 +482,13 @@ class Expression(with_metaclass(Meta)):
         """
         return (self == self)
 
+    def countna(self):
+        """Returns the number of NaN values in the expression. Note that valus
+        such as None, and empty strings do not get counted, i.e. they are not
+        treated as NaN values.
+        """
+        return (self != self).astype('int').sum() + 0  # so the output is int, not array
+
     def evaluate(self, i1=None, i2=None, out=None, selection=None):
         return self.ds.evaluate(self, i1, i2, out=out, selection=selection)
 

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -469,25 +469,22 @@ class Expression(with_metaclass(Meta)):
         return self.ds.unique(self.expression)
 
     def isna(self):
-        """Returns a boolean expression indicating if the values are NaN.
-        Note that values such as None, and an empty string get mapped to False,
-        i.e. they are not treated as NaN values.
+        """Returns a boolean expression indicating if the values are Not Availiable
+        (N/A), i.e. if they are None or numpy.nan.
         """
-        return ~(self == self)
+        return ~(self == self) | (self==None)
 
     def notna(self):
-        """Returns a boolean expression indicating if the values are not NaN.
-        Note that values such as None, and an empty string get mapped to True,
-        i.e. they are not treated as NaN values.
+        """Returns a boolean expression indicating if the values are not Not Availiable
+        (N/A), i.e. if they are not None and numpy.nan.
         """
-        return (self == self)
+        return (self == self) & ~(self==None)
 
     def countna(self):
-        """Returns the number of NaN values in the expression. Note that valus
-        such as None, and empty strings do not get counted, i.e. they are not
-        treated as NaN values.
+        """Returns the number of Not Availiable (N/A) values in the expression.
+        This includes both None and np.nan values.
         """
-        return (self != self).astype('int').sum() + 0  # so the output is int, not array
+        return self.isna().astype('int').sum() + 0  # so the output is int, not array
 
     def evaluate(self, i1=None, i2=None, out=None, selection=None):
         return self.ds.evaluate(self, i1, i2, out=out, selection=selection)

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -468,6 +468,20 @@ class Expression(with_metaclass(Meta)):
     def unique(self):
         return self.ds.unique(self.expression)
 
+    def isna(self):
+        """Returns a boolean expression indicating if the values are NaN.
+        Note that values such as None, and an empty string get mapped to False,
+        i.e. they are not treated as NaN values.
+        """
+        return ~(self == self)
+
+    def notna(self):
+        """Returns a boolean expression indicating if the values are not NaN.
+        Note that values such as None, and an empty string get mapped to True,
+        i.e. they are not treated as NaN values.
+        """
+        return (self == self)
+
     def evaluate(self, i1=None, i2=None, out=None, selection=None):
         return self.ds.evaluate(self, i1, i2, out=out, selection=selection)
 

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -468,23 +468,20 @@ class Expression(with_metaclass(Meta)):
     def unique(self):
         return self.ds.unique(self.expression)
 
-    def isna(self):
-        """Returns a boolean expression indicating if the values are Not Availiable
-        (N/A), i.e. if they are None or numpy.nan.
-        """
-        return ~(self == self) | (self==None)
-
-    def notna(self):
-        """Returns a boolean expression indicating if the values are not Not Availiable
-        (N/A), i.e. if they are not None and numpy.nan.
-        """
-        return (self == self) & ~(self==None)
 
     def countna(self):
         """Returns the number of Not Availiable (N/A) values in the expression.
-        This includes both None and np.nan values.
+        This includes missing values and np.nan values.
         """
-        return self.isna().astype('int').sum() + 0  # so the output is int, not array
+        return self.isna().astype('int').sum().item()  # so the output is int, not array
+
+    def countnan(self):
+        """Returns the number of NaN values in the expression."""
+        return self.isnan().astype('int').sum().item()  # so the output is int, not array
+
+    def countmissing(self):
+        """Returns the number of missing values in the expression."""
+        return self.ismissing().astype('int').sum().item()  # so the output is int, not array
 
     def evaluate(self, i1=None, i2=None, out=None, selection=None):
         return self.ds.evaluate(self, i1, i2, out=out, selection=selection)

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -143,6 +143,60 @@ def fillna(ar, value, fill_nan=True, fill_masked=True):
             ar[mask] = value
     return ar
 
+@register_function()
+def ismissing(x):
+    """Returns True where there are missing values (masked arrays), missing strings or None"""
+    if np.ma.isMaskedArray(x):
+        if x.dtype.kind in 'O':
+            return (x.data == None) | x.mask
+        else:
+            return x.mask == 1
+    else:
+        if not isinstance(x, np.ndarray) or x.dtype.kind in 'US':
+            x = _to_string_sequence(x)
+            return x.mask()
+        elif isinstance(x, np.ndarray) or x.dtype.kind in 'O':
+            return x == None
+        else:
+            return np.zeros(len(x), dtype=np.bool)
+
+
+@register_function()
+def notmissing(x):
+    return ~ismissing(x)
+
+
+@register_function()
+def isnan(x):
+    """Returns an array where there are NaN values"""
+    if isinstance(x, np.ndarray):
+        if np.ma.isMaskedArray(x):
+            # we don't want a masked arrays
+            w = x.data != x.data
+            w[x.mask] = False
+            return w
+        else:
+            return x != x
+    else:
+        return np.zeros(len(x), dtype=np.bool)
+
+
+@register_function()
+def notnan(x):
+    return ~isnan(x)
+
+
+@register_function()
+def isna(x):
+    """Returns a boolean expression indicating if the values are Not Availiable (missing or NaN)."""
+    return isnan(x) | ismissing(x)
+
+
+@register_function()
+def notna(x):
+    """Opposite of isna"""
+    return ~isna(x)
+
 
 ########## datetime operations ##########
 

--- a/tests/countna_test.py
+++ b/tests/countna_test.py
@@ -4,6 +4,11 @@ import numpy as np
 
 def test_countna():
     x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
-    df = vaex.from_arrays(x=x)
+    y_data = np.array([np.nan, 2, None, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    y_mask = np.array([0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1])
+    y = np.ma.MaskedArray(data=y_data, mask=y_mask)
+    df = vaex.from_arrays(x=x, y=y)
+    pandas_df = df.to_pandas_df()
 
-    assert df.x.countna() == 2
+    assert df.x.countna() == pandas_df.x.isna().sum()
+    assert df.y.countna() == pandas_df.y.isna().sum()

--- a/tests/countna_test.py
+++ b/tests/countna_test.py
@@ -1,0 +1,9 @@
+import vaex
+import numpy as np
+
+
+def test_countna():
+    x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
+    df = vaex.from_arrays(x=x)
+
+    assert df.x.countna() == 2

--- a/tests/countna_test.py
+++ b/tests/countna_test.py
@@ -12,3 +12,5 @@ def test_countna():
 
     assert df.x.countna() == pandas_df.x.isna().sum()
     assert df.y.countna() == pandas_df.y.isna().sum()
+    assert df.x.countnan() == 2
+    assert df.y.countmissing() == 6

--- a/tests/isna_test.py
+++ b/tests/isna_test.py
@@ -4,13 +4,23 @@ import numpy as np
 
 def test_isna():
     x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
-    df = vaex.from_arrays(x=x)
+    y_data = np.array([np.nan, 2, None, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    y_mask = np.array([0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1])
+    y = np.ma.MaskedArray(data=y_data, mask=y_mask)
+    df = vaex.from_arrays(x=x, y=y)
+    pandas_df = df.to_pandas_df()
 
-    assert df.x.isna().tolist() == [False, False, False, False, False, False, True, True, False, False, False, False, False]
+    assert df.x.isna().tolist() == pandas_df.x.isna().tolist()
+    assert df.y.isna().tolist() == pandas_df.y.isna().tolist()
 
 
 def test_notna():
     x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
-    df = vaex.from_arrays(x=x)
+    y_data = np.array([np.nan, 2, None, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    y_mask = np.array([0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1])
+    y = np.ma.MaskedArray(data=y_data, mask=y_mask)
+    df = vaex.from_arrays(x=x, y=y)
+    pandas_df = df.to_pandas_df()
 
-    assert df.x.notna().tolist() == [True,  True,  True, True, True,  True, False, False, True, True, True, True, True]
+    assert df.x.notna().tolist() == pandas_df.x.notna().tolist()
+    assert df.y.notna().tolist() == pandas_df.y.notna().tolist()

--- a/tests/isna_test.py
+++ b/tests/isna_test.py
@@ -1,0 +1,16 @@
+import vaex
+import numpy as np
+
+
+def test_isna():
+    x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
+    df = vaex.from_arrays(x=x)
+
+    assert df.x.isna().tolist() == [False, False, False, False, False, False, True, True, False, False, False, False, False]
+
+
+def test_notna():
+    x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
+    df = vaex.from_arrays(x=x)
+
+    assert df.x.notna().tolist() == [True,  True,  True, True, True,  True, False, False, True, True, True, True, True]

--- a/tests/isna_test.py
+++ b/tests/isna_test.py
@@ -1,6 +1,49 @@
 import vaex
 import numpy as np
 
+def test_is_missing():
+    s = vaex.string_column(["aap", None, "noot", "mies"])
+    o = ["aap", None, "noot", np.nan]
+    x = np.arange(4, dtype=np.float64)
+    x[2] = x[3] = np.nan
+    m = np.ma.array(x, mask=[0, 1, 0, 1])
+    df = vaex.from_arrays(x=x, m=m, s=s, o=o)
+    assert (df.x.ismissing().tolist() == [False, False, False, False])
+    assert (df.m.ismissing().tolist() == [False, True, False, True])
+    assert (df.s.ismissing().tolist() == [False, True, False, False])
+    assert (df.o.ismissing().tolist() == [False, True, False, False])
+
+    assert (df.m.notmissing().tolist() == [not k for k in [False, True, False, True]])
+
+
+def test_is_nan():
+    s = vaex.string_column(["aap", None, "noot", "mies"])
+    o = ["aap", None, "noot", np.nan]
+    x = np.arange(4, dtype=np.float64)
+    x[2] = x[3] = np.nan
+    m = np.ma.array(x, mask=[0, 1, 0, 1])
+    df = vaex.from_arrays(x=x, m=m, s=s, o=o)
+    assert (df.x.isnan().tolist() == [False, False, True, True])
+    assert (df.m.isnan().tolist() == [False, False, True, False])
+    assert (df.s.isnan().tolist() == [False, False, False, False])
+    assert (df.o.isnan().tolist() == [False, False, False, True])
+
+    assert (df.o.notnan().tolist() == [not k for k in [False, False, False, True]])
+
+
+
+def test_is_na():
+    s = vaex.string_column(["aap", None, "noot", "mies"])
+    o = ["aap", None, "noot", np.nan]
+    x = np.arange(4, dtype=np.float64)
+    x[2] = x[3] = np.nan
+    m = np.ma.array(x, mask=[0, 1, 0, 1])
+    df = vaex.from_arrays(x=x, m=m, s=s, o=o)
+    assert (df.x.isna().tolist() == [False, False, True, True])
+    assert (df.m.isna().tolist() == [False, True, True, True])
+    assert (df.s.isna().tolist() == [False, True, False, False])
+    assert (df.o.isna().tolist() == [False, True    , False, True])
+
 
 def test_isna():
     x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])


### PR DESCRIPTION
[Edited]

This PR adds `veax.expression` methods:

- `isna()` which returns a boolean expression in which an element is `True` if it is not available (N/A) (either `None` or `np.nan`);
- `notna()` which returns a boolean expression which is opposite of `notna()`;
- `countna()` which returns the number of not available (N/A) values (either `None` or `np.nan`).

Each of the methods comes with a unit-test.