### PR TITLE
Unit-test for unique in case of dtype object and n/a values

### DIFF
--- a/tests/unique_test.py
+++ b/tests/unique_test.py
@@ -37,3 +37,10 @@ def test_unique_nan():
         mask = np.isnan(values)
         assert values[~mask].tolist() == df.x.values[~mask].tolist()
         # assert indices.tolist() == [0, 1, 2, 0, 3, 0]
+
+def test_unique_missing():
+    # Create test databn
+    x = np.array(['A', 'B', -1, 0, 2, '', '', None, None, None, np.nan, np.nan, np.nan, np.nan,])
+    df = vaex.from_arrays(x=x)
+    uniques = df.x.unique().tolist()
+    assert set(uniques) == set(['', 'A', 'B', -1, 0, 2])

--- a/tests/unique_test.py
+++ b/tests/unique_test.py
@@ -40,7 +40,7 @@ def test_unique_nan():
 
 def test_unique_missing():
     # Create test databn
-    x = np.array(['A', 'B', -1, 0, 2, '', '', None, None, None, np.nan, np.nan, np.nan, np.nan,])
+    x = np.array([None, 'A', 'B', -1, 0, 2, '', '', None, None, None, np.nan, np.nan, np.nan, np.nan,])
     df = vaex.from_arrays(x=x)
     uniques = df.x.unique().tolist()
     assert set(uniques) == set(['', 'A', 'B', -1, 0, 2])

--- a/tests/unique_test.py
+++ b/tests/unique_test.py
@@ -42,5 +42,5 @@ def test_unique_missing():
     # Create test databn
     x = np.array([None, 'A', 'B', -1, 0, 2, '', '', None, None, None, np.nan, np.nan, np.nan, np.nan,])
     df = vaex.from_arrays(x=x)
-    uniques = df.x.unique().tolist()
-    assert set(uniques) == set(['', 'A', 'B', -1, 0, 2])
+    uniques = df.x.unique(dropnan=True).tolist()
+    assert set(uniques) == set(['', 'A', 'B', -1, 0, 2, None])


### PR DESCRIPTION
Unit-test for `unique`, which tests the behaviour in case of `dtype` `object` and the presence of n/a data (`np.nan`, `None`).