### PR TITLE
Filtering and selections when done on columns with masked values

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2585,24 +2585,28 @@ class DataFrame(object):
         i1 = i1 or 0
         i2 = i2 or len(self)
         scope = scopes._BlockScopeSelection(self, i1, i2, selection, cache=cache)
-        return scope.evaluate(name)
+        return vaex.utils.unmask_selection_mask(scope.evaluate(name))
 
     def evaluate_selection_mask(self, name="default", i1=None, i2=None, selection=None, cache=False):
         i1 = i1 or 0
         i2 = i2 or self.length_unfiltered()
+        if isinstance(name, vaex.expression.Expression):
+            # make sure if we get passed an expression, it is converted to a string
+            # otherwise the name != <sth> will evaluate to an Expression object
+            name = str(name)
         if name in [None, False] and self.filtered:
             scope_global = scopes._BlockScopeSelection(self, i1, i2, None, cache=cache)
             mask_global = scope_global.evaluate(FILTER_SELECTION_NAME)
-            return mask_global
+            return vaex.utils.unmask_selection_mask(mask_global)
         elif self.filtered and name != FILTER_SELECTION_NAME:
             scope = scopes._BlockScopeSelection(self, i1, i2, selection)
             scope_global = scopes._BlockScopeSelection(self, i1, i2, None, cache=cache)
             mask = scope.evaluate(name)
             mask_global = scope_global.evaluate(FILTER_SELECTION_NAME)
-            return mask & mask_global
+            return vaex.utils.unmask_selection_mask(mask & mask_global)
         else:
             scope = scopes._BlockScopeSelection(self, i1, i2, selection, cache=cache)
-            return scope.evaluate(name)
+            return vaex.utils.unmask_selection_mask(scope.evaluate(name))
 
         # if _is_string(selection):
 

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -794,11 +794,24 @@ def str_equals(x, y):
     3   True
     4  False
     """
+    xmask = None
+    ymask = None
+    if np.ma.isMaskedArray(x):
+        x, xmask = x.data, np.ma.getmaskarray(x)
+    if np.ma.isMaskedArray(y):
+        y, ymask = x.data, np.ma.getmaskarray(y)
+
     if not isinstance(x, six.string_types):
         x = _to_string_sequence(x)
     if not isinstance(y, six.string_types):
         y = _to_string_sequence(y)
-    return x.equals(y)
+    equals_mask = x.equals(y)
+    # take out masked values
+    if xmask is not None:
+        equals_mask = equals_mask & ~xmask
+    if ymask is not None:
+        equals_mask = equals_mask & ~ymask
+    return equals_mask
 
 
 @register_function(scope='str')

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -541,6 +541,7 @@ class TaskAggregate(Task):
                     # like nunique, they need to know if they should take the value into account or not
                     if hasattr(agg, 'set_selection_mask'):
                         agg.set_selection_mask(selection_mask)
+                        references.extend([selection_mask])
                 if agg_desc.expressions:
                     assert len(agg_desc.expressions) in [1,2], "only length 1 or 2 supported for now"
                     dtype_ref = block = block_map[agg_desc.expressions[0]].dtype

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -907,3 +907,11 @@ def to_native_array(ar):
 
 def extract_central_part(ar):
     return ar[(slice(2,-1), ) * ar.ndim]
+
+def unmask_selection_mask(selection_mask):
+    if np.ma.isMaskedArray(selection_mask):
+        # if we are doing a selection on a masked array
+        selection_mask, mask = selection_mask.data, np.ma.getmaskarray(selection_mask)
+        # exclude the masked values
+        selection_mask = selection_mask & ~mask
+    return selection_mask

--- a/tests/masked_values_filters_test.py
+++ b/tests/masked_values_filters_test.py
@@ -1,0 +1,42 @@
+import vaex
+import numpy as np
+
+
+x = np.ma.MaskedArray(data=[0, 1, 2, 3, 4], mask=[False, False, True, False, True])
+y = np.ma.MaskedArray(data=[3, 5, 2, -1.5, 0], mask=[False, False, False, False, False])
+w = np.ma.MaskedArray(data=['dog', 'dog', 'cat', 'cat', 'mouse'], mask=[False, False, True, False, True])
+df = vaex.from_arrays(x=x, y=y, w=w)
+
+
+def test_masked_values_selections():
+    # Select on a column which has masked values
+    assert df.y.count(selection='x < 3').tolist() == 2
+    assert df.y.sum(selection='x < 3').tolist() == 8.
+    assert df.y.mean(selection=df.x < 3).tolist() == 4.
+    assert df.y.std(selection=df.x < 3).tolist() == 1.
+    assert df.w.nunique(selection='x < 3').tolist() == 1.
+
+
+def test_masked_values_numerical_filter():
+    df_num_filter = df[df.x >= 1]
+    assert len(df_num_filter) == 2
+    assert df_num_filter.w.tolist() == ['dog', 'cat']
+    assert df_num_filter.y.tolist() == [5., -1.5]
+    assert df_num_filter.x.tolist() == [1., 3]
+
+
+def test_masked_values_string_filter():
+    df_str_filter = df[df.w == 'cat']
+    assert len(df_str_filter) == 1
+    assert df_str_filter.w.tolist() == ['cat']
+    assert df_str_filter.y.tolist() == [-1.5]
+    assert df_str_filter.x.tolist() == [3]
+
+
+def test_masked_values_filter_and_selection():
+    df_filter = df[df.x < 4]
+    assert df_filter.y.count(selection="w == 'cat'").tolist() == df_filter.y.count(selection=df_filter.w == 'cat').tolist()
+    assert df_filter.y.count(selection=df_filter.w == 'cat').tolist() == 1.
+    assert df_filter.y.sum(selection=df_filter.w == 'cat').tolist() == -1.5
+    assert df_filter.y.mean(selection=df_filter.w == 'cat').tolist() == -1.5
+    assert df_filter.y.nunique(selection=df_filter.w == 'cat').tolist() == 1

--- a/tests/masked_values_filters_test.py
+++ b/tests/masked_values_filters_test.py
@@ -10,11 +10,11 @@ df = vaex.from_arrays(x=x, y=y, w=w)
 
 def test_masked_values_selections():
     # Select on a column which has masked values
-    assert df.y.count(selection='x < 3').tolist() == 2
-    assert df.y.sum(selection='x < 3').tolist() == 8.
-    assert df.y.mean(selection=df.x < 3).tolist() == 4.
-    assert df.y.std(selection=df.x < 3).tolist() == 1.
-    assert df.w.nunique(selection='x < 3').tolist() == 1.
+    assert df.y.count(selection='x < 3') == 2
+    assert df.y.sum(selection='x < 3') == 8.
+    assert df.y.mean(selection=df.x < 3) == 4.
+    assert df.y.std(selection=df.x < 3) == 1.
+    assert df.w.nunique(selection='x < 3') == 1.
 
 
 def test_masked_values_numerical_filter():
@@ -34,9 +34,11 @@ def test_masked_values_string_filter():
 
 
 def test_masked_values_filter_and_selection():
+    assert df.evaluate_selection_mask(df.w == 'cat').tolist() == [False, False, False, True, False]
     df_filter = df[df.x < 4]
-    assert df_filter.y.count(selection="w == 'cat'").tolist() == df_filter.y.count(selection=df_filter.w == 'cat').tolist()
-    assert df_filter.y.count(selection=df_filter.w == 'cat').tolist() == 1.
-    assert df_filter.y.sum(selection=df_filter.w == 'cat').tolist() == -1.5
-    assert df_filter.y.mean(selection=df_filter.w == 'cat').tolist() == -1.5
-    assert df_filter.y.nunique(selection=df_filter.w == 'cat').tolist() == 1
+    assert df_filter.evaluate_selection_mask(df_filter.w == 'cat').tolist() == [False, False, False, True, False]
+    assert df_filter.y.count(selection="w == 'cat'") == df_filter.y.count(selection=df_filter.w == 'cat')
+    assert df_filter.y.count(selection=df_filter.w == 'cat') == 1.
+    assert df_filter.y.sum(selection=df_filter.w == 'cat') == -1.5
+    assert df_filter.y.mean(selection=df_filter.w == 'cat') == -1.5
+    assert df_filter.y.nunique(selection=df_filter.w == 'cat') == 1

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -375,3 +375,8 @@ def test_strings_operator_plus(dfs, extra):
 
 	assert (dfs.s + dfs.s).tolist() == [k + k for k in string_list]
 	assert (dfs.s + extra + dfs.s).tolist() == [k + extra + k for k in string_list]
+
+def test_masked_string():
+	s = np.ma.MaskedArray(data=['dog', 'dog', 'cat', 'cat', 'mouse'], mask=[False, False, True, False, True])
+	df = vaex.from_arrays(s=s)
+	assert (df.s == 'cat').tolist() == [False, False, False, True, False]


### PR DESCRIPTION
This PR fixes the behaviour of selections and filtering when done on columns that contain masked values. 

In the current version, selections and filtering seem to often just pass-through the rows that contain missing values. Consider the following example:

```
>import numpy as np
>import vaex
>x = np.ma.MaskedArray(data=[0, 1, 2, 3, 4], mask=[False, False, True, False, True])
>y = np.ma.MaskedArray(data=[3, 5, 2, -1.5, 0], mask=[False, False, False, False, False])
>df = vaex.from_arrays(x=x, y=y)
>print(df)
  #   x      y
  0   0     3
  1   1      5
  2   --    2
  3   3     -1.5
  4   --    0
>df_filter = df[df.x >= 1] 
>print(df_filter)
  #   x      y
  0   1      5
  1   --     2
  2   3     -1.5
  3   --    0
```

As one can see the `df_filtered` dataset contains the rows that should have been filtered out, similar to if instead of masked values the `x` column contained `np.nan`.  

Similar observation is made for selections:
```
>df.y.count(selection='x < 3')
 array(3)
```
where in the above example the number of rows in the resulting DataFrame should be 2 instead of 3. 


 