### PR TITLE
feat(graphql): make accessor work for pandas dataframes directly

### DIFF
--- a/packages/vaex-graphql/vaex/graphql/__init__.py
+++ b/packages/vaex-graphql/vaex/graphql/__init__.py
@@ -1,6 +1,8 @@
 import graphene
 import graphql.execution
+
 import vaex
+import pandas as pd
 
 
 class DataFrameAccessorGraphQL(object):
@@ -26,6 +28,12 @@ class DataFrameAccessorGraphQL(object):
             address = 'localhost'
         if verbose:
             print('serving at: http://{address}:{port}/graphql'.format(**locals()))
+
+
+@pd.api.extensions.register_dataframe_accessor("graphql")
+class DataFrameAccessorGraphQLPandas(DataFrameAccessorGraphQL):
+    def __init__(self, df):
+        super(DataFrameAccessorGraphQLPandas, self).__init__(vaex.from_pandas(df))
 
 
 def map_to_field(df, name):

--- a/tests/graphql_test.py
+++ b/tests/graphql_test.py
@@ -194,3 +194,17 @@ def test_where(df_local):
     """)
     assert not result.errors
     assert values(result.data['df']['row'], 'x') == [4, 5, 6]
+
+
+def test_pandas(df_local):
+    df = df_local
+    df_pandas = df_local.to_pandas_df()
+    def values(row, name):
+        return [k[name] for k in row]
+    result = df_pandas.graphql.execute("""
+    {
+        df(where: {x: {_eq: 4}}) {
+            row { x }
+        }
+    }
+    """)


### PR DESCRIPTION
This adds a subclass to directly support pandas

![image](https://user-images.githubusercontent.com/1765949/67106297-9fe84d00-f1ca-11e9-81fa-7d7c2883be4f.png)
