### PR TITLE
feat(core, hdf5): support python keywords and invalid variable names

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2762,7 +2762,7 @@ class DataFrame(object):
                         raise ValueError("Array is of length %s, while the length of the DataFrame is %s due to the filtering, the (unfiltered) length is %s." % (len(ar), len(self), self.length_unfiltered()))
                 raise ValueError("array is of length %s, while the length of the DataFrame is %s" % (len(ar), self.length_original()))
             # assert self.length_unfiltered() == len(data), "columns should be of equal length, length should be %d, while it is %d" % ( self.length_unfiltered(), len(data))
-            valid_name = vaex.utils.find_valid_name(name, used=self.get_column_names(hidden=True))
+            valid_name = vaex.utils.find_valid_name(name)
             if name != valid_name:
                 self._column_aliases[name] = valid_name
             self.columns[valid_name] = f_or_array

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -13,6 +13,7 @@ import sys
 import time
 import warnings
 import numbers
+import keyword
 
 import numpy as np
 import progressbar
@@ -560,6 +561,8 @@ def unlistify(waslist, *args):
 def find_valid_name(name, used=[]):
     first, rest = name[0], name[1:]
     name = re.sub("[^a-zA-Z_]", "_", first) + re.sub("[^a-zA-Z_0-9]", "_", rest)
+    if keyword.iskeyword(name):
+        name += '_'
     if name in used:
         nr = 1
         while name + ("_%d" % nr) in used:

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -107,6 +107,11 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
                                         h5dataset = column
                 if h5dataset is None:
                     raise ValueError('column {} not found'.format(column_name))
+
+                aliases = [key for key, value in self._column_aliases.items() if value == column_name]
+                aliases.sort()
+                if aliases:
+                    h5dataset.attrs['alias'] = aliases[0]
                 for name, values in [("ucd", self.ucds), ("unit", self.units), ("description", self.descriptions)]:
                     if column_name in values:
                         value = ensure_string(values[column_name], cast=True)
@@ -293,6 +298,8 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
                 column = h5columns[column_name]
                 if "ucd" in column.attrs:
                     self.ucds[column_name] = ensure_string(column.attrs["ucd"])
+                if "alias" in column.attrs:
+                    self._column_aliases[ensure_string(column.attrs["alias"])] = column_name
                 if "description" in column.attrs:
                     self.descriptions[column_name] = ensure_string(column.attrs["description"])
                 if "unit" in column.attrs:

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -1,17 +1,37 @@
 import vaex
 from common import *
 
-def test_column_names(ds_local):
-	ds = ds_local
-	columns_names = ds.get_column_names(virtual=True)
-	ds['__x'] = ds.x
-	assert columns_names == ds.get_column_names(virtual=True)
-	assert '__x' in ds.get_column_names(virtual=True, hidden=True)
-	assert len(columns_names) == len(ds.get_column_names(virtual=True, hidden=True))-1
 
-	ds = vaex.example()
-	ds['__x'] = ds['x'] + 1
-	assert 'FeH' in ds.get_column_names(regex='e*')
-	assert 'FeH' not in ds.get_column_names(regex='e')
-	assert '__x' not in ds.get_column_names(regex='__x')
-	assert '__x' in ds.get_column_names(regex='__x', hidden=True)
+x = np.arange(10)
+
+
+def test_column_names(ds_local):
+    ds = ds_local
+    columns_names = ds.get_column_names(virtual=True)
+    ds['__x'] = ds.x
+    assert columns_names == ds.get_column_names(virtual=True)
+    assert '__x' in ds.get_column_names(virtual=True, hidden=True)
+    assert len(columns_names) == len(ds.get_column_names(virtual=True, hidden=True))-1
+
+    ds = vaex.example()
+    ds['__x'] = ds['x'] + 1
+    assert 'FeH' in ds.get_column_names(regex='e*')
+    assert 'FeH' not in ds.get_column_names(regex='e')
+    assert '__x' not in ds.get_column_names(regex='__x')
+    assert '__x' in ds.get_column_names(regex='__x', hidden=True)
+
+
+def test_add_invalid_name(tmpdir):
+    # support invalid names and keywords
+    df = vaex.from_dict({'X!1': x, 'class': x*2})
+    assert df['X!1'].tolist() == x.tolist()
+    assert (df['X!1']*2).tolist() == (x*2).tolist()
+    assert (df['class']).tolist() == (x*2).tolist()
+    assert 'X!1' in df._column_aliases
+    assert (df.copy()['X!1']*2).tolist() == (x*2).tolist()
+
+    path = str(tmpdir.join('test.hdf5'))
+    df.export(path)
+    df = vaex.open(path)
+    assert df['X!1'].tolist() == x.tolist()
+    assert (df.copy()['X!1']*2).tolist() == (x*2).tolist()


### PR DESCRIPTION
Implemented using a df._column_aliases dict that will translate those names
when possible.
Note that it means that you cannot do:
```
df['class * 2']  # this expression cannot be parsed
```
but instead, you can do
```
df['class'] * 2  # this can use the aliasing
```
If for some reason you need to write an expression using strings, use:
```
expression_string = str(df['class']) + ' * 2'
```
Closes #253,  should also help with #369