### PR TITLE
perf(core): avoid calling df.get_column_names (1000x for 1 billion rows per column use)

### DIFF
--- a/packages/vaex-core/vaex/scopes.py
+++ b/packages/vaex-core/vaex/scopes.py
@@ -106,7 +106,7 @@ class _BlockScope(object):
         try:
             if variable in self.values:
                 return self.values[variable]
-            elif variable in self.df.get_column_names(virtual=False, hidden=True):
+            elif variable in self.df.columns:
                 offset = self.df._index_start
                 # if self.df._needs_copy(variable):
                     # self._ensure_buffer(variable)


### PR DESCRIPTION
Much faster to test if a variable is in the `df.columns` dict.
This is an overall performance increase, especially for dataframes with many columns.