### PR TITLE
perf: slicing e.g df[1:-1] goes much faster for filtered dataframes

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4395,19 +4395,15 @@ class DataFrame(object):
                 stop = len(self)+stop
             stop = min(stop, len(self))
             assert step in [None, 1]
-            if self.filtered and start == 0:
-                self.count()  # fill caches and masks
+            if self.filtered:
+                count_check = self.count()  # fill caches and masks
                 mask = self._selection_masks[FILTER_SELECTION_NAME]
-                indices = mask.first(stop-start)
-                df = self.trim().take(indices, filtered=False)
-            elif self.filtered and stop == len(self):
-                self.count()  # fill caches and masks
-                mask = self._selection_masks[FILTER_SELECTION_NAME]
-                indices = mask.last(stop-start)
-                df = self.trim().take(indices, filtered=False)
-            else:
-                df = self.extract()
-                df.set_active_range(start, stop)
+                start, stop = mask.indices(start, stop-1) # -1 since it is inclusive
+                assert start != -1
+                assert stop != -1
+                stop = stop+1  # +1 to make it inclusive
+            df = self.trim()
+            df.set_active_range(start, stop)
             return df.trim()
 
     def __delitem__(self, item):


### PR DESCRIPTION
Improved the performance of below snippet by factor of ~5.
```python
df = vaex.open('/Users/maartenbreddels/datasets/nytaxi/nyc_taxi2015.hdf5')
dff = df[df.passenger_count>0]
display(dff[1:-1])
```