### PR TITLE
fix(core): existing expressions are rewritten, to make them behave like arrays

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -211,6 +211,9 @@ class DataFrame(object):
         self._renamed_columns = []
         self._column_aliases = {}  # maps from invalid variable names to valid ones
 
+        # weak refs of expression that we keep to rewrite expressions
+        self._expressions = []
+
     def __getattr__(self, name):
         # will support the hidden methods
         if name in self.__hidden__:
@@ -3184,6 +3187,10 @@ class DataFrame(object):
             except:
                 pass
         self._save_assign_expression(new)
+        existing_expressions = [k() for k in self._expressions]
+        existing_expressions = [k for k in existing_expressions if k is not None]
+        for expression in existing_expressions:
+            expression._rename(old, new, inplace=True)
         return [self[_ensure_string_from_expression(e)]._rename(old, new) for e in expressions]
 
 

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -4,6 +4,7 @@ import functools
 import operator
 import six
 import collections
+import weakref
 
 from future.utils import with_metaclass
 import numpy as np
@@ -188,6 +189,7 @@ class Expression(with_metaclass(Meta)):
         if isinstance(expression, Expression):
             expression = expression.expression
         self.expression = expression
+        self.df._expressions.append(weakref.ref(self))
 
     @property
     def df(self):
@@ -643,12 +645,16 @@ def f({0}):
         finally:
                 logger.setLevel(log_level)
 
-    def _rename(self, old, new):
+    def _rename(self, old, new, inplace=False):
         def translate(id):
             if id == old:
                 return new
         expr = expresso.translate(self.expression, translate)
-        return Expression(self.ds, expr)
+        if inplace:
+            self.expression = expr
+            return self
+        else:
+            return Expression(self.ds, expr)
 
     def astype(self, dtype):
         if dtype == str:

--- a/tests/rename_test.py
+++ b/tests/rename_test.py
@@ -11,11 +11,21 @@ def test_rename(ds_filtered):
     assert ds.r.values.tolist() == xvalues
     assert ds.q.values.tolist() == qvalues
 
+def test_rename_existing_expression(df_local):
+    df = df_local
+    x_old = df['x']
+    xvalues = x_old.tolist()
+    # the x_old expression needs to be rewritten as well
+    df['x'] = df.x * 2
+    assert x_old.tolist() == xvalues
+
+
 
 def test_reassign_virtual(ds_local):
     df = ds_local
     x = df.x.values
     df['r'] = df.x+1
+    assert df.r.tolist() == (x+1).tolist()
     df['r'] = df.r+1
     assert df.r.tolist() == (x+2).tolist()
 


### PR DESCRIPTION
Before, if you did:
```python
x = df.x
df['x'] = df.x**2
```
`x` would 'change', i.e. if would refer to the square of x, which I think is unexpected. I think it is better to have array semantics, meaning that the expression object `x` would always refer to the 'values' if had.

To implement this, the expression behind the object (`x.expression`) will be rewritten.

Note: this is required for #415 to work, since the dot product will assign to a column, while expecting the original expressions to still refer to the 'old' values.