### PR TITLE
Test for counting missing value in dataframe.describe()

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3246,20 +3246,20 @@ class DataFrame(object):
         for feature in self.get_column_names(strings=strings, virtual=virtual)[:]:
             dtype = str(self.dtype(feature)) if self.dtype(feature) != str else 'str'
             if self.dtype(feature) == str_type or self.dtype(feature).kind in ['S', 'U', 'O']:
-                count = self.count(feature, selection=selection, delay=True)
+                na_count = self.sum(self[feature].isna().astype('int'), selection=selection, delay=True)
                 self.execute()
-                count = count.get()
-                columns[feature] = ((dtype, count, N-count, '--', '--', '--', '--'))
+                na_count = na_count.get()
+                columns[feature] = ((dtype, N-na_count , na_count, '--', '--', '--', '--'))
             else:
-                count = self.count(feature, selection=selection, delay=True)
+                na_count = self.sum(self[feature].isna().astype('int'), selection=selection, delay=True)
                 mean = self.mean(feature, selection=selection, delay=True)
                 std = self.std(feature, selection=selection, delay=True)
                 minmax = self.minmax(feature, selection=selection, delay=True)
                 self.execute()
-                count, mean, std, minmax = count.get(), mean.get(), std.get(), minmax.get()
-                count = int(count)
-                columns[feature] = ((dtype, count, N-count, mean, std, minmax[0], minmax[1]))
-        return pd.DataFrame(data=columns, index=['dtype', 'count', 'missing', 'mean', 'std', 'min', 'max'])
+                na_count, mean, std, minmax = na_count.get(), mean.get(), std.get(), minmax.get()
+                na_count = int(na_count)
+                columns[feature] = ((dtype, N-na_count, na_count, mean, std, minmax[0], minmax[1]))
+        return pd.DataFrame(data=columns, index=['dtype', 'count', 'NA', 'mean', 'std', 'min', 'max'])
 
     def cat(self, i1, i2, format='html'):
         """Display the DataFrame from row i1 till i2

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -175,13 +175,19 @@ def ismissing(x):
     """Returns True where there are missing values (masked arrays), missing strings or None"""
     if np.ma.isMaskedArray(x):
         if x.dtype.kind in 'O':
-            return (x.data == None) | x.mask
+            if x.mask is not None:
+                return (x.data == None) | x.mask
+            else:
+                return (x.data == None)
         else:
             return x.mask == 1
     else:
         if not isinstance(x, np.ndarray) or x.dtype.kind in 'US':
             x = _to_string_sequence(x)
-            return x.mask()
+            mask = x.mask()
+            if mask is None:
+                mask = np.zeros(x.length, dtype=np.bool)
+            return mask
         elif isinstance(x, np.ndarray) or x.dtype.kind in 'O':
             return x == None
         else:

--- a/tests/describe_test.py
+++ b/tests/describe_test.py
@@ -4,3 +4,13 @@ def test_describe(ds_local):
   ds = ds_local
   pdf = ds.describe()
   assert 'class \'str\'' not in str(pdf)
+
+def test_describe_missing():
+    x = np.array([5, '', 1, 4, None, 6 , np.nan, np.nan, 10, '', 0, 0, -13.5])
+    y = np.array([5, -2, 1, 4, 0, 6 , np.nan, np.nan, 10, 42, 0, np.nan, -13.5])
+    df = vaex.from_arrays(x=x, y=y)
+
+    desc_df = df.describe()
+
+    assert desc_df.x.loc['missing'] == 2
+    assert desc_df.y.loc['missing'] == 3

--- a/tests/describe_test.py
+++ b/tests/describe_test.py
@@ -1,13 +1,15 @@
 from common import *
 
+
 def test_describe(ds_local):
-  ds = ds_local
-  pdf = ds.describe()
-  assert 'class \'str\'' not in str(pdf)
+    ds = ds_local
+    pdf = ds.describe()
+    assert 'class \'str\'' not in str(pdf)
+
 
 def test_describe_missing():
-    x = np.array([5, '', 1, 4, None, 6 , np.nan, np.nan, 10, '', 0, 0, -13.5])
-    y = np.array([5, -2, 1, 4, 0, 6 , np.nan, np.nan, 10, 42, 0, np.nan, -13.5])
+    x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
+    y = np.array([5, -2, 1, 4, 0, 6, np.nan, np.nan, 10, 42, 0, np.nan, -13.5])
     df = vaex.from_arrays(x=x, y=y)
 
     desc_df = df.describe()

--- a/tests/describe_test.py
+++ b/tests/describe_test.py
@@ -7,12 +7,12 @@ def test_describe(ds_local):
     assert 'class \'str\'' not in str(pdf)
 
 
-def test_describe_missing():
+def test_describe_NA():
     x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
     y = np.array([5, -2, 1, 4, 0, 6, np.nan, np.nan, 10, 42, 0, np.nan, -13.5])
     df = vaex.from_arrays(x=x, y=y)
 
     desc_df = df.describe()
 
-    assert desc_df.x.loc['missing'] == 2
-    assert desc_df.y.loc['missing'] == 3
+    assert desc_df.x.loc['NA'] == 3
+    assert desc_df.y.loc['NA'] == 3

--- a/tests/value_counts_test.py
+++ b/tests/value_counts_test.py
@@ -8,8 +8,8 @@ def test_value_counts():
     assert len(ds.x.value_counts()) == 21
     assert len(ds.y.value_counts()) == 19
 
-    assert len(ds.m.value_counts()) == 19
-    assert len(ds.m.value_counts(dropmissing=False)) == 20
+    assert len(ds.m.value_counts(dropmissing=True)) == 19
+    assert len(ds.m.value_counts()) == 20
 
     assert len(ds.n.value_counts(dropna=False)) == 20
     assert len(ds.n.value_counts(dropna=True)) == 19


### PR DESCRIPTION
This PR is to highlight and patch a bug which happens when counting the number of missing values in  `dataframe.describe()`, which happens when the `expression` is of `dtype` `O`.

