### PR TITLE
Better str representation in dataframe.dtypes

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1935,7 +1935,7 @@ class DataFrame(object):
     def dtypes(self):
         """Gives a Pandas series object containing all numpy dtypes of all columns (except hidden)."""
         from pandas import Series
-        return Series({column_name:self.dtype(column_name) for column_name in self.get_column_names()})
+        return Series({column_name:self.dtype(column_name) if self.dtype(column_name) != str_type else 'str' for column_name in self.get_column_names()})
 
     def is_masked(self, column):
         '''Return if a column is a masked (numpy.ma) column.'''

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -13,7 +13,7 @@ def test_dtype(ds_local):
 
 def test_dtypes(ds_local):
   ds = ds_local
-  assert [ds.dtypes[name] for name in ds.column_names] == [ds[name].dtype for name in ds.column_names]
+  assert [ds.dtypes[name] for name in ds.column_names] == [ds[name].dtype if ds[name].dtype != str_type else 'str' for name in ds.column_names]
 
 def test_dtype_str():
   df = vaex.from_arrays(x=["foo", "bars"], y=[1,2])


### PR DESCRIPTION
Modify the `dataframe.dtypes` to make the printing of the `str` `dtype` more pretty. 