### PR TITLE
POC: Feat plotly express support

### DIFF
--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -188,6 +188,9 @@ try:
 except:
     str_type = str
 
+class str_type(object):
+    kind = 'O'
+
 use_c_api = True
 
 class ColumnString(Column):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5170,7 +5170,7 @@ class DataFrameLocal(DataFrame):
         self._has_selection = mask is not None
         self.signal_selection_changed.emit(self)
 
-    def groupby(self, by=None, agg=None):
+    def groupby(self, by=None, agg=None, sort=None):
         """Return a :class:`GroupBy` or :class:`DataFrame` object when agg is not None
 
         Examples:

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4249,7 +4249,7 @@ class DataFrame(object):
         if isinstance(name, six.string_types):
             if isinstance(value, Expression):
                 value = value.expression
-            if isinstance(value, np.ndarray):
+            if isinstance(value, (np.ndarray, Column)):
                 self.add_column(name, value)
             else:
                 self.add_virtual_column(name, value)

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -90,13 +90,13 @@ class Meta(type):
                     self = a
                     # print(op, a, b)
                     try:
-                        stringy = isinstance(b, str_type) or (isinstance(b, Expression) and b.dtype == str_type)
+                        stringy = isinstance(b, str) or (isinstance(b, Expression) and b.dtype == str_type)
                     except:
                         # this can happen when expression is a literal, like '1' (used in propagate_unc)
                         # which causes the dtype to fail
                         stringy = False
                     if stringy:
-                        if isinstance(b, str_type):
+                        if isinstance(b, (str)):
                             b = repr(b)
                         if op['code'] == '==':
                             expression = 'str_equals({0}, {1})'.format(a.expression, b)

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -113,7 +113,15 @@ class GroupByBase(object):
 
         self.by = []
         for by_value in by:
-            if not isinstance(by_value, BinnerBase):
+            if callable(by_value):
+                if by_value.__name__ == 'one_group':
+                    df['__row__'] = vaex.vrange(0, len(df))
+                    by_value = df.__row__ == df.__row__
+                else:
+                    df['__row__'] = vaex.vrange(0, len(df))
+                    by_value = df.__row__.apply(by_value)
+                by_value = Grouper(df[str(by_value)])
+            elif not isinstance(by_value, BinnerBase):
                 by_value = Grouper(df[str(by_value)])
             self.by.append(by_value)
         # self._waslist, [self.by, ] = vaex.utils.listify(by)
@@ -127,6 +135,33 @@ class GroupByBase(object):
         self.grid = vaex.superagg.Grid(self.binners)
         self.shape = [by.N for by in self.by]
         self.dims = self.groupby_expression[:]
+
+    @property
+    def groups(self):
+        for group, df in self:
+            yield group
+
+    def get_group(self, group):
+        values = group
+        filter_expressions = [self.df[expression] == value for expression, value in zip(self.groupby_expression, values)]
+        filter_expression = filter_expressions[0]
+        for expression in filter_expressions[1:]:
+            filter_expression = filter_expression & expression
+        return self.df[filter_expression]
+
+    def __iter__(self):
+        count_agg = vaex.agg.count()
+        counts = self.df._agg(count_agg, self.grid)
+        counts = vaex.utils.extract_central_part(counts)
+        mask = counts > 0
+        # import pdb; pdb.set_trace()
+        values2d = np.array([coord[mask] for coord in np.meshgrid(*self.coords1d, indexing='ij')], dtype='O')
+        for i in range(values2d.shape[1]):
+            values = values2d[:,i]
+            # print(values)
+            dff = self.get_group(values)
+            yield tuple(values.tolist()), dff
+
 
     def _agg(self, actions):
         df = self.df

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -216,3 +216,18 @@ def test_groupby_same_result():
 
         assert vc.values.tolist() == group_sort['count'].values.tolist(), 'counts are not correct.'
         assert vc.index.tolist() == group_sort['h'].values.tolist(), 'the indices of the counts are not correct.'
+
+def test_groupby_iter():
+    # ds = ds_local.extract()
+    g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 0, 1], dtype='int32')
+    s = np.array(list(map(str, [0, 0, 0, 0, 1, 1, 1, 1, 2, 2])))
+    df = vaex.from_arrays(g=g, s=s)
+    groupby = df.groupby([lambda x: '', lambda x: x//2])  # similar to plotly_express' one_group
+    dfg = groupby.agg({'g': 'mean'})#.sort('s')
+    names = [k[0] for k in list(groupby)]
+    assert names == []
+    assert dfg.s.tolist() == ['0', '1', '2']
+    assert dfg.g.tolist() == [0, 1, 0.5]
+
+    dfg2 = df.groupby('s', {'g': 'mean'}).sort('s')
+    assert dfg._equals(dfg2)


### PR DESCRIPTION
Proof of concept, requires this patch to plotly:
```
diff --git a/packages/python/plotly/_plotly_utils/basevalidators.py b/packages/python/plotly/_plotly_utils/basevalidators.py
index 0ade83a95..0065125ec 100644
--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -75,6 +75,7 @@ def copy_to_readonly_numpy_array(v, kind=None, force_numeric=False):
     """
     np = get_module("numpy")
     pd = get_module("pandas")
+    vaex = get_module("vaex")
     assert np is not None

     # ### Process kind ###
@@ -89,6 +90,9 @@ def copy_to_readonly_numpy_array(v, kind=None, force_numeric=False):
     numeric_kinds = {"u", "i", "f"}
     kind_default_dtypes = {"u": "uint32", "i": "int32", "f": "float64", "O": "object"}

+    # Handle vaex expressions
+    if vaex and isinstance(v, vaex.expression.Expression):
+        v = v.values
     # Handle pandas Series and Index objects
     if pd and isinstance(v, (pd.Series, pd.Index)):
         if v.dtype.kind in numeric_kinds:
@@ -168,10 +172,12 @@ def is_homogeneous_array(v):
     """
     np = get_module("numpy")
     pd = get_module("pandas")
+    vaex = get_module("vaex")
     if (
         np
         and isinstance(v, np.ndarray)
         or (pd and isinstance(v, (pd.Series, pd.Index)))
+        or (vaex and isinstance(v, (vaex.expression.Expression)))
     ):
         return True
     if is_numpy_convertable(v):
```

But it works :)
![image](https://user-images.githubusercontent.com/1765949/63542114-e188ae80-c51f-11e9-9fa0-97892e03ea1a.png)
