### PR TITLE
Unit-test: add pd.NaT towards the total count of NA in describe()

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3320,19 +3320,21 @@ class DataFrame(object):
         for feature in self.get_column_names(strings=strings, virtual=virtual)[:]:
             dtype = str(self.dtype(feature)) if self.dtype(feature) != str else 'str'
             if self.dtype(feature) == str_type or self.dtype(feature).kind in ['S', 'U', 'O']:
-                count = self.count(feature, selection=selection, delay=True)
+                # count_na = self[feature].countna(feature, selection=selection, delay=True)
+                count_na = self[feature].isna().astype('int').sum(delay=True)
                 self.execute()
-                count = count.get()
-                columns[feature] = ((dtype, count, N-count, '--', '--', '--', '--'))
+                count_na = count_na.get()
+                columns[feature] = ((dtype, N-count_na, count_na, '--', '--', '--', '--'))
             else:
-                count = self.count(feature, selection=selection, delay=True)
+                # count = self.count(feature, selection=selection, delay=True)
+                count_na = self[feature].isna().astype('int').sum(delay=True)
                 mean = self.mean(feature, selection=selection, delay=True)
                 std = self.std(feature, selection=selection, delay=True)
                 minmax = self.minmax(feature, selection=selection, delay=True)
                 self.execute()
-                count, mean, std, minmax = count.get(), mean.get(), std.get(), minmax.get()
-                count = int(count)
-                columns[feature] = ((dtype, count, N-count, mean, std, minmax[0], minmax[1]))
+                count_na, mean, std, minmax = count_na.get(), mean.get(), std.get(), minmax.get()
+                count_na = int(count_na)
+                columns[feature] = ((dtype, N-count_na, count_na, mean, std, minmax[0], minmax[1]))
         return pd.DataFrame(data=columns, index=['dtype', 'count', 'NA', 'mean', 'std', 'min', 'max'])
 
     def cat(self, i1, i2, format='html'):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3319,22 +3319,34 @@ class DataFrame(object):
         columns = {}
         for feature in self.get_column_names(strings=strings, virtual=virtual)[:]:
             dtype = str(self.dtype(feature)) if self.dtype(feature) != str else 'str'
-            if self.dtype(feature) == str_type or self.dtype(feature).kind in ['S', 'U', 'O']:
-                # count_na = self[feature].countna(feature, selection=selection, delay=True)
+            if self.dtype(feature) == str_type or self.dtype(feature).kind in ['S', 'U']:
+                count = self.count(feature, selection=selection, delay=True)
+                self.execute()
+                count = count.get()
+                columns[feature] = ((dtype, count, N-count, '--', '--', '--', '--'))
+            elif self.dtype(feature).kind == 'O':
+                # this will also properly count NaN-like objects like NaT
                 count_na = self[feature].isna().astype('int').sum(delay=True)
                 self.execute()
                 count_na = count_na.get()
                 columns[feature] = ((dtype, N-count_na, count_na, '--', '--', '--', '--'))
             else:
-                # count = self.count(feature, selection=selection, delay=True)
-                count_na = self[feature].isna().astype('int').sum(delay=True)
+                is_datetime = self.is_datetime(feature)
                 mean = self.mean(feature, selection=selection, delay=True)
                 std = self.std(feature, selection=selection, delay=True)
                 minmax = self.minmax(feature, selection=selection, delay=True)
+                if is_datetime:  # this path tests using isna, which test for nat
+                    count_na = self[feature].isna().astype('int').sum(delay=True)
+                else:
+                    count = self.count(feature, selection=selection, delay=True)
                 self.execute()
-                count_na, mean, std, minmax = count_na.get(), mean.get(), std.get(), minmax.get()
-                count_na = int(count_na)
-                columns[feature] = ((dtype, N-count_na, count_na, mean, std, minmax[0], minmax[1]))
+                if is_datetime:
+                    count_na, mean, std, minmax = count_na.get(), mean.get(), std.get(), minmax.get()
+                    count = N - int(count_na)
+                else:
+                    count, mean, std, minmax = count.get(), mean.get(), std.get(), minmax.get()
+                    count = int(count)
+                columns[feature] = ((dtype, count, N-count, mean, std, minmax[0], minmax[1]))
         return pd.DataFrame(data=columns, index=['dtype', 'count', 'NA', 'mean', 'std', 'min', 'max'])
 
     def cat(self, i1, i2, format='html'):

--- a/tests/describe_test.py
+++ b/tests/describe_test.py
@@ -1,4 +1,5 @@
 from common import *
+import pandas as pd
 
 
 def test_describe(ds_local):
@@ -10,9 +11,16 @@ def test_describe(ds_local):
 def test_describe_NA():
     x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
     y = np.array([5, -2, 1, 4, 0, 6, np.nan, np.nan, 10, 42, 0, np.nan, -13.5])
-    df = vaex.from_arrays(x=x, y=y)
+    t = np.array([np.datetime64('2001'), np.datetime64('2005'), np.datetime64('2001'),
+                  np.datetime64('2002'), np.datetime64('2006'), np.datetime64('2009'),
+                  np.datetime64('2003'), np.datetime64('2007'), np.datetime64('2011'),
+                  np.datetime64('2004'), np.datetime64('2008'), np.nan,
+                  pd.NaT])
+
+    df = vaex.from_arrays(x=x, y=y, t=t)
 
     desc_df = df.describe()
 
     assert desc_df.x.loc['NA'] == 3
     assert desc_df.y.loc['NA'] == 3
+    assert desc_df.t.loc['NA'] == 2

--- a/tests/describe_test.py
+++ b/tests/describe_test.py
@@ -13,17 +13,20 @@ def test_describe_NA():
     x = np.array([5, '', -1, 4.5, None, np.nan, np.nan])
     y = np.array([0, 6, np.nan, np.nan, -13.13, -0.5, np.nan])
     df = vaex.from_arrays(x=x, y=y)
-
     desc_df = df.describe()
-
     assert desc_df.x.loc['NA'] == 3
     assert desc_df.y.loc['NA'] == 3
 
 
-def test_describe_nat():
+def test_describe_nat_in_dtype_object():
     t = np.array([np.datetime64('2001'), pd.NaT, np.datetime64('2005'), np.nan])
     df = vaex.from_arrays(t=t)
-
     desc_df = df.describe()
-
     assert desc_df.t.loc['NA'] == 2
+
+
+def test_describe_nat():
+    t = np.array([np.datetime64('2001'), np.datetime64('NaT'), np.datetime64('2005')], dtype=np.datetime64)
+    df = vaex.from_arrays(t=t)
+    desc_df = df.describe()
+    assert desc_df.t.loc['NA'] == 1

--- a/tests/describe_test.py
+++ b/tests/describe_test.py
@@ -1,4 +1,5 @@
 from common import *
+
 import pandas as pd
 
 
@@ -9,18 +10,20 @@ def test_describe(ds_local):
 
 
 def test_describe_NA():
-    x = np.array([5, '', 1, 4, None, 6, np.nan, np.nan, 10, '', 0, 0, -13.5])
-    y = np.array([5, -2, 1, 4, 0, 6, np.nan, np.nan, 10, 42, 0, np.nan, -13.5])
-    t = np.array([np.datetime64('2001'), np.datetime64('2005'), np.datetime64('2001'),
-                  np.datetime64('2002'), np.datetime64('2006'), np.datetime64('2009'),
-                  np.datetime64('2003'), np.datetime64('2007'), np.datetime64('2011'),
-                  np.datetime64('2004'), np.datetime64('2008'), np.nan,
-                  pd.NaT])
-
-    df = vaex.from_arrays(x=x, y=y, t=t)
+    x = np.array([5, '', -1, 4.5, None, np.nan, np.nan])
+    y = np.array([0, 6, np.nan, np.nan, -13.13, -0.5, np.nan])
+    df = vaex.from_arrays(x=x, y=y)
 
     desc_df = df.describe()
 
     assert desc_df.x.loc['NA'] == 3
     assert desc_df.y.loc['NA'] == 3
+
+
+def test_describe_nat():
+    t = np.array([np.datetime64('2001'), pd.NaT, np.datetime64('2005'), np.nan])
+    df = vaex.from_arrays(t=t)
+
+    desc_df = df.describe()
+
     assert desc_df.t.loc['NA'] == 2


### PR DESCRIPTION
At the moment the `describe` method does not detect `pandas.NaT` (not a time) values as N/A. This unit-test exposes this.