### PR TITLE
feat(core,groupby,binby): category support

### DIFF
--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -81,7 +81,7 @@ class AggregatorDescriptorBasic(AggregatorDescriptor):
         return spec
 
     def pretty_name(self, id=None):
-        id = id or "_".join(map(str, self.expression))
+        id = id or "_".join(map(str, self.expressions))
         return '{0}_{1}'.format(id, self.short_name)
 
     def _prepare_types(self, df):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4782,6 +4782,7 @@ class DataFrame(object):
         return type(expression, vmin, vmax, shape)
 
     def _binner_ordinal(self, expression, ordinal_count, min_value=0):
+        expression = _ensure_string_from_expression(expression)
         type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerOrdinal_", self.data_type(expression))
         return type(expression, ordinal_count, min_value)
 

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -82,6 +82,17 @@ def test_groupby_1d(ds_local):
     assert dfg.g.tolist() == [0, 1, 2]
     assert dfg['count'].tolist() == [4, 4, 2]
 
+def test_groupby_1d_cat(ds_local):
+    ds = ds_local.extract()
+    g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2])
+    ds.add_column('g', g)
+    ds.categorize('g', ['cat', 'dog', 'snake'])
+    dfg = ds.groupby(by=ds.g, agg='count')
+
+    assert dfg.g.tolist() == ['cat', 'dog', 'snake']
+    assert dfg['count'].tolist() == [4, 4, 2]
+
+
 
 def test_groupby_1d_nan(ds_local):
     ds = ds_local.extract()
@@ -102,6 +113,17 @@ def test_binby_1d(ds_local):
     assert ar.coords['statistic'].values.tolist() == ["count"]
     assert ar.dims == ('statistic', 'g')
     assert ar.data.tolist() == [[4, 4, 2]]
+
+
+def test_binby_1d_cat(ds_local):
+    ds = ds_local.extract()
+    g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2])
+    ds.add_column('g', g)
+    ds.categorize('g', ['cat', 'dog', 'snake'])
+    ar = ds.binby(by=ds.g, agg=vaex.agg.count())
+
+    assert ar.coords['g'].values.tolist() == ['cat', 'dog', 'snake']
+    assert ar.data.tolist() == [4, 4, 2]
 
 
 def test_binby_2d(ds_local):


### PR DESCRIPTION
When groupby is used with categories, it will show the labels in the aggregated dataframe.
```
g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2])
df = vaex.from_arrays(g=g)
df.categorize('g', ['cat', 'dog', 'snake'])
df.groupby(by=df.g, agg='count')
```