### PR TITLE
Dask array support

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -22,7 +22,7 @@ url = 'https://www.github.com/maartenbreddels/vaex'
 # TODO: would be nice to have astropy only as dep in vaex-astro
 install_requires_core = ["numpy>=1.11", "astropy>=2", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2", "psutil>=1.2.1",
-                         "requests", "six", "cloudpickle", "pandas"]
+                         "requests", "six", "cloudpickle", "pandas", "dask[array]"]
 if sys.version_info[0] == 2:
     install_requires_core.append("futures>=2.2.0")
 install_requires_viz = ["matplotlib>=1.3.1", ]

--- a/tests/dask_array_test.py
+++ b/tests/dask_array_test.py
@@ -1,0 +1,46 @@
+from common import *
+import dask
+import dask.array as da
+
+@pytest.fixture
+def df():
+    x = np.arange(10, dtype=np.float64)
+    y = x**2
+    df = vaex.from_arrays(x=x, y=y)
+    df = df[['x', 'y']] # make sure we are in this order
+    return df
+
+def test_dask_array(df):
+    X = np.array(df)
+    Xd = df.to_dask_array(chunks=(5,1)).compute()
+    assert Xd.tolist() == X.tolist()
+
+    Xd = (df.to_dask_array(chunks=(5,1))**2).compute()
+    assert Xd.tolist() == (X**2).tolist()
+
+    # on a column
+    x = df.x.to_numpy()
+    xd = df['x'].to_dask_array(chunks=(5,)).compute()
+    assert xd.tolist() == x.tolist()
+
+    xd = (df['x'].to_dask_array(chunks=(5,))**2).compute()
+    assert xd.tolist() == (x**2).tolist()
+
+
+def test_dask_sin(df):
+    X = np.array(df)
+    Xdv = df.to_dask_array()
+    sines = np.sin(Xdv).compute()
+    assert sines[:,0].tolist() == np.sin(df.x).tolist()
+    assert sines[:,1].tolist() == np.sin(df.y).tolist()
+
+    # on a column
+    x = df.x.to_numpy()
+    xd = da.sin(df['x'].to_dask_array(chunks=(5,))).compute()
+    assert xd.tolist() == np.sin(df.x).tolist()
+
+def test_dask_svd(df):
+    Xd = df.to_dask_array(chunks=(10,2))
+    values = da.linalg.svd(Xd)
+    values = dask.compute(*values)
+    values = [k.tolist() for k in values]


### PR DESCRIPTION
Allow converting a dataframe to a 2d dask array, or an expression (lazily) to a 1d dask array.

Example:

```python
Xd = da.sin(df.to_dask_array())
xd = da.sin(df['x'].to_dask_array())
```


Note that vaex also accepts dask arrays as input, but will directly cast/computes them to a numpy array via np.asanyarray/