### PR TITLE
fix(core): allows overwriting jitted functions

### DIFF
--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -833,7 +833,7 @@ class FunctionSerializableJit(FunctionSerializable):
 
         # function validation, and finding variable names
         all_vars = df.get_column_names(hidden=True) + list(df.variables.keys())
-        funcs = set(expression_namespace.keys())
+        funcs = set(list(expression_namespace.keys()) + list(df.functions.keys()))
         names = []
         vaex.expresso.validate_expression(expression, all_vars, funcs, names)
         # TODO: can we do the above using the Expressio API?s

--- a/tests/jit_test.py
+++ b/tests/jit_test.py
@@ -35,6 +35,18 @@ def test_numba(ds):
     assert ds.arc_distance.tolist() == ds.arc_distance_jit.tolist()
 
 
+@pytest.mark.skipif(sys.version_info < (3,6) and sys.version_info[0] != 2,
+                    reason="no support for python3.5 (numba segfaults)")
+def test_jit_overwrite(ds_local):
+    ds = ds_local # TODO: remote overwriting of functions does not work
+    ds_original = ds.copy()
+    expr = arc_distance(ds.y*1, ds.y*1, ds.y**2*ds.y, ds.x+ds.y)
+    ds['arc_distance'] = expr
+    ds['arc_distance_jit'] = ds['arc_distance'].jit_numba()
+    ds['arc_distance_jit'] = ds['arc_distance * 2'].jit_numba()
+    assert (ds.arc_distance*2).tolist() == ds.arc_distance_jit.tolist()
+
+
 @pytest.mark.skipif(cupy is None,
                     reason="cuda support relies on cupy")
 def test_cuda(ds_local):


### PR DESCRIPTION
e.g. when doing
df['a'] = df.a.jit_cuda()
df['a'] = (df.a*2).jit_cuda()
It wouldn't not process that correctly