### PR TITLE
WIP feat(core): implement nep13 and nep18 to allow sklearn integration

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -38,6 +38,7 @@ import six
 
 import vaex.dataframe
 import vaex.dataset
+from vaex.dataframe import DataFrame, DataFrameLocal
 from vaex.functions import register_function
 from . import stat
 # import vaex.file

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -71,7 +71,7 @@ class ColumnIndexed(Column):
         self.df = df
         self.indices = indices
         self.name = name
-        self.dtype = self.df.dtype(name)
+        self.dtype = self.df.dtype_evaluate(name)
         self.shape = (len(indices),)
         max_index = self.indices.max()
         if not np.ma.is_masked(max_index):
@@ -126,7 +126,7 @@ class ColumnConcatenatedLazy(Column):
     def __init__(self, dfs, column_name):
         self.dfs = dfs
         self.column_name = column_name
-        dtypes = [df.dtype(column_name) for df in dfs]
+        dtypes = [df.dtype_evaluate(column_name) for df in dfs]
         self.is_masked = any([df.is_masked(column_name) for df in dfs])
         if self.is_masked:
             self.fill_value = dfs[0].columns[self.column_name].fill_value

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -43,6 +43,7 @@ except ImportError:
     from urlparse import urlparse
 
 _DEBUG = os.environ.get('VAEX_DEBUG', False)  # extra sanify checks that might hit performance
+_allow_array_casting = True
 
 DEFAULT_REPR_FORMAT = 'plain'
 FILTER_SELECTION_NAME = '__filter__'
@@ -211,6 +212,8 @@ class DataFrame(object):
         self._renamed_columns = []
         self._column_aliases = {}  # maps from invalid variable names to valid ones
 
+        self._transposed = False
+
     def __getattr__(self, name):
         # will support the hidden methods
         if name in self.__hidden__:
@@ -255,7 +258,7 @@ class DataFrame(object):
         return self.is_category(column)
 
     def is_datetime(self, expression):
-        dtype = self.dtype(expression)
+        dtype = self.dtype_evaluate(expression)
         return dtype != str_type and dtype.kind == 'M'
 
     def is_category(self, column):
@@ -321,13 +324,13 @@ class DataFrame(object):
         from vaex.column import _to_string_sequence
 
         transient = self[str(expression)].transient or self.filtered or self.is_masked(expression)
-        if self.dtype(expression) == str_type and not transient:
+        if self.dtype_evaluate(expression) == str_type and not transient:
             # string is a special case, only ColumnString are not transient
             ar = self.columns[str(expression)]
             if not isinstance(ar, ColumnString):
                 transient = True
 
-        dtype = self.dtype(column)
+        dtype = self.dtype_evaluate(column)
         ordered_set_type = ordered_set_type_from_dtype(dtype, transient)
         sets = [None] * self.executor.thread_pool.nthreads
         def map(thread_index, i1, i2, ar):
@@ -359,13 +362,13 @@ class DataFrame(object):
         from vaex.column import _to_string_sequence
 
         transient = self[str(expression)].transient or self.filtered or self.is_masked(expression)
-        if self.dtype(expression) == str_type and not transient:
+        if self.dtype_evaluate(expression) == str_type and not transient:
             # string is a special case, only ColumnString are not transient
             ar = self.columns[str(expression)]
             if not isinstance(ar, ColumnString):
                 transient = True
 
-        dtype = self.dtype(column)
+        dtype = self.dtype_evaluate(column)
         index_type = index_type_from_dtype(dtype, transient)
         index_list = [None] * self.executor.thread_pool.nthreads
         def map(thread_index, i1, i2, ar):
@@ -397,7 +400,7 @@ class DataFrame(object):
         if return_inverse:
             # inverse type can be smaller, depending on length of set
             inverse = np.zeros(self._length_unfiltered, dtype=np.int64)
-            dtype = self.dtype(expression)
+            dtype = self.dtype_evaluate(expression)
             from vaex.column import _to_string_sequence
             def map(thread_index, i1, i2, ar):
                 if dtype == str_type:
@@ -1138,7 +1141,7 @@ class DataFrame(object):
         expression = _ensure_strings_from_expressions(expression)
         binby = _ensure_strings_from_expressions(binby)
         waslist, [expressions, ] = vaex.utils.listify(expression)
-        dtypes = [self.dtype(expr) for expr in expressions]
+        dtypes = [self.dtype_evaluate(expr) for expr in expressions]
         dtype0 = dtypes[0]
         if not all([k.kind == dtype0.kind for k in dtypes]):
             raise ValueError("cannot mix datetime and non-datetime expressions")
@@ -1931,8 +1934,8 @@ class DataFrame(object):
         N = self.count(selection=selection)
         extra = 0
         for column in list(self.get_column_names(virtual=virtual)):
-            dtype = self.dtype(column)
-            dtype_internal = self.dtype(column, internal=True)
+            dtype = self.dtype_evaluate(column)
+            dtype_internal = self.dtype_evaluate(column, internal=True)
             #if dtype in [str_type, str] and dtype_internal.kind == 'O':
             if isinstance(self.columns[column], ColumnString):
                 # TODO: document or fix this
@@ -1949,7 +1952,7 @@ class DataFrame(object):
         """Alias for `df.byte_size()`, see :meth:`DataFrame.byte_size`."""
         return self.byte_size()
 
-    def dtype(self, expression, internal=False):
+    def dtype_evaluate(self, expression, internal=False):
         """Return the numpy dtype for the given expression, if not a column, the first row will be evaluated to get the dtype."""
         expression = _ensure_string_from_expression(expression)
         if expression in self._dtypes_override:
@@ -1977,7 +1980,7 @@ class DataFrame(object):
     def dtypes(self):
         """Gives a Pandas series object containing all numpy dtypes of all columns (except hidden)."""
         from pandas import Series
-        return Series({column_name:self.dtype(column_name) for column_name in self.get_column_names()})
+        return Series({column_name:self.dtype_evaluate(column_name) for column_name in self.get_column_names()})
 
     def is_masked(self, column):
         '''Return if a column is a masked (numpy.ma) column.'''
@@ -2748,7 +2751,7 @@ class DataFrame(object):
 
         table = Table(meta=meta)
         for name, data in self.to_items(column_names=column_names, selection=selection, strings=strings, virtual=virtual):
-            if self.dtype(name) == str_type:  # for astropy we convert it to unicode, it seems to ignore object type
+            if self.dtype_evaluate(name) == str_type:  # for astropy we convert it to unicode, it seems to ignore object type
                 data = np.array(data).astype('U')
             meta = dict()
             if name in self.ucds:
@@ -2789,7 +2792,7 @@ class DataFrame(object):
         column_position = len(self.column_names)
         if name in self.get_column_names():
             column_position = self.column_names.index(name)
-            renamed = '__' +vaex.utils.find_valid_name(name, used=self.get_column_names())
+            renamed = vaex.utils.find_valid_name('__' +name, used=self.get_column_names(hidden=True))
             self._rename(name, renamed)
 
         if isinstance(f_or_array, (np.ndarray, Column)):
@@ -3125,13 +3128,16 @@ class DataFrame(object):
         """
         type = "change" if name in self.virtual_columns else "add"
         expression = _ensure_string_from_expression(expression)
+        column_position = len(self.column_names)
         if name in self.get_column_names():
-            renamed = '__' +vaex.utils.find_valid_name(name, used=self.get_column_names())
+            column_position = self.column_names.index(name)
+            renamed = vaex.utils.find_valid_name('__' +name, used=self.get_column_names(hidden=True))
             expression = self._rename(name, renamed, expression)[0].expression
 
         name = vaex.utils.find_valid_name(name, used=[] if not unique else self.get_column_names())
         self.virtual_columns[name] = expression
-        self.column_names.append(name)
+        if name not in self.column_names:
+            self.column_names.insert(column_position, name)
         self._save_assign_expression(name)
         self.signal_column_changed.emit(self, name, "add")
         # self.write_virtual_meta()
@@ -3209,7 +3215,7 @@ class DataFrame(object):
             parts += ["<td>%s</td>" % name]
             virtual = name not in self.column_names
             if name in self.column_names:
-                dtype = str(self.dtype(name)) if self.dtype(name) != str else 'str'
+                dtype = str(self.dtype_evaluate(name)) if self.dtype_evaluate(name) != str else 'str'
             else:
                 dtype = "</i>virtual column</i>"
             parts += ["<td>%s</td>" % dtype]
@@ -3238,7 +3244,7 @@ class DataFrame(object):
             for name in variable_names:
                 parts += ["<tr>"]
                 parts += ["<td>%s</td>" % name]
-                type = self.dtype(name).name
+                type = self.dtype_evaluate(name).name
                 parts += ["<td>%s</td>" % type]
                 units = self.unit(name)
                 units = units.to_string("latex_inline") if units else ""
@@ -3307,8 +3313,8 @@ class DataFrame(object):
         N = len(self)
         columns = {}
         for feature in self.get_column_names(strings=strings, virtual=virtual)[:]:
-            dtype = str(self.dtype(feature)) if self.dtype(feature) != str else 'str'
-            if self.dtype(feature) == str_type or self.dtype(feature).kind in ['S', 'U', 'O']:
+            dtype = str(self.dtype_evaluate(feature)) if self.dtype_evaluate(feature) != str else 'str'
+            if self.dtype_evaluate(feature) == str_type or self.dtype_evaluate(feature).kind in ['S', 'U', 'O']:
                 count = self.count(feature, selection=selection, delay=True)
                 self.execute()
                 count = count.get()
@@ -3535,7 +3541,7 @@ class DataFrame(object):
                 return False
             if not virtual and name in self.virtual_columns:
                 return False
-            if not strings and (self.dtype(name) == str_type or self.dtype(name).type == np.string_):
+            if not strings and (self.dtype_evaluate(name) == str_type or self.dtype_evaluate(name).type == np.string_):
                 return False
             if not hidden and name.startswith('__'):
                 return False
@@ -4243,7 +4249,7 @@ class DataFrame(object):
         """Returns True if there is a selection with the given name."""
         return self.get_selection(name) is not None
 
-    def __setitem__(self, name, value):
+    def __setitem__(self, item, value):
         '''Convenient way to add a virtual column / expression to this DataFrame.
 
         Example:
@@ -4255,13 +4261,18 @@ class DataFrame(object):
         <vaex.expression.Expression(expressions='r')> instance at 0x121687e80 values=[2.9655450396553587, 5.77829281049018, 6.99079603950256, 9.431842752707537, 0.8825613121347967 ... (total 330000 values) ... 7.453831761514681, 15.398412491068198, 8.864250273925633, 17.601047186042507, 14.540181524970293]
         '''
 
-        if isinstance(name, six.string_types):
+        if isinstance(item, six.string_types):
             if isinstance(value, Expression):
                 value = value.expression
             if isinstance(value, (np.ndarray, Column)):
-                self.add_column(name, value)
+                self.add_column(item, value)
             else:
-                self.add_virtual_column(name, value)
+                self.add_virtual_column(item, value)
+        elif isinstance(item, tuple):
+            assert len(item) == 2 and isinstance(item[0], slice), 'can only set using df[:,0] or df[:,\'name\'] syntax'
+            if isinstance(item[1], int):
+                name = self.get_column_names()[item[1]]
+            self[name] = value
         else:
             raise TypeError('__setitem__ only takes strings as arguments, not {}'.format(type(name)))
 
@@ -4298,6 +4309,12 @@ class DataFrame(object):
             df._selection_masks[FILTER_SELECTION_NAME] = vaex.superutils.Mask(df._length_unfiltered)
             return df
         elif isinstance(item, (tuple, list)):
+            df = self
+            if isinstance(item[0], slice):
+                df = df[item[0]]
+            if len(item) > 1 and isinstance(item[1], int):
+                name = self.get_column_names()[item[1]]
+                return df[name]
             df = self.copy(column_names=item)
             return df
         elif isinstance(item, slice):
@@ -4403,7 +4420,13 @@ class DataFrame(object):
 
     def __iter__(self):
         """Iterator over the column names."""
-        return iter(list(self.get_column_names()))
+        if self._transposed:
+            for name in self.get_column_names():
+                yield self[name]
+        else:
+            # TODO: we should iterate over rows, this would be breaking though
+            for name in self.get_column_names():
+                yield name
 
     def _root_nodes(self):
         """Returns a list of string which are the virtual columns that are not used in any other virtual column."""
@@ -4688,6 +4711,74 @@ class DataFrameLocal(DataFrame):
 
     def echo(self, arg): return arg
 
+    @property
+    def shape(self):
+        if self._transposed:
+            return (len(self.get_column_names()), len(self))
+        else:
+            return (len(self), len(self.get_column_names()))
+
+    @property
+    def T(self):
+        df = self.copy()
+        df._transposed = not self._transposed
+        return df
+
+    @property
+    def dtype(self):
+        dtypes = [self[k].dtype for k in self.get_column_names()]
+        assert all([dtypes[0] == dtype for dtype in dtypes])
+        return dtypes[0]
+
+    def __invert__(self):
+        return np.invert(self)  # dispatch to __array_function or __array_ufunc__
+
+    def __array_function__(self, func, types, args, kwargs):
+        # print('__array_function__', func, types, args, kwargs)
+        if func.__name__ == 'may_share_memory':
+            return False
+        assert args[0] is self
+        def dispatch_to_expression(name):
+            expression = self[name]
+            forward_args = (expression,) + args[1:]
+            return expression.__array_function__(func, types, forward_args, kwargs)
+
+        results = [dispatch_to_expression(name) for name in self.get_column_names()]
+        if any([k is NotImplemented for k in results]):
+            raise TypeError("no implementation found for %r on types that implement __array_function__: %r" % (func, types))
+        if isinstance(results[0], Expression):
+            df = self.copy()
+            for i, name in enumerate(self.get_column_names()):
+                df[name] = results[i]
+            return df
+        else:
+            return np.array(results)
+        return NotImplemented
+
+    def __array_ufunc__(self, ufunc, method, *args, **kwargs):
+        # print('__array_ufunc__', ufunc, method, args, kwargs)
+        assert args[0] is self
+        def dispatch_to_expression(name, i):
+            expression = self[name]
+            forward_args = (expression,) + args[1:]
+            if len(forward_args) > 1 and isinstance(forward_args[1], np.ndarray):
+                ar = args[1]
+                if len(ar) == len(self.get_column_names()):  # poor man's broadcasting
+                    forward_args = (forward_args[0],) + (forward_args[1][i], ) + forward_args[2:]
+            return expression.__array_ufunc__(ufunc, method, *forward_args, **kwargs)
+
+        results = [dispatch_to_expression(name, i) for i, name in enumerate(self.get_column_names())]
+        if any([k is NotImplemented for k in results]):
+            raise TypeError("no implementation found for %r on types that implement __array_ufunc__: %r" % (ufunc, method))
+        if isinstance(results[0], Expression):
+            df = self.copy()
+            for i, name in enumerate(self.get_column_names()):
+                df[name] = results[i]
+            return df
+        else:
+            return np.array(results)
+        return NotImplemented
+
     def __array__(self, dtype=None):
         """Gives a full memory copy of the DataFrame into a 2d numpy array of shape (n_rows, n_columns).
         Note that the memory order is fortran, so all values of 1 column are contiguous in memory for performance reasons.
@@ -4698,13 +4789,15 @@ class DataFrameLocal(DataFrame):
 
         If any of the columns contain masked arrays, the masks are ignored (i.e. the masked elements are returned as well).
         """
+        if not _allow_array_casting:
+            raise RuntimeError('casting a dataframe to an array is explicitly disabled')
         if dtype is None:
             dtype = np.float64
         chunks = []
-        for name in self.get_column_names(strings=False):
-            if not np.can_cast(self.dtype(name), dtype):
-                if self.dtype(name) != dtype:
-                    raise ValueError("Cannot cast %r (of type %r) to %r" % (name, self.dtype(name), dtype))
+        for name in self.get_column_names():
+            if not np.can_cast(self.dtype_evaluate(name), dtype):
+                if self.dtype_evaluate(name) != dtype:
+                    raise ValueError("Cannot cast %r (of type %r) to %r" % (name, self.dtype_evaluate(name), dtype))
             else:
                 chunks.append(self.evaluate(name))
         return np.array(chunks, dtype=dtype).T
@@ -4864,14 +4957,14 @@ class DataFrameLocal(DataFrame):
                 if unit1 != unit2:
                     print("unit mismatch : %r vs %r for %s" % (unit1, unit2, column_name))
                     meta_mismatch.append(column_name)
-                type1 = self.dtype(column_name)
+                type1 = self.dtype_evaluate(column_name)
                 if type1 != str_type:
                     type1 = type1.type
-                type2 = other.dtype(column_name)
+                type2 = other.dtype_evaluate(column_name)
                 if type2 != str_type:
                     type2 = type2.type
                 if type1 != type2:
-                    print("different dtypes: %s vs %s for %s" % (self.dtype(column_name), other.dtype(column_name), column_name))
+                    print("different dtypes: %s vs %s for %s" % (self.dtype_evaluate(column_name), other.dtype_evaluate(column_name), column_name))
                     type_mismatch.append(column_name)
                 else:
                     # a = self.columns[column_name]
@@ -4909,7 +5002,7 @@ class DataFrameLocal(DataFrame):
                         a = normalize(a)
                         b = normalize(b)
                         boolean_mask = (a == b)
-                        if self.dtype(column_name) != str_type and self.dtype(column_name).kind == 'f':  # floats with nan won't equal itself, i.e. NaN != NaN
+                        if self.dtype_evaluate(column_name) != str_type and self.dtype_evaluate(column_name).kind == 'f':  # floats with nan won't equal itself, i.e. NaN != NaN
                             boolean_mask |= (np.isnan(a) & np.isnan(b))
                         return boolean_mask
                     boolean_mask = equal_mask(a, b)
@@ -5009,7 +5102,7 @@ class DataFrameLocal(DataFrame):
             index = right._index(right_on)
             lookup = np.zeros(left._length_original, dtype=np.int64)
             lookup_extra_chunks = []
-            dtype = left.dtype(left_on)
+            dtype = left.dtype_evaluate(left_on)
             duplicates_right = index.has_duplicates
 
             if duplicates_right and not allow_duplication:
@@ -5171,7 +5264,7 @@ class DataFrameLocal(DataFrame):
               self.columns[column_name].dtype.type == np.float64 and
               self.columns[column_name].strides[0] == 8 and
               column_name not in
-              self.virtual_columns) or self.dtype(column_name) == str_type or self.dtype(column_name).kind == 'S')
+              self.virtual_columns) or self.dtype_evaluate(column_name) == str_type or self.dtype_evaluate(column_name).kind == 'S')
         # and False:
 
     def selected_length(self, selection="default"):
@@ -5308,12 +5401,12 @@ class DataFrameLocal(DataFrame):
             return grid
 
     def _binner_scalar(self, expression, limits, shape):
-        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerScalar_", self.dtype(expression))
+        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerScalar_", self.dtype_evaluate(expression))
         vmin, vmax = limits
         return type(expression, vmin, vmax, shape)
 
     def _binner_ordinal(self, expression, ordinal_count, min_value=0):
-        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerOrdinal_", self.dtype(expression))
+        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerOrdinal_", self.dtype_evaluate(expression))
         return type(expression, ordinal_count, min_value)
 
     def _create_grid(self, binby, limits, shape, delay=False):

--- a/packages/vaex-core/vaex/export.py
+++ b/packages/vaex-core/vaex/export.py
@@ -63,7 +63,7 @@ def _export(dataset_input, dataset_output, random_index_column, path, column_nam
     order_array_inverse = None
 
     # for strings we also need the inverse order_array, keep track of that
-    has_strings = any([dataset_input.dtype(k) == str_type for k in column_names])
+    has_strings = any([dataset_input.dtype_evaluate(k) == str_type for k in column_names])
 
     if partial_shuffle:
         # if we only export a portion, we need to create the full length random_index array, and
@@ -162,7 +162,7 @@ def _export_column(dataset_input, dataset_output, column_name, full_mask, shuffl
         if 1:
             block_scope = dataset_input._block_scope(0, vaex.execution.buffer_size_default)
             to_array = dataset_output.columns[column_name]
-            dtype = dataset_input.dtype(column_name)
+            dtype = dataset_input.dtype_evaluate(column_name)
             if shuffle or sort:  # we need to create a in memory copy, otherwise we will do random writes which is VERY inefficient
                 to_array_disk = to_array
                 if np.ma.isMaskedArray(to_array):
@@ -296,7 +296,7 @@ def export_fits(dataset, path, column_names=None, shuffle=False, selection=False
             column = dataset.columns[column_name]
             shape = (N,) + column.shape[1:]
             dtype = column.dtype
-            if dataset.dtype(column_name) == str_type:
+            if dataset.dtype_evaluate(column_name) == str_type:
                 max_length = dataset[column_name].apply(lambda x: len(x)).max(selection=selection)
                 dtype = np.dtype('S'+str(int(max_length)))
         else:
@@ -317,7 +317,7 @@ def export_fits(dataset, path, column_names=None, shuffle=False, selection=False
         random_index_name = None
 
     # TODO: all expressions can have missing values.. how to support that?
-    null_values = {key: dataset.columns[key].fill_value for key in dataset.get_column_names() if dataset.is_masked(key) and dataset.dtype(key).kind != "f"}
+    null_values = {key: dataset.columns[key].fill_value for key in dataset.get_column_names() if dataset.is_masked(key) and dataset.dtype_evaluate(key).kind != "f"}
     vaex.file.colfits.empty(path, N, column_names, data_types, data_shapes, ucds, units, null_values=null_values)
     if shuffle:
         del column_names[-1]

--- a/packages/vaex-core/vaex/remote.py
+++ b/packages/vaex-core/vaex/remote.py
@@ -542,7 +542,7 @@ class DatasetRest(DataFrameRemote):
         self.executor = ServerExecutor()
 
     def copy(self, column_names=None, virtual=True):
-        dtypes = {name: self.dtype(name) for name in self.get_column_names(strings=True, virtual=False)}
+        dtypes = {name: self.dtype_evaluate(name) for name in self.get_column_names(strings=True, virtual=False)}
         ds = DatasetRest(self.server, self.name, self.column_names, dtypes=dtypes, length_original=self._length_original)
         state = self.state_get()
         if not virtual:
@@ -592,7 +592,7 @@ class DatasetRest(DataFrameRemote):
             logger.debug("result = %r", result)
             return result
 
-    def dtype(self, expression):
+    def dtype_evaluate(self, expression):
         if expression in self._dtypes:
             return self._dtypes[expression]
         else:

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -496,7 +496,7 @@ class TaskAggregate(Task):
         self.aggregations.append((aggregator_descriptor, selections, [create_aggregator(i) for i in range(self.nthreads)], selection_waslist, edges, task))
         self.expressions_all.extend(aggregator_descriptor.expressions)
         self.expressions_all = list(set(self.expressions_all))
-        self.dtypes = {expr: self.df.dtype(expr) for expr in self.expressions_all}
+        self.dtypes = {expr: self.df.dtype_evaluate(expr) for expr in self.expressions_all}
         return task
 
     def map(self, thread_index, i1, i2, *blocks):

--- a/packages/vaex-core/vaex/webserver.py
+++ b/packages/vaex-core/vaex/webserver.py
@@ -368,7 +368,7 @@ def process(webserver, user_id, path, fraction=None, progress=None, **arguments)
                 response = dict(result=[{'name': ds.name,
                                          'length_original': ds.length_original(),
                                          'column_names': ds.get_column_names(strings=True),
-                                         'dtypes': {name: str("str" if ds.dtype(name) == vaex.column.str_type else ds.dtype(name)) for name in ds.get_column_names(strings=True)},
+                                         'dtypes': {name: str("str" if ds.dtype_evaluate(name) == vaex.column.str_type else ds.dtype_evaluate(name)) for name in ds.get_column_names(strings=True)},
                                          'state': ds.state_get()
                                          } for ds in webserver.datasets])
                 logger.debug("response: %r", response)
@@ -468,7 +468,7 @@ def process(webserver, user_id, path, fraction=None, progress=None, **arguments)
                                 result = task_invoke(dataset, method_name, **arguments)
                                 # evaluating a string results in dtype = object, but that is difficult
                                 # to (de)serialize, better would be to serialize the arrow arrays
-                                if dataset.dtype(arguments['expression']) == vaex.column.str_type:
+                                if dataset.dtype_evaluate(arguments['expression']) == vaex.column.str_type:
                                     result = result.astype(vaex.column.str_type)
                                 return result
                             elif method_name in allowed_method_names:

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -147,7 +147,7 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
                 sparse_groups[id(sparse_matrix)].append(column_name)
                 sparse_matrices[id(sparse_matrix)] = sparse_matrix
                 continue
-            dtype = dataset.dtype(column_name)
+            dtype = dataset.dtype_evaluate(column_name)
             if column_name in dataset.get_column_names(virtual=False):
                 column = dataset.columns[column_name]
                 shape = (N,) + column.shape[1:]

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -6,10 +6,10 @@ from vaex.column import str_type
 def test_dtype(ds_local):
   ds = ds_local
   for name in ds.column_names:
-    if ds.dtype(name) == str_type:
+    if ds.dtype_evaluate(name) == str_type:
       assert ds[name].values.dtype.kind in 'OSU'
     else:
-      assert ds[name].values.dtype == ds.dtype(ds[name])
+      assert ds[name].values.dtype == ds.dtype_evaluate(ds[name])
 
 
 def test_dtypes(ds_local):
@@ -18,10 +18,10 @@ def test_dtypes(ds_local):
 
 def test_dtype_str():
   df = vaex.from_arrays(x=["foo", "bars"], y=[1,2])
-  assert df.dtype(df.x) == str_type
+  assert df.dtype_evaluate(df.x) == str_type
   df['s'] = df.y.apply(lambda x: str(x))
-  assert df.dtype(df.x) == str_type
-  assert df.dtype(df.s) == str_type
+  assert df.dtype_evaluate(df.x) == str_type
+  assert df.dtype_evaluate(df.s) == str_type
 
   n = np.array(['aap', 'noot'])
   assert vaex.from_arrays(n=n).n.dtype == str_type

--- a/tests/ml/catboost_test.py
+++ b/tests/ml/catboost_test.py
@@ -46,13 +46,13 @@ def test_catboost():
                                              features=features)
     booster.fit(ds_train, ds_train.class_)
     class_predict = booster.predict(ds_test)
-    assert np.all(ds.col.class_ == class_predict)
+    assert np.all(ds.col.class_.values == class_predict)
 
     ds = booster.transform(ds)   # this will add the catboost_prediction column
     state = ds.state_get()
     ds = vaex.ml.datasets.load_iris()
     ds.state_set(state)
-    assert np.all(ds.col.class_ == ds.evaluate(ds.catboost_prediction))
+    assert np.all(ds.col.class_.values == ds.evaluate(ds.catboost_prediction))
 
 
 def test_catboost_numerical_validation():

--- a/tests/ml/lightgbm_test.py
+++ b/tests/ml/lightgbm_test.py
@@ -62,13 +62,13 @@ def test_lightgbm():
     class_predict = booster.predict(ds_test, copy=True)  # for coverage
     booster.fit(ds_train, ds.class_)
     class_predict = booster.predict(ds_test)
-    assert np.all(ds.col.class_ == class_predict)
+    assert np.all(ds.col.class_.values == class_predict)
 
     ds = booster.transform(ds)   # this will add the lightgbm_prediction column
     state = ds.state_get()
     ds = vaex.ml.datasets.load_iris()
     ds.state_set(state)
-    assert np.all(ds.col.class_ == ds.evaluate(ds.lightgbm_prediction))
+    assert np.all(ds.col.class_.values == ds.evaluate(ds.lightgbm_prediction))
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")

--- a/tests/ml/xgboost_test.py
+++ b/tests/ml/xgboost_test.py
@@ -47,13 +47,13 @@ def test_xgboost():
                                            features=features)
     booster.fit(ds_train, ds_train.class_)
     class_predict = booster.predict(ds_test)
-    assert np.all(ds.col.class_ == class_predict)
+    assert np.all(ds.col.class_.values == class_predict)
 
     ds = booster.transform(ds)   # this will add the xgboost_prediction column
     state = ds.state_get()
     ds = vaex.ml.datasets.load_iris()
     ds.state_set(state)
-    assert np.all(ds.col.class_ == ds.evaluate(ds.xgboost_prediction))
+    assert np.all(ds.col.class_.values == ds.evaluate(ds.xgboost_prediction))
 
 
 def test_xgboost_numerical_validation():

--- a/tests/nep13_nep18_test.py
+++ b/tests/nep13_nep18_test.py
@@ -1,0 +1,71 @@
+import vaex
+import pytest
+import numpy as np
+import contextlib
+
+
+@contextlib.contextmanager
+def relax_sklearn_check():
+    import sklearn.preprocessing.data
+    import sklearn.preprocessing._encoders
+    import sklearn.preprocessing.base
+    modules = [sklearn.preprocessing.data, sklearn.preprocessing._encoders, sklearn.preprocessing.base]
+    old_check_arrays = {module: getattr(module, 'check_array') for module in modules}
+    for module in modules:
+       module.check_array = lambda x, *args, **kwargs: x
+    yield
+    for module in modules:
+       module.check_array = old_check_arrays[module]
+
+@contextlib.contextmanager
+def no_array_casting():
+    vaex.dataframe._allow_array_casting = True
+    yield
+    vaex.dataframe._allow_array_casting = True
+
+@pytest.fixture
+def df():
+    x = np.arange(10, dtype=np.float64)
+    y = x**2
+    df = vaex.from_arrays(x=x, y=y)
+    return df
+
+def test_zeros_like(df):
+    z = np.zeros_like(df.x)
+    assert z.tolist() == [0] * 10
+
+def test_sklearn_min_max_scalar(df):
+    from sklearn.preprocessing import MinMaxScaler
+    with relax_sklearn_check(), no_array_casting():
+        scaler = MinMaxScaler()
+        scaler.fit(df)
+
+        dft = scaler.transform(df)
+        assert isinstance(dft, vaex.DataFrame)
+    X = np.array(df)
+    Xt = scaler.transform(X)
+    assert np.all(Xt == np.array(dft))
+
+def test_sklearn_standard_scaler(df):
+    from sklearn.preprocessing import StandardScaler
+    with relax_sklearn_check(), no_array_casting():
+        scaler = StandardScaler()
+        scaler.fit(df)
+
+        dft = scaler.transform(df)
+        assert isinstance(dft, vaex.DataFrame)
+    X = np.array(df)
+    Xt = scaler.transform(X)
+    assert np.all(Xt == np.array(dft))
+
+def test_sklearn_power_transformer(df):
+    from sklearn.preprocessing import PowerTransformer
+    with relax_sklearn_check(), no_array_casting():
+        scaler = PowerTransformer(standardize=False)
+        scaler.fit(df)
+
+        dft = scaler.transform(df.copy())
+        assert isinstance(dft, vaex.DataFrame)
+    X = np.array(df)
+    Xt = scaler.transform(X)
+    assert np.all(Xt == np.array(dft))

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -69,8 +69,8 @@ def test_concat():
 	ds2 = vaex.from_arrays(names=['hello', 'this', 'is', 'long'])
 	ds = ds1.concat(ds2)
 	assert len(ds) == len(ds1) + len(ds2)
-	assert ds.dtype('names') == vaex.column.str_type
-	assert ds.dtype('names') != np.object
+	assert ds.dtype_evaluate('names') == vaex.column.str_type
+	assert ds.dtype_evaluate('names') != np.object
 
 def test_string_count_stat():
 	ds = vaex.from_arrays(names=['hello', 'this', 'is', 'long'])
@@ -104,11 +104,11 @@ def test_concat_mixed():
 	# and the other string
 	ds1 = vaex.from_arrays(names=['not', 'missing'])
 	ds2 = vaex.from_arrays(names=[np.nan, np.nan])
-	assert ds1.dtype(ds1.names) == str
-	assert ds2.dtype(ds2.names) == np.float64
+	assert ds1.dtype_evaluate(ds1.names) == str
+	assert ds2.dtype_evaluate(ds2.names) == np.float64
 	ds = ds1.concat(ds2)
 	assert len(ds) == len(ds1) + len(ds2)
-	assert ds.dtype(ds.names) == ds1.names.dtype
+	assert ds.dtype_evaluate(ds.names) == ds1.names.dtype
 
 def test_strip():
 	ds = vaex.from_arrays(names=['this ', ' has', ' space'])


### PR DESCRIPTION
This is a WIP on having the vaex dataframe and expressions behave more like 2d and 1d numpy arrays. This allows us to feed sklearn's fit a vaex dataframe, and have transform also return a dataframe with virtual columns. This gives us
 * A better API for vaex dataframes, since it's more like numpy
 * Leverage the sklearn algorithms, and turn them into vaex expressions/virtual columns
 * JIT the result of sklearn transforms, so we can use CUDA or numba to optimize them.
 * Out of core support for sklearn, since we don't keep anything in memory, it's all streaming algos (at least for the transformers tested here).

Numpy NEPs:
 * https://numpy.org/neps/nep-0018-array-function-protocol.html
 * https://numpy.org/neps/nep-0013-ufunc-overrides.html

Example usage (5x faster):
![image](https://user-images.githubusercontent.com/1765949/64759161-a8e45f80-d536-11e9-894b-2aa958765257.png)

 # TODO
 * [ ] increase coverage of numpy function (for instance to allow PCA?)
 * [ ] Test coverage
 * [ ] See if we can get sklearn's check_array to allow a vaex dataframe to pass through.