### PR TITLE
Improving the LabelEncoder

### DIFF
--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -23,15 +23,16 @@ def pca(self, n_components=2, features=None, prefix='PCA_', progress=False):
     return pca
 
 
-def label_encoder(self, features=None, prefix='label_encoded_'):
+def label_encoder(self, features=None, prefix='label_encoded_', allow_unseen=False):
     '''Requires vaex.ml: Create :class:`vaex.ml.transformations.LabelEncoder` and fit it.
 
     :param features: List of features to encode.
     :param prefix: Prefix for the names of the encoded features.
+    :param allow_unseen: If True, encode unseen value as -1, otherwise an error is raised.
     '''
     features = features or self.get_column_names()
     features = _ensure_strings_from_expressions(features)
-    label_encoder = LabelEncoder(features=features, prefix=prefix)
+    label_encoder = LabelEncoder(features=features, prefix=prefix, allow_unseen=allow_unseen)
     label_encoder.fit(self)
     return label_encoder
 


### PR DESCRIPTION
This PR makes improvements on the implementation of `vaex.ml.LabelEncoder()`. It leverages the super fast `map` method. and runs fully out of core. There is now support for values that were not present during the training (fitting) stage. 

The past implementation was not fully out of core as far as I can tell.

Also, there is a small adjustment to the unit-test. The encoder is longer tested against the `sklearn`s implementation, for the simple reason that the order of the unique elements (categories) in a feature is not guaranteed to be the same in `vaex` and `sklearn`. However, I am comfortable with this, since the `map` method is properly tested. 