### PR TITLE
add object_type is str test

### DIFF
--- a/tests/obj_type_test.py
+++ b/tests/obj_type_test.py
@@ -1,0 +1,16 @@
+import vaex
+
+
+def object_type_test():
+    df = vaex.read_csv('s3://xdss-public-datasets/demos/titanic.csv')
+    assert df['Cabin'].dtype == str
+
+    """
+    >> df.dtypes
+    ...
+    Ticket         <class 'str'> (can we make this into just "str")? 
+    Fare                 float64 
+    Cabin                 object
+    Embarked       <class 'str'>
+    index                  int64
+    """


### PR DESCRIPTION
No more Object type.
For starters, make it str and ket the user deal with the consequences if it's not.

Not really at the same importance level, but can we change `<class 'str'>` to `str`? on the way
```
>>> df.dtype:
...
PassengerId         int64
Survived               int64
Pclass                   int64
Name           <class 'str'> -> str
```