### PR TITLE
Clean up deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,14 @@ before_install:
   - if [[ "$PYTHON_VERSION" != "2.7" ]]; then export OPTIONAL_PACKAGES="scikit-learn "; fi
   - if [[ $TRAVIS_OS_NAME == osx ]] && [[ "$PYTHON_VERSION" != "2.7" ]]; then export OPTIONAL_PACKAGES="$OPTIONAL_PACKAGES lightgbm py-xgboost "; fi
   - if [[ "$PYTHON_VERSION" == "2.7" ]]; then export PYTEST_EXTRA_ARGS="--ignore=tests/ml"; fi
-  - bash miniconda.sh -b -p $HOME/miniconda
+  - travis_wait bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
   # future: kapteyn should only be needed for astro package testing
-  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION certifi=2019.6.16 pip numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython runipy pandas pytest numba pyarrow graphviz python-graphviz pcre catboost $OPTIONAL_PACKAGES
+  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION certifi=2019.6.16 pip numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython runipy pandas pytest numba pyarrow graphviz python-graphviz pcre catboost libcxx=9.0.0 $OPTIONAL_PACKAGES
   - which pip
   - source activate test-environment
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -70,7 +70,7 @@ install:
 script:
   - source activate test-environment
   - python -m vaex.test.dataset TestDataset
-  # - py.test packages/vaex-core/vaex/test/dataset.py::TestDataset 
+  # - py.test packages/vaex-core/vaex/test/dataset.py::TestDataset
   - py.test tests/ ${PYTEST_EXTRA_ARGS}
   # - runipy examples/tutorial_ipython_notebook.ipynb
   # - runipy examples/advanced_plotting.ipynb

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -110,7 +110,7 @@ class GroupByBase(object):
     def __init__(self, df, by):
         self.df = df
 
-        if not isinstance(by, collections.Iterable)\
+        if not isinstance(by, collections_abc.Iterable)\
             or isinstance(by, six.string_types):
             by = [by]
 
@@ -133,9 +133,9 @@ class GroupByBase(object):
 
     def _agg(self, actions):
         df = self.df
-        if isinstance(actions, collections.Mapping):
+        if isinstance(actions, collections_abc.Mapping):
             actions = list(actions.items())
-        elif not isinstance(actions, collections.Iterable)\
+        elif not isinstance(actions, collections_abc.Iterable)\
             or isinstance(actions, six.string_types):
             actions = [actions]
 
@@ -156,7 +156,7 @@ class GroupByBase(object):
                 aggregates = item
                 name = None
 
-            if not isinstance(aggregates, collections.Iterable)\
+            if not isinstance(aggregates, collections_abc.Iterable)\
                 or isinstance(aggregates, six.string_types):
                 # not a list, or a string
                 aggregates = [aggregates]
@@ -199,7 +199,7 @@ class BinBy(GroupByBase):
 
         keys = list(arrays.keys())
         key0 = keys[0]
-        if not isinstance(actions, collections.Iterable)\
+        if not isinstance(actions, collections_abc.Iterable)\
             or isinstance(actions, six.string_types):
             assert len(keys) == 1
             final_array = arrays[key0]

--- a/packages/vaex-jupyter/vaex/jupyter/state.py
+++ b/packages/vaex-jupyter/vaex/jupyter/state.py
@@ -41,7 +41,7 @@ class VizBaseState(vaex.ml.state.HasState):
 
     def _calculate_limits(self, attr='x', expression='x_expression'):
         expression = getattr(self, expression)
-        categorical = self.ds.iscategory(expression)
+        categorical = self.ds.is_category(expression)
         if categorical:
             N = self.ds.category_count(expression)
             min, max = -0.5, N-0.5
@@ -56,7 +56,7 @@ class VizBaseState(vaex.ml.state.HasState):
 
     def _calculate_centers(self, attr='x', expression='x_expression'):
         expression = getattr(self, expression)
-        categorical = self.ds.iscategory(expression)
+        categorical = self.ds.is_category(expression)
         min, max = getattr(self, attr + '_min'), getattr(self, attr + '_max')
         if min is None or max is None:
             return # special condition that can occur during testing, since debounced does not work
@@ -68,7 +68,7 @@ class VizBaseState(vaex.ml.state.HasState):
             # print(expression, [min, max], getattr(self, attr + '_shape') or self.shape)
             centers = self.ds.bin_centers(expression, [min, max], shape=getattr(self, attr + '_shape') or self.shape)
         setattr(self, attr + '_centers', centers)
-                                                                      
+
 class VizHistogramState(VizBaseState):
     x_expression = traitlets.Unicode()
     x_slice = traitlets.CInt(None, allow_none=True)
@@ -83,7 +83,7 @@ class VizHistogramState(VizBaseState):
     x_centers = traitlets.Any().tag(**serialize_numpy)
     x_shape = traitlets.CInt(None, allow_none=True)
     #centers = traitlets.Any()
-    
+
     def __init__(self, ds, **kwargs):
         super(VizHistogramState, self).__init__(ds, **kwargs)
         self.observe(lambda x: self.signal_slice.emit(self), ['x_slice'])
@@ -91,7 +91,7 @@ class VizHistogramState(VizBaseState):
         # no need for recompute
         # self.observe(lambda x: self.calculate_grid(), ['groupby', 'shape', 'groupby_normalize'])
         # self.observe(lambda x: self.calculate_grid(), ['groupby', 'shape', 'groupby_normalize'])
-        
+
         self.observe(lambda x: self._update_grid(), ['x_min', 'x_max', 'shape'])
         if self.x_min is None and self.x_max is None:
             self.calculate_limits()
@@ -116,11 +116,11 @@ class VizHistogramState(VizBaseState):
                 deserializer = self.trait_metadata(name, 'deserialize', ident)
                 value = deserializer(state[name])
                 setattr(self, name, value)
-                                                                      
+
     def calculate_limits(self):
         self._calculate_limits('x', 'x_expression')
         self.signal_regrid.emit(None) # TODO this is also called in the ctor, unnec work
-    
+
     def limits_changed(self, change):
         self.signal_regrid.emit(None) # TODO this is also called in the ctor, unnec work
 
@@ -128,7 +128,7 @@ class VizHistogramState(VizBaseState):
     def _update_grid(self):
         self._calculate_centers()
         self.signal_regrid.emit(None)
-            
+
 class VizBase2dState(VizBaseState):
     x_expression = traitlets.Unicode()
     y_expression = traitlets.Unicode()
@@ -144,7 +144,7 @@ class VizBase2dState(VizBaseState):
     x_max = traitlets.CFloat()
     y_min = traitlets.CFloat()
     y_max = traitlets.CFloat()
-    
+
     def __init__(self, ds, **kwargs):
         super(VizBase2dState, self).__init__(ds, **kwargs)
         self.observe(lambda x: self.calculate_limits(), ['x_expression', 'y_expression', 'type', 'aux'])
@@ -162,7 +162,7 @@ class VizBase2dState(VizBaseState):
         self._calculate_limits('x', 'x_expression')
         self._calculate_limits('y', 'y_expression')
         self.signal_regrid.emit(self)
-    
+
     def limits_changed(self, change):
         self.signal_regrid.emit(self)
 
@@ -174,7 +174,7 @@ class VizHeatmapState(VizBase2dState):
     grid_sliced = traitlets.Any().tag(**serialize_numpy)
     x_centers = traitlets.Any().tag(**serialize_numpy)
     #centers = traitlets.Any()
-    
+
     def __init__(self, ds, **kwargs):
         self.ds = ds
         super(VizHeatmapState, self).__init__(ds, **kwargs)

--- a/packages/vaex-jupyter/vaex/jupyter/traitlets.py
+++ b/packages/vaex-jupyter/vaex/jupyter/traitlets.py
@@ -12,7 +12,7 @@ def nice_type(df, name):
 
 
 class ColumnsMixin(traitlets.HasTraits):
-    df = traitlets.Any(readonly=True)
+    df = traitlets.Any().tag(readonly=True)
     columns = traitlets.Any([
         {
             'name': 'foo',
@@ -31,7 +31,7 @@ class ColumnsMixin(traitlets.HasTraits):
         if df:
             df.signal_column_changed.connect(self._on_column_changed)
             self._populate_columns()
-    
+
     def _on_column_changed(self, df, name, action):
         assert df == self.df
         self._populate_columns()

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -148,7 +148,7 @@ class LabelEncoder(Transformer):
     # title = traitlets.Unicode(default_value='Label Encoder', read_only=True).tag(ui='HTML')
     prefix = traitlets.Unicode(default_value='label_encoded_', help=help_prefix).tag(ui='Text')
     labels_ = traitlets.Dict(default_value={}, allow_none=True, help='The encoded labels of each feature.').tag(output=True)
-    allow_unseen = traitlets.Bool(default=False, allow_none=False, help='If True, unseen values will be \
+    allow_unseen = traitlets.Bool(default_value=False, allow_none=False, help='If True, unseen values will be \
                                   encoded with -1, otherwise an error is raised').tag(ui='Checkbox')
 
     def fit(self, df):

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -44,7 +44,7 @@ def test_invalid_name_read(tmpdir):
     path = str(tmpdir.join('test.hdf5'))
     df.export(path)
 
-    h5 = h5py.File(path)
+    h5 = h5py.File(path, mode='r+')
     h5['/table/columns']['1'] = h5['/table/columns']['x']
     del h5['/table/columns']['x']
 


### PR DESCRIPTION
When we run the unit tests we see lots of deprecation warnings. These are mostly from external dependencies, but few do come from vaex. In this PR I am cleaning up the vaex deprecation warnings:
- [x] `iscategory` -> `is_category`
- [x] importing `collections` methods "correctly"
- [x] explicitly pass the `mode` for to `h5py` when creating a file (in test only)
- [x] some traitlets properties should be passed as tags as not in the constructor.