### PR TITLE
refactor(core): dataframe copying and expression rewriting was slow

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4346,9 +4346,9 @@ class DataFrame(object):
         <vaex.expression.Expression(expressions='r')> instance at 0x121687e80 values=[2.9655450396553587, 5.77829281049018, 6.99079603950256, 9.431842752707537, 0.8825613121347967 ... (total 330000 values) ... 7.453831761514681, 15.398412491068198, 8.864250273925633, 17.601047186042507, 14.540181524970293]
         '''
 
-        if isinstance(item, six.string_types):
-            if isinstance(value, supported_column_types):
-                self.add_column(item, value)
+        if isinstance(name, six.string_types):
+            if isinstance(value, (np.ndarray, Column)):
+                self.add_column(name, value)
             else:
                 self.add_virtual_column(name, value)
         else:

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -1,3 +1,4 @@
+import ast
 import base64
 import cloudpickle as pickle
 import functools
@@ -188,8 +189,55 @@ class Expression(with_metaclass(Meta)):
         assert not isinstance(ds, Expression)
         if isinstance(expression, Expression):
             expression = expression.expression
-        self.expression = expression
+        if isinstance(expression, ast.expr):
+            self._ast = expression
+            self._expression = None
+        else:
+            self._expression = expression
+            self._ast = None
         self.df._expressions.append(weakref.ref(self))
+        self._ast_names = None
+
+    def copy(self, df=None):
+        # expression either has _expressio nor _ast not None
+        if df is None:
+            df = self.df
+        if self._expression is not None:
+            expression = Expression(df, self._expression)
+            if self._ast is not None:
+                expression._ast = copy.deepcopy(self._ast)
+        elif self._ast is not None:
+            expression = Expression(df, copy.deepcopy(self._ast))
+            if self._ast is not None:
+                expression._ast = self._ast
+        return expression
+
+    @property
+    def ast(self):
+        """Returns the abstract syntax tree (AST) of the expression"""
+        if self._ast is None:
+            self._ast = expresso.parse_expression(self.expression)
+        return self._ast
+
+    @property
+    def ast_names(self):
+        if self._ast_names is None:
+            self._ast_names = expresso.names(self.ast)
+        return self._ast_names
+
+    @property
+    def expression(self):
+        if self._expression is None:
+            self._expression = expresso.node_to_string(self.ast)
+        return self._expression
+
+    @expression.setter
+    def expression(self, value):
+        # if we reassign to expression, we clear the ast cache
+        if value != self._expression:
+            self._expression = value
+            self._ast = None
+
 
     @property
     def df(self):
@@ -268,7 +316,7 @@ class Expression(with_metaclass(Meta)):
 
     def derivative(self, var, simplify=True):
         var = _ensure_string_from_expression(var)
-        return self.__class__(self.ds, expresso.derivative(self.expression, var, simplify=simplify))
+        return self.__class__(self.ds, expresso.derivative(self.ast, var, simplify=simplify))
 
     def expand(self, stop=[]):
         """Expand the expression such that no virtual columns occurs, only normal columns.
@@ -285,10 +333,10 @@ class Expression(with_metaclass(Meta)):
         def translate(id):
             if id in self.ds.virtual_columns and id not in stop:
                 return self.ds.virtual_columns[id]
-        expr = expresso.translate(self.expression, translate)
+        expr = expresso.translate(self.ast, translate)
         return Expression(self.ds, expr)
 
-    def variables(self):
+    def variables(self, ourself=False, expand_virtual=True, include_virtual=True):
         """Return a set of variables this expression depends on.
 
         Example:
@@ -302,12 +350,15 @@ class Expression(with_metaclass(Meta)):
         def record(varname):
             # do this recursively for virtual columns
             if varname in self.ds.virtual_columns and varname not in variables:
-                expresso.translate(self.ds.virtual_columns[varname], record)
-            # we don't want to record ourself
-            if varname != self.expression:
+                if (include_virtual and (varname != self.expression)) or (varname == self.expression and ourself):
+                    variables.add(varname)
+                if expand_virtual:
+                    expresso.translate(self.ds.virtual_columns[varname], record)
+            # we usually don't want to record ourself
+            elif varname != self.expression or ourself:
                 variables.add(varname)
 
-        expresso.translate(self.expression, record)
+        expresso.translate(self.ast, record)
         return variables
 
     def _graph(self):
@@ -674,15 +725,30 @@ def f({0}):
                 logger.setLevel(log_level)
 
     def _rename(self, old, new, inplace=False):
-        def translate(id):
-            if id == old:
-                return new
-        expr = expresso.translate(self.expression, translate)
-        if inplace:
-            self.expression = expr
-            return self
-        else:
-            return Expression(self.ds, expr)
+        # assert inplace
+        expression = self if inplace else self.copy()
+        # def translate(id):
+        #     if id == old:
+        #         return new
+        # expr = expresso.translate(self.ast, translate)
+        # expr = self.expression
+        # ast = self.ast
+        # copied = False
+        # for node in self._ast_names:
+        #     if node.id == "old":
+        #         if not copied and not inplace:
+        #             ast = 
+        if old in expression.ast_names:
+            for node in expression.ast_names[old]:
+                node.id = new
+            expression._expression = None  # resets the cached string representation
+        return expression
+
+        # if inplace:
+        #     self.expression = expr
+        #     return self
+        # else:
+        #     return Expression(self.ds, expr)
 
     def astype(self, dtype):
         if dtype == str:

--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -457,10 +457,6 @@ class NameCollector(ast.NodeTransformer):
         if node.id not in self.names:
             self.names[node.id] = []
         self.names[node.id].append(node)
-        # expr = self.translator(node.id)
-        # if expr:
-        #     node = parse_expression(expr)
-        #     node = self.visit(node)
         return node
 
 class GraphBuiler(ast.NodeVisitor):
@@ -537,9 +533,6 @@ def names(expression):
     return nc.names
 
 
-from functools import lru_cache
-
-# @lru_cache(maxsize=10000)
 def parse_expression(expression_string):
     expr = ast.parse(expression_string).body[0]
     assert isinstance(expr, ast.Expr), "not an expression"

--- a/tests/expression_variables_test.py
+++ b/tests/expression_variables_test.py
@@ -8,6 +8,9 @@ def test_expression_expand():
 	assert ds.r.variables() == {'x', 'y'}
 	ds['s'] = ds.r + ds.x
 	assert ds.s.variables() == {'r', 'x', 'y'}
+	assert ds.s.variables(ourself=True) == {'s', 'r', 'x', 'y'}
+	assert ds.s.variables(include_virtual=False) == {'x', 'y'}
+	assert ds.s.variables(ourself=True, include_virtual=False) == {'s', 'x', 'y'}
 	ds['t'] = ds.s + ds.y
 	assert ds.t.variables() == {'s', 'r', 'x', 'y'}
 	ds['u'] = np.arctan(ds.t)

--- a/tests/getattr_test.py
+++ b/tests/getattr_test.py
@@ -20,14 +20,16 @@ def test_column_subset_virtual_recursive(ds_local):
     ds['q'] = ds.r/2
     dss = ds[['q']]
     assert dss.get_column_names() == ['q']
-    assert set(dss.get_column_names(hidden=True)) == set(['__x', '__y', '__r', 'q'])
+    all_columns = set(dss.get_column_names(hidden=True))
+    assert all_columns == set(['__x', '__y', '__r', 'q'])
     np.array(dss)  # test if all columns can be put in arrays
 
 def test_column_subset_virtual(ds_filtered):
     ds = ds_filtered
     dss = ds[['y']]
     assert dss.get_column_names() == ['y']
-    assert set(dss.get_column_names(hidden=True)) == set(['__x', 'y'])
+    all_columns = set(dss.get_column_names(hidden=True))
+    assert all_columns == set(['__x', 'y'])
     np.array(dss)  # test if all columns can be put in arrays, with the possible filter copied as hidden
 
     # 'nested' filter


### PR DESCRIPTION
#415 is quite slow because each time expressions (strings) need to be compiled to find out dependencies, and also rewriting expression were slow.

By caching the ast, and keeping a dict of name->ast node we can do many of these operations faster.

TODO: needs cleanups.