### PR TITLE
Slicing dataframes and expressions (reloaded)

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4423,6 +4423,8 @@ class DataFrame(object):
             start, stop, step = item.start, item.stop, item.step
             start = start or 0
             stop = stop or len(self)
+            if start < 0:
+                start = len(self)+start
             if stop < 0:
                 stop = len(self)+stop
             stop = min(stop, len(self))

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -5,14 +5,16 @@ def test_slice_expression(df):
     assert df.x[:2].tolist() == df[:2].x.tolist()
     assert df.x[2:6].tolist() == df[2:6].x.tolist()
     assert df.x[-3:].tolist() == df[-3:].x.tolist()
-    assert df.x[::-3].tolist() == df[::-3].x.tolist()
+    # we don't support non 1 steps
+    # assert df.x[::-3].tolist() == df[::-3].x.tolist()
 
 
 def test_slice_against_numpy(df):
-        assert df.x[:2].tolist() == df.x.values[:2].tolist()
-        assert df.x[2:6].tolist() == df.x.values[2:6].tolist()
-        assert df.x[-3:].tolist() == df.x.values[-3:].tolist()
-        assert df.x[::-3].tolist() == df.x.values[::-3].tolist()
+    assert df.x[:2].tolist() == df.x.values[:2].tolist()
+    assert df.x[2:6].tolist() == df.x.values[2:6].tolist()
+    assert df.x[-3:].tolist() == df.x.values[-3:].tolist()
+    # we don't support non 1 steps
+    # assert df.x[::-3].tolist() == df.x.values[::-3].tolist()
 
 
 def test_slice(ds_local):

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -4,6 +4,15 @@ from common import *
 def test_slice_expression(df):
     assert df.x[:2].tolist() == df[:2].x.tolist()
     assert df.x[2:6].tolist() == df[2:6].x.tolist()
+    assert df.x[-3:].tolist() == df[-3:].x.tolist()
+    assert df.x[::-3].tolist() == df[::-3].x.tolist()
+
+
+def test_slice_against_numpy(df):
+        assert df.x[:2].tolist() == df.x.values[:2].tolist()
+        assert df.x[2:6].tolist() == df.x.values[2:6].tolist()
+        assert df.x[-3:].tolist() == df.x.values[-3:].tolist()
+        assert df.x[::-3].tolist() == df.x.values[::-3].tolist()
 
 
 def test_slice(ds_local):


### PR DESCRIPTION
Update of the unit-test for slicing DataFrames and Expressions, highlighting slicing options that are not yet supported. 