### PR TITLE
test for lists

### DIFF
--- a/tests/list_column_test.py
+++ b/tests/list_column_test.py
@@ -1,0 +1,12 @@
+import vaex
+import os
+
+
+def test_list_column():
+    df = vaex.from_dict(
+        {'list': [[1, 2], [2, 3], [4, 5]], 'strings': ['hey you', 'this is', 'a use case']})
+    assert df['list'].dtype == list
+    assert df['strings'].dtype == list
+    df['strings'] = df['strings'].str.split(' ')
+    df.export_hdf5('.test.hdf5')
+    os.remove('.test.hdf5')

--- a/tests/list_column_test.py
+++ b/tests/list_column_test.py
@@ -1,12 +1,18 @@
-import vaex
 import os
+
+import vaex
 
 
 def test_list_column():
     df = vaex.from_dict(
-        {'list': [[1, 2], [2, 3], [4, 5]], 'strings': ['hey you', 'this is', 'a use case']})
+        {'list': [[1, 2], [2, 3], [4, 5]],
+         'strings': ['hey you', 'this is', 'a use case'], 'A': [1, 2, 3],
+         'B': [2, 4, 6]})
+    df['strings'] = df['strings'].str.split(' ')
+    df['C'] = df.pack_columns(['A', 'B'])
     assert df['list'].dtype == list
     assert df['strings'].dtype == list
-    df['strings'] = df['strings'].str.split(' ')
+    assert df['C'].dtype == list
+    assert len(df['C'][0]) == 2
     df.export_hdf5('.test.hdf5')
     os.remove('.test.hdf5')


### PR DESCRIPTION
using a column of lists.
obviously, it will be "nice to have" to have a list of multiple types, but mostly it's important to have a homogenise column for pixels, text tokens, and packed columns (the one-hot-encoder could result with a single column instead of 5000 columns for 5000 values). 

* In-text case, lists are not the same length, which was a challenge for TF, so they made a special Tensor that can have multiple lengths, but paddings can be the first solution.
* We might need a pack_column, unpack methods to turn pack columns to a column of lists and back to columns.