### PR TITLE
Adding support for timedelta operations (methods)

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -107,6 +107,9 @@ String operations
      :members:
      :special-members:
 
+String (pandas) operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. autoclass:: vaex.expression.StringOperationsPandas
      :members:
      :special-members:
@@ -115,6 +118,13 @@ Date/time operations
 ~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: vaex.expression.DateTime
+     :members:
+     :special-members:
+
+Timedelta operations
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: vaex.expression.TimeDelta
      :members:
      :special-members:
 

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -153,6 +153,12 @@ class DateTime(object):
         self.expression = expression
 
 
+class TimeDelta(object):
+    """TimeDelta operations"""
+    def __init__(self, expression):
+        self.expression = expression
+
+
 class StringOperations(object):
     """String operations"""
     def __init__(self, expression):
@@ -184,6 +190,10 @@ class Expression(with_metaclass(Meta)):
     @property
     def dt(self):
         return DateTime(self)
+
+    @property
+    def td(self):
+        return TimeDelta(self)
 
     @property
     def str(self):

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -148,19 +148,28 @@ class Meta(type):
 
 
 class DateTime(object):
-    """DateTime operations"""
+    """DateTime operations
+
+    Usually accessed using e.g. `df.birthday.dt.dayofweek`
+    """
     def __init__(self, expression):
         self.expression = expression
 
 
 class TimeDelta(object):
-    """TimeDelta operations"""
+    """TimeDelta operations
+
+    Usually accessed using e.g. `df.delay.td.days`
+    """
     def __init__(self, expression):
         self.expression = expression
 
 
 class StringOperations(object):
-    """String operations"""
+    """String operations.
+
+    Usually accessed using e.g. `df.name.str.lower()`
+    """
     def __init__(self, expression):
         self.expression = expression
 
@@ -189,10 +198,12 @@ class Expression(with_metaclass(Meta)):
 
     @property
     def dt(self):
+        """Gives access to datetime operations via :py:class:`DateTime`"""
         return DateTime(self)
 
     @property
     def td(self):
+        """Gives access to timedelta operations via :py:class:`TimeDelta`"""
         return TimeDelta(self)
 
     @property

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -14,7 +14,8 @@ import six
 scopes = {
     'str': vaex.expression.StringOperations,
     'str_pandas': vaex.expression.StringOperationsPandas,
-    'dt': vaex.expression.DateTime
+    'dt': vaex.expression.DateTime,
+    'td': vaex.expression.TimeDelta
 }
 
 def register_function(scope=None, as_property=False, name=None, on_expression=True):
@@ -593,6 +594,162 @@ def dt_second(x):
     """
     import pandas as pd
     return pd.Series(_pandas_dt_fix(x)).dt.second.values
+
+########## timedelta operations ##########
+
+@register_function(scope='td', as_property=True)
+def td_days(x):
+    """Number of days in each timedelta sample.
+
+    :returns: an expression containing the number of days in a timedelta sample.
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> delta = np.array([17658720110,   11047049384039, 40712636304958, -18161254954], dtype='timedelta64[s]')
+    >>> df = vaex.from_arrays(delta=delta)
+    >>> df
+      #  delta
+      0  204 days +9:12:00
+      1  1 days +6:41:10
+      2  471 days +5:03:56
+      3  -22 days +23:31:15
+
+    >>> df.delta.td.days
+    Expression = td_days(delta)
+    Length: 4 dtype: int64 (expression)
+    -----------------------------------
+    0  204
+    1    1
+    2  471
+    3  -22
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.days.values
+
+@register_function(scope='td', as_property=True)
+def td_microseconds(x):
+    """Number of microseconds (>= 0 and less than 1 second) in each timedelta sample.
+
+    :returns: an expression containing the number of microseconds in a timedelta sample.
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> delta = np.array([17658720110,   11047049384039, 40712636304958, -18161254954], dtype='timedelta64[s]')
+    >>> df = vaex.from_arrays(delta=delta)
+    >>> df
+      #  delta
+      0  204 days +9:12:00
+      1  1 days +6:41:10
+      2  471 days +5:03:56
+      3  -22 days +23:31:15
+
+    >>> df.delta.td.microseconds
+    Expression = td_microseconds(delta)
+    Length: 4 dtype: int64 (expression)
+    -----------------------------------
+    0  290448
+    1  978582
+    2   19583
+    3  709551
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.microseconds.values
+
+@register_function(scope='td', as_property=True)
+def td_nanoseconds(x):
+    """Number of nanoseconds (>= 0 and less than 1 microsecond) in each timedelta sample.
+
+    :returns: an expression containing the number of nanoseconds in a timedelta sample.
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> delta = np.array([17658720110,   11047049384039, 40712636304958, -18161254954], dtype='timedelta64[s]')
+    >>> df = vaex.from_arrays(delta=delta)
+    >>> df
+      #  delta
+      0  204 days +9:12:00
+      1  1 days +6:41:10
+      2  471 days +5:03:56
+      3  -22 days +23:31:15
+
+    >>> df.delta.td.nanoseconds
+    Expression = td_nanoseconds(delta)
+    Length: 4 dtype: int64 (expression)
+    -----------------------------------
+    0  384
+    1   16
+    2  488
+    3  616
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.nanoseconds.values
+
+@register_function(scope='td', as_property=True)
+def td_seconds(x):
+    """Number of seconds (>= 0 and less than 1 day) in each timedelta sample.
+
+    :returns: an expression containing the number of seconds in a timedelta sample.
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> delta = np.array([17658720110,   11047049384039, 40712636304958, -18161254954], dtype='timedelta64[s]')
+    >>> df = vaex.from_arrays(delta=delta)
+    >>> df
+      #  delta
+      0  204 days +9:12:00
+      1  1 days +6:41:10
+      2  471 days +5:03:56
+      3  -22 days +23:31:15
+
+    >>> df.delta.td.seconds
+    Expression = td_seconds(delta)
+    Length: 4 dtype: int64 (expression)
+    -----------------------------------
+    0  30436
+    1  39086
+    2  28681
+    3  23519
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.seconds.values
+
+@register_function(scope='td', as_property=False)
+def td_total_seconds(x):
+    """Total duration of each timedelta sample expressed in seconds.
+
+    :return: an expression containing the total number of seconds in a timedelta sample.
+
+    Example:
+    >>> import vaex
+    >>> import numpy as np
+    >>> delta = np.array([17658720110,   11047049384039, 40712636304958, -18161254954], dtype='timedelta64[s]')
+    >>> df = vaex.from_arrays(delta=delta)
+    >>> df
+      #  delta
+      0  204 days +9:12:00
+      1  1 days +6:41:10
+      2  471 days +5:03:56
+      3  -22 days +23:31:15
+
+    >>> df.delta.td.total_seconds()
+    Expression = td_total_seconds(delta)
+    Length: 4 dtype: float64 (expression)
+    -------------------------------------
+    0  -7.88024e+08
+    1  -2.55032e+09
+    2   6.72134e+08
+    3   2.85489e+08
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.total_seconds().values
 
 
 ########## string operations ##########

--- a/packages/vaex-core/vaex/geo.py
+++ b/packages/vaex-core/vaex/geo.py
@@ -7,7 +7,9 @@ class DataFrameAccessorGeo(object):
     """Geometry/geographic helper methods
 
     Example:
+
     >>> df_xyz = df.geo.spherical2cartesian(df.longitude, df.latitude, df.distance)
+    >>> df_xyz.x.mean()
 
     """
     def __init__(self, df):

--- a/tests/timedelta_test.py
+++ b/tests/timedelta_test.py
@@ -1,0 +1,15 @@
+import vaex
+import pandas as pd
+import numpy as np
+
+
+def test_timedelta_methods():
+    delta = np.array([17658720110, 11047049384039, 40712636304958, -18161254954], dtype='timedelta64[s]')
+    df = vaex.from_arrays(delta=delta)
+    pdf = pd.DataFrame({'delta': delta})
+
+    assert df.delta.td.days.tolist() == pdf.delta.dt.days.tolist()
+    assert df.delta.td.seconds.tolist() == pdf.delta.dt.seconds.tolist()
+    assert df.delta.td.microseconds.tolist() == pdf.delta.dt.microseconds.tolist()
+    assert df.delta.td.nanoseconds.tolist() == pdf.delta.dt.nanoseconds.tolist()
+    assert df.delta.td.total_seconds().tolist() == pdf.delta.dt.total_seconds().tolist()


### PR DESCRIPTION
Adding support for methods on `timedelta` columns. For the moment, the support is added via 
`pandas` (just like for the `datetime` operations).

New accessor is added, `td` "timedelta" which houses these method. 

The following example describes the usage.
```
    >>> import vaex
    >>> import numpy as np
    >>> delta = np.array([17658720110,   11047049384039, 40712636304958, -18161254954], dtype='timedelta64[s]')
    >>> df = vaex.from_arrays(delta=delta)
    >>> df
      #  delta
      0  204 days +9:12:00
      1  1 days +6:41:10
      2  471 days +5:03:56
      3  -22 days +23:31:15

    >>> df.delta.td.days
    Expression = td_days(delta)
    Length: 4 dtype: int64 (expression)
    -----------------------------------
    0  204
    1    1
    2  471
    3  -22
```