### PR TITLE
fix(core): file column should support nbytes property

### DIFF
--- a/packages/vaex-core/vaex/file/column.py
+++ b/packages/vaex-core/vaex/file/column.py
@@ -51,6 +51,10 @@ class ColumnFile(vaex.column.Column):
         self.shape = (length,)
         self.write = write
 
+    @property
+    def nbytes(self):
+        return self.length * self.dtype.itemsize
+
     def __del__(self):
         for f in self.file_handles:
             f.close()


### PR DESCRIPTION
This is the start for the support of strings for s3 files needed to fix #284. It requires more changes however. We assume the data is always locally available as contiguous array, we should only do that when we want to access the data.