### PR TITLE
Fillna df.mean() compatibility test

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -235,6 +235,9 @@ class DataFrame(object):
                     def myrepr(k):
                         if isinstance(k, Expression):
                             return str(k)
+                        elif isinstance(k, np.ndarray) and k.ndim == 0:
+                            # to support numpy scalars
+                            return myrepr(k.item())
                         else:
                             return repr(k)
                     arg_string = ", ".join([myrepr(k) for k in args] + ['{}={}'.format(name, myrepr(value)) for name, value in kwargs.items()])

--- a/tests/fillna_test.py
+++ b/tests/fillna_test.py
@@ -105,3 +105,11 @@ def test_fillna():
     assert m == [0, 9, 9, 9]
     assert (df.s.fillna('kees').tolist() == ["aap", "kees", "noot", "mies"])
     assert (df.o.fillna({'a':1}).tolist() == ["aap", {'a': 1}, "noot", {'a':1}])
+
+def test_fillna_array():
+    x = np.array([1, 2, 3, np.nan])
+    df = vaex.from_arrays(x=x)
+
+    # fillna should take scalar arrays, so you can pass directly the result of df.x.mean() for instance
+    df['x_2'] = df.x.fillna(np.array(2.0))
+    assert df.x_2.tolist() == [1, 2, 3, 2]


### PR DESCRIPTION
Desired functionality for fillna in a standard use case.
```
# Current implementation
df['x'] = df.x.fillna(float(df.x.mean()))
```
vs
```
# Desired functionality
df['x'] = df.x.fillna(df.x.mean())
```

- [ ] implement new functionality 
- [ ] add unit-test 
- [ ] review