### PR TITLE
feat: lazy df accessor plugin system

### DIFF
--- a/packages/vaex-astro/setup.py
+++ b/packages/vaex-astro/setup.py
@@ -14,15 +14,19 @@ version     = version.__version__
 url         = 'https://www.github.com/maartenbreddels/vaex'
 install_requires_astro = ['vaex-core>=0.1']
 
-setup(name=name + '-astro',
-      version=version,
-      description='Astronomy related transformations and FITS file support',
-      url=url,
-      author=author,
-      author_email=author_email,
-      install_requires=install_requires_astro,
-      license=license,
-      packages=['vaex.astro'],
-      zip_safe=False,
-      entry_points={'vaex.plugin': ['astro = vaex.astro.transformations:add_plugin']}
-      )
+setup(
+    name=name + '-astro',
+    version=version,
+    description='Astronomy related transformations and FITS file support',
+    url=url,
+    author=author,
+    author_email=author_email,
+    install_requires=install_requires_astro,
+    license=license,
+    packages=['vaex.astro'],
+    zip_safe=False,
+    entry_points={
+        'vaex.plugin': ['astro = vaex.astro.legacy:add_plugin'],
+        'vaex.dataframe.accessor': ['astro = vaex.astro.transformations:DataFrameAccessorAstro'],
+    },
+)

--- a/packages/vaex-astro/vaex/astro/legacy.py
+++ b/packages/vaex-astro/vaex/astro/legacy.py
@@ -1,0 +1,115 @@
+from vaex.dataframe import DataFrame
+import numpy as np
+
+
+def add_plugin():
+    pass  # importing this module already does the job
+
+
+def patch(f):
+    '''Adds method f to the DataFrame class'''
+    name = f.__name__
+    DataFrame.__hidden__[name] = f
+    return f
+
+
+@patch
+def add_virtual_columns_eq2ecl(self, long_in="ra", lat_in="dec", long_out="lambda_", lat_out="beta", name_prefix="__celestial_eq2ecl", radians=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.eq2ecl(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_eq2gal(self, long_in="ra", lat_in="dec", long_out="l", lat_out="b", name_prefix="__celestial_eq2gal", radians=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.eq2ecl(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_gal2eq(self, long_in='l', lat_in='b', long_out='ra', lat_out='dec', name_prefix="__celestial_gal2eq", radians=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.gal2eq(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_distance_from_parallax(self, parallax="parallax", distance_name="distance", parallax_uncertainty=None, uncertainty_postfix="_uncertainty"):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.parallax2distance(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_cartesian_velocities_to_pmvr(self, x="x", y="y", z="z", vx="vx", vy="vy", vz="vz", vr="vr", pm_long="pm_long", pm_lat="pm_lat", distance=None):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.velocity_cartesian2pmvr(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_proper_motion_eq2gal(self, long_in="ra", lat_in="dec", pm_long="pm_ra", pm_lat="pm_dec", pm_long_out="pm_l", pm_lat_out="pm_b",
+                                            name_prefix="__proper_motion_eq2gal",
+                                            right_ascension_galactic_pole=192.85,
+                                            declination_galactic_pole=27.12,
+                                            propagate_uncertainties=False,
+                                            radians=False, inverse=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.pm_eq2gal(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_proper_motion_gal2eq(self, long_in="ra", lat_in="dec", pm_long="pm_l", pm_lat="pm_b", pm_long_out="pm_ra", pm_lat_out="pm_dec",
+                                            name_prefix="__proper_motion_gal2eq",
+                                            right_ascension_galactic_pole=192.85,
+                                            declination_galactic_pole=27.12,
+                                            propagate_uncertainties=False,
+                                            radians=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.pm_gal2eq(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_lbrvr_proper_motion2vcartesian(self, long_in="l", lat_in="b", distance="distance", pm_long="pm_l", pm_lat="pm_b",
+                                                       vr="vr", vx="vx", vy="vy", vz="vz",
+                                                       center_v=(0, 0, 0),
+                                                       propagate_uncertainties=False, radians=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.lbrvrpm2vcartesian(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_equatorial_to_galactic_cartesian(self, alpha, delta, distance, xname, yname, zname, radians=True, alpha_gp=np.radians(192.85948), delta_gp=np.radians(27.12825), l_omega=np.radians(32.93192)):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.equatorial2galactic_cartesian(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_celestial(self, long_in, lat_in, long_out, lat_out, name_prefix="__celestial", radians=False, _matrix=None):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.celestial(inplace=True, **kwargs)
+
+@patch
+def add_virtual_columns_proper_motion2vperpendicular(self, distance="distance", pm_long="pm_l", pm_lat="pm_b",
+                                                     vl="vl", vb="vb",
+                                                     propagate_uncertainties=False,
+                                                     radians=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.proper_motion2vperpendicular(inplace=True, **kwargs)
+
+
+@patch
+def add_virtual_columns_cartesian_angular_momenta(self, x='x', y='y', z='z',
+                                                  vx='vx', vy='vy', vz='vz',
+                                                  Lx='Lx', Ly='Ly', Lz='Lz',
+                                                  propagate_uncertainties=False):
+    kwargs = dict(**locals())
+    kwargs.pop('self')
+    return self.astro.cartesian_angular_momenta(inplace=True, **kwargs)

--- a/packages/vaex-astro/vaex/astro/transformations.py
+++ b/packages/vaex-astro/vaex/astro/transformations.py
@@ -1,13 +1,7 @@
-from vaex.dataset import Dataset
 import vaex
 import numpy as np
 import math
 
-def patch(f):
-    '''Adds method f to the Dataset class'''
-    name = f.__name__
-    Dataset.__hidden__[name] = f
-    return f
 
 # All assume equinox J2000
 comat = {'eq2ecl': [[0.9999999999999928, 1.1102233723050031e-07, 4.411803426976324e-08],
@@ -20,106 +14,7 @@ comat = {'eq2ecl': [[0.9999999999999928, 1.1102233723050031e-07, 4.4118034269763
                      [-0.873437051955779, -0.44482972122205366, -0.19807633727507046],
                      [-0.48383507361641837, 0.7469821839845096, 0.45598381369115243]]}
 
-@patch
-def add_virtual_columns_eq2ecl(self, long_in="ra", lat_in="dec", long_out="lambda_", lat_out="beta", name_prefix="__celestial_eq2ecl", radians=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.eq2ecl(inplace=True, **kwargs)
 
-@patch
-def add_virtual_columns_eq2gal(self, long_in="ra", lat_in="dec", long_out="l", lat_out="b", name_prefix="__celestial_eq2gal", radians=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.eq2ecl(inplace=True, **kwargs)
-
-@patch
-def add_virtual_columns_gal2eq(self, long_in='l', lat_in='b', long_out='ra', lat_out='dec', name_prefix="__celestial_gal2eq", radians=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.gal2eq(inplace=True, **kwargs)
-
-@patch
-def add_virtual_columns_distance_from_parallax(self, parallax="parallax", distance_name="distance", parallax_uncertainty=None, uncertainty_postfix="_uncertainty"):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.parallax2distance(inplace=True, **kwargs)
-
-
-@patch
-def add_virtual_columns_cartesian_velocities_to_pmvr(self, x="x", y="y", z="z", vx="vx", vy="vy", vz="vz", vr="vr", pm_long="pm_long", pm_lat="pm_lat", distance=None):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.velocity_cartesian2pmvr(inplace=True, **kwargs)
-
-
-@patch
-def add_virtual_columns_proper_motion_eq2gal(self, long_in="ra", lat_in="dec", pm_long="pm_ra", pm_lat="pm_dec", pm_long_out="pm_l", pm_lat_out="pm_b",
-                                            name_prefix="__proper_motion_eq2gal",
-                                            right_ascension_galactic_pole=192.85,
-                                            declination_galactic_pole=27.12,
-                                            propagate_uncertainties=False,
-                                            radians=False, inverse=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.pm_eq2gal(inplace=True, **kwargs)
-
-
-@patch
-def add_virtual_columns_proper_motion_gal2eq(self, long_in="ra", lat_in="dec", pm_long="pm_l", pm_lat="pm_b", pm_long_out="pm_ra", pm_lat_out="pm_dec",
-                                            name_prefix="__proper_motion_gal2eq",
-                                            right_ascension_galactic_pole=192.85,
-                                            declination_galactic_pole=27.12,
-                                            propagate_uncertainties=False,
-                                            radians=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.pm_gal2eq(inplace=True, **kwargs)
-
-
-@patch
-def add_virtual_columns_lbrvr_proper_motion2vcartesian(self, long_in="l", lat_in="b", distance="distance", pm_long="pm_l", pm_lat="pm_b",
-                                                       vr="vr", vx="vx", vy="vy", vz="vz",
-                                                       center_v=(0, 0, 0),
-                                                       propagate_uncertainties=False, radians=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.lbrvrpm2vcartesian(inplace=True, **kwargs)
-
-
-@patch
-def add_virtual_columns_equatorial_to_galactic_cartesian(self, alpha, delta, distance, xname, yname, zname, radians=True, alpha_gp=np.radians(192.85948), delta_gp=np.radians(27.12825), l_omega=np.radians(32.93192)):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.equatorial2galactic_cartesian(inplace=True, **kwargs)
-
-
-@patch
-def add_virtual_columns_celestial(self, long_in, lat_in, long_out, lat_out, name_prefix="__celestial", radians=False, _matrix=None):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.celestial(inplace=True, **kwargs)
-
-@patch
-def add_virtual_columns_proper_motion2vperpendicular(self, distance="distance", pm_long="pm_l", pm_lat="pm_b",
-                                                     vl="vl", vb="vb",
-                                                     propagate_uncertainties=False,
-                                                     radians=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.proper_motion2vperpendicular(inplace=True, **kwargs)
-
-
-@patch
-def add_virtual_columns_cartesian_angular_momenta(self, x='x', y='y', z='z',
-                                                  vx='vx', vy='vy', vz='vz',
-                                                  Lx='Lx', Ly='Ly', Lz='Lz',
-                                                  propagate_uncertainties=False):
-    kwargs = dict(**locals())
-    kwargs.pop('self')
-    return self.astro.cartesian_angular_momenta(inplace=True, **kwargs)
-
-
-@vaex.register_dataframe_accessor('astro')
 class DataFrameAccessorAstro(object):
     """Astronomy specific helper methods
 
@@ -463,6 +358,5 @@ class DataFrameAccessorAstro(object):
             df.ucds[name] = "stat.error;pos.distance"
         return df
 
-def add_plugin():
-    pass  # importing this module already does the job
+
 

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -134,6 +134,7 @@ setup(name=name + '-core',
       zip_safe=False,
       entry_points={
           'console_scripts': ['vaex = vaex.__main__:main'],
-          'gui_scripts': ['vaexgui = vaex.__main__:main']  # sometimes in osx, you need to run with this
+          'gui_scripts': ['vaexgui = vaex.__main__:main'],  # sometimes in osx, you need to run with this
+          'vaex.dataframe.accessor': ['geo = vaex.geo:DataFrameAccessorGeo']
       }
       )

--- a/packages/vaex-core/vaex/geo.py
+++ b/packages/vaex-core/vaex/geo.py
@@ -2,7 +2,7 @@ import vaex
 import numpy as np
 from .utils import _ensure_strings_from_expressions, _ensure_string_from_expression
 
-@vaex.register_dataframe_accessor('geo')
+
 class DataFrameAccessorGeo(object):
     """Geometry/geographic helper methods
 

--- a/packages/vaex-jupyter/setup.py
+++ b/packages/vaex-jupyter/setup.py
@@ -26,6 +26,6 @@ setup(name=name + '-jupyter',
       license=license,
       packages=['vaex.jupyter'],
       zip_safe=False,
-      entry_points={'vaex.namespace': ['widget = vaex.jupyter:add_namespace']},
+      entry_points={'vaex.dataframe.accessor': ['widget = vaex.jupyter:DataFrameAccessorWidget']},
       include_package_data=True,  # include files listed in manifest.in
-      )
+)

--- a/packages/vaex-jupyter/vaex/jupyter/__init__.py
+++ b/packages/vaex-jupyter/vaex/jupyter/__init__.py
@@ -179,7 +179,7 @@ class init(object):
 #       return execute
 #   return wrapped
 
-@vaex.register_dataframe_accessor('widget')
+
 class DataFrameAccessorWidget(object):
     def __init__(self, df):
         self.df = df

--- a/packages/vaex-ml/setup.py
+++ b/packages/vaex-ml/setup.py
@@ -25,4 +25,5 @@ setup(name=name + '-ml',
       packages=['vaex.ml', 'vaex.ml.incubator', 'vaex.ml.datasets'],
       include_package_data=True,
       zip_safe=False,
-    )
+      entry_points={'vaex.dataframe.accessor': ['ml = vaex.ml:DataFrameAccessorML']}
+)

--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -8,228 +8,216 @@ from .pipeline import Pipeline
 from vaex.utils import InnerNamespace
 from vaex.utils import _ensure_strings_from_expressions
 
-def pca(self, n_components=2, features=None, prefix='PCA_', progress=False):
-    '''Requires vaex.ml: Create :class:`vaex.ml.transformations.PCA` and fit it.
 
-    :param n_components: Number of components to retain. If None, all the components will be retained.
-    :param features: List of features to transform.
-    :param prefix: Prefix for the names of the transformed features.
-    :param progress: If True, display a progressbar of the PCA fitting process.
-    '''
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    pca = PCA(n_components=n_components, features=features, progress=progress)
-    pca.fit(self)
-    return pca
+class DataFrameAccessorML(object):
+    def __init__(self, df):
+        self.df = df
 
+    def pca(self, n_components=2, features=None, prefix='PCA_', progress=False):
+        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.PCA` and fit it.
 
-def label_encoder(self, features=None, prefix='label_encoded_', allow_unseen=False):
-    '''Requires vaex.ml: Create :class:`vaex.ml.transformations.LabelEncoder` and fit it.
-
-    :param features: List of features to encode.
-    :param prefix: Prefix for the names of the encoded features.
-    :param allow_unseen: If True, encode unseen value as -1, otherwise an error is raised.
-    '''
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    label_encoder = LabelEncoder(features=features, prefix=prefix, allow_unseen=allow_unseen)
-    label_encoder.fit(self)
-    return label_encoder
+        :param n_components: Number of components to retain. If None, all the components will be retained.
+        :param features: List of features to transform.
+        :param prefix: Prefix for the names of the transformed features.
+        :param progress: If True, display a progressbar of the PCA fitting process.
+        '''
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        pca = PCA(n_components=n_components, features=features, progress=progress)
+        pca.fit(self.df)
+        return pca
 
 
-def one_hot_encoder(self, features=None, one=1, zero=0, prefix=''):
-    '''Requires vaex.ml: Create :class:`vaex.ml.transformations.OneHotEncoder` and fit it.
+    def label_encoder(self, features=None, prefix='label_encoded_', allow_unseen=False):
+        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.LabelEncoder` and fit it.
 
-    :param features: List of features to encode.
-    :param one: What value to use instead of "1".
-    :param zero: What value to use instead of "0".
-    :param prefix: Prefix for the names of the encoded features.
-    :returns one_hot_encoder: vaex.ml.transformations.OneHotEncoder object.
-    '''
-    if features is None:
-        raise ValueError('Please give at least one categorical feature.')
-    features = _ensure_strings_from_expressions(features)
-    one_hot_encoder = OneHotEncoder(features=features, one=one, zero=zero, prefix=prefix)
-    one_hot_encoder.fit(self)
-    return one_hot_encoder
+        :param features: List of features to encode.
+        :param prefix: Prefix for the names of the encoded features.
+        :param allow_unseen: If True, encode unseen value as -1, otherwise an error is raised.
+        '''
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        label_encoder = LabelEncoder(features=features, prefix=prefix, allow_unseen=allow_unseen)
+        label_encoder.fit(self.df)
+        return label_encoder
 
 
-def frequency_encoder(self, features=None, unseen='nan', prefix='frequency_encoded_'):
-    '''
-    Requires vaex.ml: Create :class:`vaex.ml.transformations.FrequencyEncoder` and fit it.
+    def one_hot_encoder(self, features=None, one=1, zero=0, prefix=''):
+        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.OneHotEncoder` and fit it.
 
-    :param features: List of features to encode.
-    :param unseen: Strategy to deal with unseen values. Accepted arguments are "zero" or "nan".
-    :param prefix: Prefix for the names of the encoded features.
-    '''
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    freq_encoder = FrequencyEncoder(features=features, prefix=prefix)
-    freq_encoder.fit(self)
-    return freq_encoder
-
-
-def standard_scaler(self, features=None, with_mean=True, with_std=True, prefix='standard_scaled_'):
-    '''Requires vaex.ml: Create :class:`vaex.ml.transformations.StandardScaler` and fit it.
-
-    :param features: List of features to scale.
-    :param with_mean: If True, remove the mean from each feature.
-    :param with_std: If True, scale each feature to unit variance.
-    :param prefix: Prefix for the names of the scaled features.
-    '''
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    standard_scaler = StandardScaler(features=features, with_mean=with_mean, with_std=with_std, prefix=prefix)
-    standard_scaler.fit(self)
-    return standard_scaler
+        :param features: List of features to encode.
+        :param one: What value to use instead of "1".
+        :param zero: What value to use instead of "0".
+        :param prefix: Prefix for the names of the encoded features.
+        :returns one_hot_encoder: vaex.ml.transformations.OneHotEncoder object.
+        '''
+        if features is None:
+            raise ValueError('Please give at least one categorical feature.')
+        features = _ensure_strings_from_expressions(features)
+        one_hot_encoder = OneHotEncoder(features=features, one=one, zero=zero, prefix=prefix)
+        one_hot_encoder.fit(self.df)
+        return one_hot_encoder
 
 
-def minmax_scaler(self, features=None, feature_range=[0, 1], prefix='minmax_scaled_'):
-    '''Requires vaex.ml: Create :class:`vaex.ml.transformations.MinMaxScaler` and fit it.
+    def frequency_encoder(self, features=None, unseen='nan', prefix='frequency_encoded_'):
+        '''
+        Requires vaex.ml: Create :class:`vaex.ml.transformations.FrequencyEncoder` and fit it.
 
-    :param features: List of features to scale.
-    :param feature_range: The range the features are scaled to.
-    :param prefix: Prefix for the names of the scaled features.
-    '''
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    minmax_scaler = MinMaxScaler(features=features, feature_range=feature_range, prefix=prefix)
-    minmax_scaler.fit(self)
-    return minmax_scaler
-
-
-def xgboost_model(self, target, num_boost_round, features=None, params={}, prediction_name='xgboost_prediction'):
-    '''Requires vaex.ml: create a XGBoost model and train/fit it.
-
-    :param target: Target to train/fit on.
-    :param num_boost_round: Number of rounds.
-    :param features: List of features to train on.
-    :return vaex.ml.xgboost.XGBModel: Fitted XGBoost model.
-    '''
-    from .xgboost import XGBoostModel
-    dataframe = self
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    booster = XGBoostModel(prediction_name=prediction_name,
-                           num_boost_round=num_boost_round,
-                           features=features,
-                           params=params)
-    booster.fit(dataframe, target)
-    return booster
+        :param features: List of features to encode.
+        :param unseen: Strategy to deal with unseen values. Accepted arguments are "zero" or "nan".
+        :param prefix: Prefix for the names of the encoded features.
+        '''
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        freq_encoder = FrequencyEncoder(features=features, prefix=prefix)
+        freq_encoder.fit(self.df)
+        return freq_encoder
 
 
-def lightgbm_model(self, target, num_boost_round, features=None, copy=False, params={},
-                   prediction_name='lightgbm_prediction'):
-    '''Requires vaex.ml: create a lightgbm model and train/fit it.
+    def standard_scaler(self, features=None, with_mean=True, with_std=True, prefix='standard_scaled_'):
+        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.StandardScaler` and fit it.
 
-    :param target: The target variable to predict.
-    :param num_boost_round: Number of boosting iterations.
-    :param features: List of features to train on.
-    :param bool copy: Copy data or use the modified xgboost library for efficient transfer.
-    :return vaex.ml.lightgbm.LightGBMModel: Fitted LightGBM model.
-    '''
-    from .lightgbm import LightGBMModel
-    dataframe = self
-    features = features or self.get_column_names(virtual=True)
-    features = _ensure_strings_from_expressions(features)
+        :param features: List of features to scale.
+        :param with_mean: If True, remove the mean from each feature.
+        :param with_std: If True, scale each feature to unit variance.
+        :param prefix: Prefix for the names of the scaled features.
+        '''
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        standard_scaler = StandardScaler(features=features, with_mean=with_mean, with_std=with_std, prefix=prefix)
+        standard_scaler.fit(self.df)
+        return standard_scaler
 
-    booster = LightGBMModel(prediction_name=prediction_name,
+
+    def minmax_scaler(self, features=None, feature_range=[0, 1], prefix='minmax_scaled_'):
+        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.MinMaxScaler` and fit it.
+
+        :param features: List of features to scale.
+        :param feature_range: The range the features are scaled to.
+        :param prefix: Prefix for the names of the scaled features.
+        '''
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        minmax_scaler = MinMaxScaler(features=features, feature_range=feature_range, prefix=prefix)
+        minmax_scaler.fit(self.df)
+        return minmax_scaler
+
+
+    def xgboost_model(self, target, num_boost_round, features=None, params={}, prediction_name='xgboost_prediction'):
+        '''Requires vaex.ml: create a XGBoost model and train/fit it.
+
+        :param target: Target to train/fit on.
+        :param num_boost_round: Number of rounds.
+        :param features: List of features to train on.
+        :return vaex.ml.xgboost.XGBModel: Fitted XGBoost model.
+        '''
+        from .xgboost import XGBoostModel
+        dataframe = self.df
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        booster = XGBoostModel(prediction_name=prediction_name,
                             num_boost_round=num_boost_round,
                             features=features,
                             params=params)
-    booster.fit(dataframe, target, copy=copy)
-    return booster
+        booster.fit(dataframe, target)
+        return booster
 
 
-def catboost_model(self, target, num_boost_round, features=None, params=None, prediction_name='catboost_prediction'):
-    '''Requires vaex.ml: create a CatBoostModel model and train/fit it.
+    def lightgbm_model(self, target, num_boost_round, features=None, copy=False, params={},
+                    prediction_name='lightgbm_prediction'):
+        '''Requires vaex.ml: create a lightgbm model and train/fit it.
 
-    :param target: Target to train/fit on
-    :param num_boost_round: Number of rounds
-    :param features: List of features to train on
-    :return vaex.ml.catboost.CatBoostModel: Fitted CatBoostModel model
-    '''
-    from .catboost import CatBoostModel
-    dataframe = self
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    booster = CatBoostModel(prediction_name=prediction_name,
-                            num_boost_round=num_boost_round,
-                            features=features,
-                            params=params)
-    booster.fit(dataframe, target)
-    return booster
+        :param target: The target variable to predict.
+        :param num_boost_round: Number of boosting iterations.
+        :param features: List of features to train on.
+        :param bool copy: Copy data or use the modified xgboost library for efficient transfer.
+        :return vaex.ml.lightgbm.LightGBMModel: Fitted LightGBM model.
+        '''
+        from .lightgbm import LightGBMModel
+        dataframe = self.df
+        features = features or self.df.get_column_names(virtual=True)
+        features = _ensure_strings_from_expressions(features)
 
-
-def pygbm_model(self, label, max_iter, features=None, param={}, classifier=False, prediction_name='pygbm_prediction', **kwargs):
-    '''Requires vaex.ml: create a pygbm model and train/fit it.
-
-    :param label: Label to train/fit on
-    :param max_iter: Max number of iterations/trees
-    :param features: List of features to train on
-    :param bool classifier: If true, return a the classifier (will use argmax on the probabilities)
-    :return vaex.ml.pygbm.PyGBMModel or vaex.ml.pygbm.PyGBMClassifier: Fitted PyGBM model
-    '''
-    from .incubator.pygbm import PyGBMModel, PyGBMClassifier
-    dataframe = self
-    features = features or self.get_column_names()
-    features = _ensure_strings_from_expressions(features)
-    cls = PyGBMClassifier if classifier else PyGBMModel
-    b = cls(prediction_name=prediction_name, max_iter=max_iter, features=features, param=param, **kwargs)
-    b.fit(dataframe, label)
-    return b
+        booster = LightGBMModel(prediction_name=prediction_name,
+                                num_boost_round=num_boost_round,
+                                features=features,
+                                params=params)
+        booster.fit(dataframe, target, copy=copy)
+        return booster
 
 
-def state_transfer(self):
-    from .transformations import StateTransfer
-    state = self.state_get()
-    state.pop('active_range')  # we are not interested in this..
-    return StateTransfer(state=state)
+    def catboost_model(self, target, num_boost_round, features=None, params=None, prediction_name='catboost_prediction'):
+        '''Requires vaex.ml: create a CatBoostModel model and train/fit it.
+
+        :param target: Target to train/fit on
+        :param num_boost_round: Number of rounds
+        :param features: List of features to train on
+        :return vaex.ml.catboost.CatBoostModel: Fitted CatBoostModel model
+        '''
+        from .catboost import CatBoostModel
+        dataframe = self.df
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        booster = CatBoostModel(prediction_name=prediction_name,
+                                num_boost_round=num_boost_round,
+                                features=features,
+                                params=params)
+        booster.fit(dataframe, target)
+        return booster
 
 
-def train_test_split(self, test_size=0.2, strings=True, virtual=True, verbose=True):
-    '''Will split the DataFrame in train and test part, assuming it is shuffled.
+    def pygbm_model(self, label, max_iter, features=None, param={}, classifier=False, prediction_name='pygbm_prediction', **kwargs):
+        '''Requires vaex.ml: create a pygbm model and train/fit it.
 
-    :param test_size: The fractional size of the test set.
-    :param strings: If True, the output DataFrames will also contain string columns, if any.
-    :param virtual: If True, the output DataFrames will also contain virtual contain, if any.
-    :param verbose: If True, print warnings to screen.
-    '''
-    if verbose:
-        warnings.warn('Make sure the DataFrame is shuffled')
-    initial = None
-    try:
-        assert self.filtered is False, 'Filtered DataFrames are not yet supported.'
-        # full_length = len(self)
-        self = self.trim()
-        initial = self.get_active_range()
-        self.set_active_fraction(test_size)
-        test = self.trim()
-        __, end = self.get_active_range()
-        self.set_active_range(end, self.length_original())
-        train = self.trim()
-    finally:
-        if initial is not None:
-            self.set_active_range(*initial)
-    return train, test
+        :param label: Label to train/fit on
+        :param max_iter: Max number of iterations/trees
+        :param features: List of features to train on
+        :param bool classifier: If true, return a the classifier (will use argmax on the probabilities)
+        :return vaex.ml.pygbm.PyGBMModel or vaex.ml.pygbm.PyGBMClassifier: Fitted PyGBM model
+        '''
+        from .incubator.pygbm import PyGBMModel, PyGBMClassifier
+        dataframe = self.df
+        features = features or self.df.get_column_names()
+        features = _ensure_strings_from_expressions(features)
+        cls = PyGBMClassifier if classifier else PyGBMModel
+        b = cls(prediction_name=prediction_name, max_iter=max_iter, features=features, param=param, **kwargs)
+        b.fit(dataframe, label)
+        return b
 
 
-def add_namespace():
-    vaex.dataframe.DataFrame.ml = InnerNamespace({}, vaex.dataframe.DataFrame, prefix='ml_')
-    vaex.dataframe.DataFrame.ml._add(train_test_split=train_test_split)
+    def state_transfer(self):
+        from .transformations import StateTransfer
+        state = self.df.state_get()
+        state.pop('active_range')  # we are not interested in this..
+        return StateTransfer(state=state)
 
-    vaex.dataframe.DataFrame.ml._add(xgboost_model=xgboost_model,
-                                     lightgbm_model=lightgbm_model,
-                                     catboost_model=catboost_model,
-                                     pygbm_model=pygbm_model,
-                                     state_transfer=state_transfer,
-                                     one_hot_encoder=one_hot_encoder,
-                                     label_encoder=label_encoder,
-                                     frequency_encoder=frequency_encoder,
-                                     pca=pca,
-                                     standard_scaler=standard_scaler,
-                                     minmax_scaler=minmax_scaler)
-add_namespace()
+
+    def train_test_split(self, test_size=0.2, strings=True, virtual=True, verbose=True):
+        '''Will split the DataFrame in train and test part, assuming it is shuffled.
+
+        :param test_size: The fractional size of the test set.
+        :param strings: If True, the output DataFrames will also contain string columns, if any.
+        :param virtual: If True, the output DataFrames will also contain virtual contain, if any.
+        :param verbose: If True, print warnings to screen.
+        '''
+        if verbose:
+            warnings.warn('Make sure the DataFrame is shuffled')
+        initial = None
+        try:
+            assert self.df.filtered is False, 'Filtered DataFrames are not yet supported.'
+            # full_length = len(self)
+            df = self.df.trim()
+            initial = self.df.get_active_range()
+            df.set_active_fraction(test_size)
+            test = df.trim()
+            __, end = df.get_active_range()
+            df.set_active_range(end, df.length_original())
+            train = df.trim()
+        finally:
+            if initial is not None:
+                df.set_active_range(*initial)
+        return train, test
+
 
 from .transformations import PCA
 from .transformations import StandardScaler, MinMaxScaler, MaxAbsScaler, RobustScaler

--- a/packages/vaex-viz/setup.py
+++ b/packages/vaex-viz/setup.py
@@ -25,6 +25,6 @@ setup(name=name + '-viz',
       license=license,
       packages=['vaex.viz'],
       zip_safe=False,
-      entry_points={'vaex.namespace': ['ml = vaex.viz:add_namespace'],
+      entry_points={'vaex.dataframe.accessor': ['viz = vaex.viz:DataFrameAccessorViz'],
                     'vaex.plugin': ['plot = vaex.viz.mpl:add_plugin']}
       )

--- a/packages/vaex-viz/vaex/viz/__init__.py
+++ b/packages/vaex-viz/vaex/viz/__init__.py
@@ -1,7 +1,6 @@
-import vaex.dataset
-from vaex.utils import InnerNamespace
+class DataFrameAccessorViz(object):
+    def __init__(self, df):
+        self.df = df
 
-
-def add_namespace():
-    vaex.dataset.Dataset.viz = InnerNamespace({})
-    vaex.dataset.Dataset.viz._add(plot2d=vaex.dataset.Dataset.plot)
+    def plot2d(self, *args, **kwargs):
+        self.df.plot(*args, **kwargs)

--- a/tests/internal/accessor_test.py
+++ b/tests/internal/accessor_test.py
@@ -1,0 +1,47 @@
+import vaex
+import pytest
+
+
+class Foo(object):
+    def __init__(self, df):
+        self.df = df
+
+
+class Spam(object):
+    def __init__(self, df):
+        self.df = df
+
+
+class Egg(object):
+    def __init__(self, spam):
+        self.spam = spam
+        self.df = spam.df
+
+
+def test_accessor_basic():
+    vaex._add_lazy_accessor('foo', lambda: Foo)
+    df = vaex.example()
+    assert isinstance(df.foo, Foo)
+    assert df.foo is df.foo
+    assert df.foo.df is df
+
+def test_accessor_nested():
+    df = vaex.example()
+    vaex._add_lazy_accessor('spam.egg', lambda: Egg)
+    with pytest.raises(expected_exception=AttributeError):
+        a = df.spam
+    vaex._add_lazy_accessor('spam.egg.foo', lambda: Foo)
+    with pytest.raises(expected_exception=AttributeError):
+        a = df.spam
+    vaex._add_lazy_accessor('spam', lambda: Spam)
+    assert df.spam is df.spam
+    assert df.spam.df is df
+    assert isinstance(df.spam, Spam)
+
+    assert df.spam.egg is df.spam.egg
+    assert df.spam.egg.spam is df.spam
+    assert isinstance(df.spam.egg, Egg)
+
+    assert df.spam.egg.foo is df.spam.egg.foo
+    assert df.spam.egg.foo.df is df.spam.egg  # abuse of foo
+    assert isinstance(df.spam.egg.foo, Foo)

--- a/tests/ml/catboost_test.py
+++ b/tests/ml/catboost_test.py
@@ -123,7 +123,7 @@ def test_catboost_pipeline():
     pca = train.ml.pca(n_components=3, features=features)
     train = pca.transform(train)
     # Do state transfer
-    st = vaex.ml.state_transfer(train)
+    st = train.ml.state_transfer()
     # now the catboost model thingy
     features = ['r', 'PCA_0', 'PCA_1', 'PCA_2']
     # define the boosting model

--- a/tests/ml/lightgbm_test.py
+++ b/tests/ml/lightgbm_test.py
@@ -77,12 +77,12 @@ def test_lightgbm_serialize(tmpdir):
     features = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width']
     target = 'class_'
 
-    gbm = ds.ml_lightgbm_model(target, 20, features=features, params=params)
+    gbm = ds.ml.lightgbm_model(target, 20, features=features, params=params)
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
     pl.load(str(tmpdir.join('test.json')))
 
-    gbm = ds.ml_lightgbm_model(target, 20, features=features, params=params)
+    gbm = ds.ml.lightgbm_model(target, 20, features=features, params=params)
     gbm.state_set(gbm.state_get())
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
@@ -147,7 +147,7 @@ def test_lightgbm_pipeline():
     pca = train.ml.pca(n_components=3, features=features)
     train = pca.transform(train)
     # Do state transfer
-    st = vaex.ml.state_transfer(train)
+    st = train.ml.state_transfer()
     # now the lightgbm model thingy
     features = ['r', 'PCA_0', 'PCA_1', 'PCA_2']
     # The booster model from vaex.ml

--- a/tests/ml/sklearn_test.py
+++ b/tests/ml/sklearn_test.py
@@ -119,7 +119,7 @@ def test_sklearn_estimator_pipeline():
     pca = train.ml.pca(n_components=2, features=features)
     train = pca.transform(train)
     # Do state transfer
-    st = vaex.ml.state_transfer(train)
+    st = train.ml.state_transfer()
     # now apply the model
     features = ['sepal_virtual', 'petal_scaled']
     model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')

--- a/tests/ml/xgboost_test.py
+++ b/tests/ml/xgboost_test.py
@@ -124,7 +124,7 @@ def test_xgboost_pipeline():
     pca = train.ml.pca(n_components=3, features=features)
     train = pca.transform(train)
     # Do state transfer
-    st = vaex.ml.state_transfer(train)
+    st = train.ml.state_transfer()
     # now the xgboost model thingy
     features = ['r', 'PCA_0', 'PCA_1', 'PCA_2']
     # define the boosting model


### PR DESCRIPTION
This change will make it easier for us, and 3rd parties to add new dataframe accessors to vaex, without increasing import time.

Adding an entry point to setup.py `{'vaex.dataframe.accessor': ['geo = vaex.geo:DataFrameAccessorGeo']}` will only import vaex.geo when df.geo is accessed, this will speed up importing time of vaex, since before we eagerly imported all `vaex.namespace` plugins (which is now deprecated). Note that the 'normal' way of adding an accessor `vaex.register_dataframe_accessor` is still supported.

I think by now we should think of creating a section in the documentation for extending vaex.


Also, 'nested' accessors are now supported, e.g.:
```
        entry_points={
            'vaex.dataframe.accessor': ['geo.cone = ectopylasm.vaex:ConeAccessor']
        }
```

We also do not have to import vaex.ml, before accessing df.ml, since this will be done automatically when we access it.

