### PR TITLE
feat(core,server): server takes token and/or token-trusted

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -137,6 +137,14 @@ def open(path, convert=False, shuffle=False, copy_index=True, *args, **kwargs):
             path = aliases[path]
         if path.startswith("http://") or path.startswith("ws://"):  # TODO: think about https and wss
             server, name = path.rsplit("/", 1)
+            url = urlparse(path)
+            if '?' in name:
+                name = name[:name.index('?')]
+            extra_args = {key: values[0] for key, values in parse_qs(url.query).items()}
+            if 'token' in extra_args:
+                kwargs['token'] = extra_args['token']
+            if 'token_trusted' in extra_args:
+                kwargs['token_trusted'] = extra_args['token_trusted']
             server = vaex.server(server, **kwargs)
             dataframe_map = server.datasets(as_dict=True)
             if name not in dataframe_map:
@@ -509,9 +517,9 @@ aliases = vaex.settings.main.auto_store_dict("aliases")
 
 # py2/p3 compatibility
 try:
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, parse_qs
 except ImportError:
-    from urlparse import urlparse
+    from urlparse import urlparse, parse_qs
 
 
 def server(url, **kwargs):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2137,7 +2137,7 @@ class DataFrame(object):
                      active_range=[self._index_start, self._index_end])
         return state
 
-    def state_set(self, state, use_active_range=False):
+    def state_set(self, state, use_active_range=False, trusted=True):
         """Sets the internal state of the df
 
         Example:
@@ -2178,7 +2178,7 @@ class DataFrame(object):
             for old, new in state['renamed_columns']:
                 self._rename(old, new)
         for name, value in state['functions'].items():
-            self.add_function(name, vaex.serialize.from_dict(value))
+            self.add_function(name, vaex.serialize.from_dict(value, trusted=trusted))
         if 'column_names' in state:
             # we clear all columns, and add them later on, since otherwise self[name] = ... will try
             # to rename the columns (which is unsupported for remote dfs)

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -730,17 +730,19 @@ class FunctionSerializablePickle(FunctionSerializable):
         return dict(pickled=pickled)
 
     @classmethod
-    def state_from(cls, state):
+    def state_from(cls, state, trusted=True):
         obj = cls()
-        obj.state_set(state)
+        obj.state_set(state, trusted=trusted)
         return obj
 
-    def state_set(self, state):
+    def state_set(self, state, trusted=True):
         data = state['pickled']
         if vaex.utils.PY2:
             data = base64.decodestring(data)
         else:
             data = base64.decodebytes(data.encode('ascii'))
+        if trusted is False:
+            raise ValueError("Will not unpickle data when source is not trusted")
         self.f = self.unpickle(data)
 
     def __call__(self, *args, **kwargs):
@@ -770,7 +772,7 @@ class FunctionSerializableJit(FunctionSerializable):
                     verbose=self.verbose)
 
     @classmethod
-    def state_from(cls, state):
+    def state_from(cls, state, trusted=True):
         return cls(expression=state['expression'],
                    arguments=state['arguments'],
                    argument_dtypes=list(map(np.dtype, state['argument_dtypes'])),

--- a/packages/vaex-core/vaex/serialize.py
+++ b/packages/vaex-core/vaex/serialize.py
@@ -16,7 +16,7 @@ def to_dict(obj):
     return dict(cls=fullname(obj.__class__), state=obj.state_get())
 
 
-def from_dict(d):
+def from_dict(d, trusted=True):
     cls_name = d['cls']
     if cls_name not in registry:
         # lets load the module, so we give it a chance to register
@@ -25,7 +25,7 @@ def from_dict(d):
     if cls_name not in registry:
         raise ValueError('unknown class: ' + cls_name)
     else:
-        obj = registry[cls_name].state_from(d['state'])
+        obj = registry[cls_name].state_from(d['state'], trusted=trusted)
         # obj.state_set(d['state'])
         return obj
 

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -41,7 +41,7 @@ import vaex.serialize
 class Multiply:
 	def __init__(self, scale=0): self.scale = scale
 	@classmethod
-	def state_from(cls, state):
+	def state_from(cls, state, trusted=True):
 		return cls(scale=state)
 	def state_get(self): return self.scale
 	def __call__(self, x): return x * self.scale

--- a/packages/vaex-ml/vaex/ml/catboost.py
+++ b/packages/vaex-ml/vaex/ml/catboost.py
@@ -137,7 +137,7 @@ class CatBoostModel(state.HasState):
         return dict(tree_state=base64.encodebytes(data).decode('ascii'),
                     substate=super(CatBoostModel, self).state_get())
 
-    def state_set(self, state):
+    def state_set(self, state, trusted=True):
         super(CatBoostModel, self).state_set(state['substate'])
         data = base64.decodebytes(state['tree_state'].encode('ascii'))
         filename = tempfile.mktemp()

--- a/packages/vaex-ml/vaex/ml/incubator/annoy.py
+++ b/packages/vaex-ml/vaex/ml/incubator/annoy.py
@@ -58,7 +58,7 @@ class ANNOYModel(state.HasState):
                     substate=super(ANNOYModel, self).state_get(),
                     n_dimensions=len(self.features))
 
-    def state_set(self, state):
+    def state_set(self, state, trusted=True):
         super(ANNOYModel, self).state_set(state['substate'])
         data = base64.decodebytes(state['tree_state'].encode('ascii'))
         n_dimensions = state['n_dimensions']

--- a/packages/vaex-ml/vaex/ml/incubator/pygbm.py
+++ b/packages/vaex-ml/vaex/ml/incubator/pygbm.py
@@ -122,8 +122,10 @@ class PyGBMModel(state.HasState):
         return dict(tree_state=base64.encodebytes(pickle.dumps(self.pygbm_model)).decode('ascii'),
                     substate=super(PyGBMModel, self).state_get())
 
-    def state_set(self, state):
+    def state_set(self, state, trusted=True):
         super(PyGBMModel, self).state_set(state['substate'])
+        if trusted is False:
+            raise ValueError("Will not unpickle data when source is not trusted")
         self.pygbm_model = pickle.loads(base64.decodebytes(state['tree_state'].encode('ascii')))
 
 @vaex.serialize.register

--- a/packages/vaex-ml/vaex/ml/lightgbm.py
+++ b/packages/vaex-ml/vaex/ml/lightgbm.py
@@ -155,7 +155,7 @@ class LightGBMModel(state.HasState):
         return dict(tree_state=base64.encodebytes(data).decode('ascii'),
                     substate=super(LightGBMModel, self).state_get())
 
-    def state_set(self, state):
+    def state_set(self, state, trusted=True):
         super(LightGBMModel, self).state_set(state['substate'])
         data = base64.decodebytes(state['tree_state'].encode('ascii'))
         filename = tempfile.mktemp()

--- a/packages/vaex-ml/vaex/ml/state.py
+++ b/packages/vaex-ml/vaex/ml/state.py
@@ -33,7 +33,7 @@ def default_from_json(trait_name, data, state_obj):
 class HasState(traitlets.HasTraits):
 
     @classmethod
-    def state_from(cls, state):
+    def state_from(cls, state, trusted=True):
         obj = cls()
         obj.state_set(state)
         return obj
@@ -46,7 +46,7 @@ class HasState(traitlets.HasTraits):
             state[name] = value
         return state
 
-    def state_set(self, state):
+    def state_set(self, state, trusted=True):
         for name in self.trait_names():
             if name in state:
                 from_json = self.trait_metadata(name, 'from_json', default_from_json)

--- a/packages/vaex-ml/vaex/ml/xgboost.py
+++ b/packages/vaex-ml/vaex/ml/xgboost.py
@@ -137,7 +137,7 @@ class XGBoostModel(state.HasState):
         return dict(tree_state=base64.encodebytes(data).decode('ascii'),
                     substate=super(XGBoostModel, self).state_get())
 
-    def state_set(self, state):
+    def state_set(self, state, trusted=True):
         super(XGBoostModel, self).state_set(state['substate'])
         data = base64.decodebytes(state['tree_state'].encode('ascii'))
         filename = tempfile.mktemp()

--- a/tests/server/token_test.py
+++ b/tests/server/token_test.py
@@ -1,0 +1,49 @@
+import numpy as np
+import vaex
+import vaex.webserver
+import pytest
+
+import sys
+test_port = 29110 + sys.version_info[0] * 10 + sys.version_info[1]
+scheme = 'ws'
+
+@pytest.fixture(scope='module')
+def webserver():
+    webserver = vaex.webserver.WebServer(datasets=[], port=test_port, cache_byte_size=0, token='token', token_trusted='token_trusted')
+    x = np.arange(10)
+    df = vaex.from_arrays(x=x)
+    df.name = 'df'
+    webserver.set_datasets([df])
+    webserver.serve_threaded()
+    yield webserver
+    webserver.stop_serving()
+    #return webserver
+
+@pytest.fixture(scope='module')
+def server(webserver):
+    server = vaex.server("%s://localhost:%d" % (scheme, test_port))
+    yield server
+    server.close()
+
+@pytest.fixture()
+def base_url():
+    return "%s://localhost:%d" % (scheme, test_port)
+# @pytest.fixture()
+# def df_remote(webserver, server):
+#     return server.datasets(as_dict=True)['df']
+
+def test_no_auth(webserver, base_url):
+    with pytest.raises(ValueError, match='.*No token.*'):
+        df = vaex.open("%s/df" % (base_url))
+        df.x.sum()
+        pytest.fail('When no token given, operations should not be supported')
+
+
+def test_no_trusted(webserver, base_url):
+    df = vaex.open("%s/df?token=token" % (base_url))
+    df.x.sum()
+    df.x.jit_numba().sum()
+    with pytest.raises(ValueError, match='.*pickle.*'):
+        df.x.apply(lambda x: x+1).sum()
+        pytest.fail('When no token_trusted given, function serialization operations using pickle should not be supported')
+


### PR DESCRIPTION
to make deserialization safer

 * If no token_trusted is passed to the server, the server will not trust during state_set, and
will not deserialize pickled states.
 * If token of token_trusted is set, a user needs to provide either one of them.

Usage for server:
```
$ vaex webserver ~/datasets/gaia/STSci/gaia_ps1_subset.hdf5  --token-trusted=mytoken
```

From Python:
```
df = vaex.open('ws://0.0.0.0:9000/gaia_ps1_subset?token_trusted=mytoken')
df.x.apply(lambda x: x+1).sum()
```

Now the lambda function will get deserialized at the server, otherwise it is now allowed.

Use `--token` to protect the server from any user, but disallow unsafe deserialization.

Use case: run a server, share a token to a group of semi-trusted users/tests, and use the `--token-trusted` to give yourself and a group of select users more freedom (basically arbitrary code execution) 
