### PR TITLE
Fixes for issues related to renameing columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - export OPTIONAL_PACKAGES="";
   - export PYTEST_EXTRA_ARGS="";
   - if [[ "$PYTHON_VERSION" != "2.7" ]]; then export OPTIONAL_PACKAGES="scikit-learn "; fi
-  - if [[ $TRAVIS_OS_NAME == osx ]] && [[ "$PYTHON_VERSION" != "2.7" ]]; then export OPTIONAL_PACKAGES="$OPTIONAL_PACKAGES lightgbm py-xgboost "; fi
+  - if [[ $TRAVIS_OS_NAME == osx ]] && [[ "$PYTHON_VERSION" != "2.7" ]]; then export OPTIONAL_PACKAGES="$OPTIONAL_PACKAGES lightgbm=2.2.3 py-xgboost "; fi
   - if [[ "$PYTHON_VERSION" == "2.7" ]]; then export PYTEST_EXTRA_ARGS="--ignore=tests/ml"; fi
   - travis_wait bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/tests/rename_test.py
+++ b/tests/rename_test.py
@@ -42,3 +42,9 @@ def test_rename_state_transfer():
     ds2.state_set(ds.state_get())
     assert ds2.r.tolist() == [5]
     assert ds2.q.tolist() == [14]
+
+def test_rename_access(ds_local):
+    df = ds_local
+    df.rename_column(name='x', new_name='x2')
+    assert df['x2'].tolist() == df.x2.tolist()
+


### PR DESCRIPTION
- [ ] `.rename` support for filtered DataFrames
- [ ] `.rename` support for trimmed DataFrames
- [ ]  when rename of a column, the dict of the DataFrame gets updated, but the `df.original_name`
stays the same, and the new name isnot accessible.