### PR TITLE
feat(core): better string detection for dtype=object

### DIFF
--- a/packages/vaex-arrow/vaex_arrow/convert.py
+++ b/packages/vaex-arrow/vaex_arrow/convert.py
@@ -8,6 +8,7 @@ def arrow_array_from_numpy_array(array):
     mask = None
     if np.ma.isMaskedArray(array):
         mask = array.mask
+        array = array.data
     if dtype.kind == 'S':
         type = pyarrow.binary(dtype.itemsize)
         arrow_array = pyarrow.array(array, type, mask=mask)

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -185,7 +185,7 @@ def open(path, convert=False, shuffle=False, copy_index=True, *args, **kwargs):
                     else:
                         ds = vaex.file.open(filename_hdf5, *args, **kwargs)
                 else:
-                    if ext == '.csv':  # special support for csv.. should probably approach it a different way
+                    if ext == '.csv' or naked_path.endswith(".csv.bz2"):  # special support for csv.. should probably approach it a different way
                         ds = from_csv(path, copy_index=copy_index, **kwargs)
                     else:
                         ds = vaex.file.open(path, *args, **kwargs)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2767,7 +2767,7 @@ class DataFrame(object):
             else:
                 if isinstance(ar, np.ndarray) and ar.dtype.kind == 'O':
                     types = list({type(k) for k in ar if k == k and k is not None})
-                    if len(types) == 1 and types[0] in six.string_types:
+                    if len(types) == 1 and issubclass(types[0], six.string_types):
                         self._dtypes_override[name] = str_type
         else:
             raise ValueError("functions not yet implemented")

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -2,6 +2,7 @@ from common import *
 from vaex.column import str_type
 
 
+
 def test_dtype(ds_local):
   ds = ds_local
   for name in ds.column_names:
@@ -21,3 +22,18 @@ def test_dtype_str():
   df['s'] = df.y.apply(lambda x: str(x))
   assert df.dtype(df.x) == str_type
   assert df.dtype(df.s) == str_type
+
+  n = np.array(['aap', 'noot'])
+  assert vaex.from_arrays(n=n).n.dtype == str_type
+
+  n = np.array([np.nan, 'aap', 'noot'], dtype=object)
+  df = vaex.from_arrays(n=n)
+  assert df.n.dtype == str_type
+  assert df.copy().n.dtype == str_type
+  assert 'n' in df._dtypes_override
+
+  n = np.array([None, 'aap', 'noot'])
+  df = vaex.from_arrays(n=n)
+  assert df.n.dtype == str_type
+  assert df.copy().n.dtype == str_type
+  assert 'n' in df._dtypes_override


### PR DESCRIPTION
This will allow the csv in https://towardsdatascience.com/a-billion-rows-a-second-36b7a2066175?gi=d0ff8b86a706 to be loaded in 1 line: `df = vaex.open('/path/to/file.cvs.bz2', convert='file.hdf5')` 