### PR TITLE
fix(core,trim): trimming didn't trim hidden columns

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3764,7 +3764,7 @@ class DataFrame(object):
         df = self if inplace else self.copy()
         if self._index_start == 0 and self._index_end == self._length_original:
             return df
-        for name in df:
+        for name in df.get_column_names(hidden=True):
             column = df.columns.get(name)
             if column is not None:
                 if self._index_start == 0 and len(column) == self._index_end:

--- a/tests/trim_test.py
+++ b/tests/trim_test.py
@@ -23,3 +23,10 @@ def test_trim(ds_local):
     assert ds_trimmed.length_original() == ds_trimmed.length_unfiltered() == 3
     assert ds_trimmed.get_active_range() == (0, ds_trimmed.length_original()) == (0, 3)
     assert ds_trimmed.evaluate('x').tolist() == np.arange(6, 9.).tolist()
+
+
+def test_trim_hidden(df_local):
+    df = df_local
+    df['r'] = df.x + df.y
+    df_sub = df[['r']].head()
+    assert len(df_sub.columns['__x']) == len(df_sub)


### PR DESCRIPTION
This fixes error for e.g.:
```
ds = vaex.example()
ds['r'] = (ds.x + ds.y) / (ds.z * 5)
ds[['r', 'x']].head(5)
```