### PR TITLE
Improve error on open unsupported formats

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -189,12 +189,12 @@ def open(path, convert=False, shuffle=False, copy_index=True, *args, **kwargs):
                         ds = from_csv(path, copy_index=copy_index, **kwargs)
                     else:
                         ds = vaex.file.open(path, *args, **kwargs)
-                    if convert:
+                    if convert and ds:
                         ds.export_hdf5(filename_hdf5, shuffle=shuffle)
                         ds = vaex.file.open(filename_hdf5) # argument were meant for pandas?
                 if ds is None:
                     if os.path.exists(path):
-                        raise IOError('Could not open file: {}, did you install vaex-hdf5?'.format(path))
+                        raise IOError('Could not open file: {}, did you install vaex-hdf5? Is the format supported?'.format(path))
                     if os.path.exists(path):
                         raise IOError('Could not open file: {}, it does not exist?'.format(path))
             elif len(filenames) > 1:

--- a/tests/open_test.py
+++ b/tests/open_test.py
@@ -60,7 +60,7 @@ def test_open():
     with tempfile.NamedTemporaryFile(suffix='json') as in_f:
         in_f.write(b'[]')
         in_f.flush()
-        with pytest.raises(OSError) as exc:
+        with pytest.raises(IOError) as exc:
             vaex.open(in_f.name, convert=target)
         assert 'format supported' in str(exc.value)
     assert not os.path.exists(target)

--- a/tests/open_test.py
+++ b/tests/open_test.py
@@ -56,5 +56,11 @@ def test_open():
     os.remove(h51)
     os.remove(h52)
 
-
-
+    # be nice to users when converting from unsupported format
+    with tempfile.NamedTemporaryFile(suffix='json') as in_f:
+        in_f.write(b'[]')
+        in_f.flush()
+        with pytest.raises(OSError) as exc:
+            vaex.open(in_f.name, convert=target)
+        assert 'format supported' in str(exc.value)
+    assert not os.path.exists(target)


### PR DESCRIPTION
avoid errors like the following when opening unsupported formats

```
In [148]: vaex.open('events-80kk.jsonl', convert='events-v.hd5')   
ERROR:MainThread:vaex:error opening 'events-80kk.jsonl'
-------------------------------------------------------------------
AttributeError                    Traceback (most recent call last)
<ipython-input-148-fd088de8f507> in <module>
----> 1 vaex.open('events-80kk.jsonl', convert='events-v.hd5')

~/devel/feedstock/ep2019/virtual/lib/python3.6/site-packages/vaex/__init__.py in open(path, convert, shuffle, copy_index, *args, **kwarg
s)
    191                         ds = vaex.file.open(path, *args, **kwargs)
    192                     if convert:
--> 193                         ds.export_hdf5(filename_hdf5, shuffle=shuffle)
    194                         ds = vaex.file.open(filename_hdf5) # argument were meant for pandas?
    195                 if ds is None:

AttributeError: 'NoneType' object has no attribute 'export_hdf5'
```