### PR TITLE
feat(core): parallel evaluate

### DIFF
--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -1,0 +1,10 @@
+"""Conversion between different types of arrays"""
+import numpy as np
+
+
+def to_numpy(x):
+    if isinstance(x, np.ndarray):
+        return x
+    if hasattr(x, "to_numpy"):
+        x = x.to_numpy()
+    return x

--- a/packages/vaex-core/vaex/export.py
+++ b/packages/vaex-core/vaex/export.py
@@ -184,7 +184,7 @@ def _export_column(dataset_input, dataset_output, column_name, full_mask, shuffl
                 block_scope.move(i1, i2)
                 if selection:
                     mask = full_mask[i1:i2]
-                    values = dataset_input.evaluate(column_name, i1=i1, i2=i2, filtered=False) #selection=selection)
+                    values = dataset_input.evaluate(column_name, i1=i1, i2=i2, filtered=False, parallel=False) #selection=selection)
                     values = values[mask]
                     no_values = len(values)
                     if no_values:
@@ -210,7 +210,7 @@ def _export_column(dataset_input, dataset_output, column_name, full_mask, shuffl
                                 to_array[to_offset:to_offset + no_values] = values
                             to_offset += no_values
                 else:
-                    values = dataset_input.evaluate(column_name, i1=i1, i2=i2)
+                    values = dataset_input.evaluate(column_name, i1=i1, i2=i2, parallel=False)
                     if is_string:
                         no_values = len(values)
                         # for strings, we don't take sorting/shuffling into account when building the structure

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -255,7 +255,7 @@ class Expression(with_metaclass(Meta)):
 
     @property
     def shape(self):
-        return (len(self.ds),)
+        return self.df._shape_of(self)
 
     def to_numpy(self):
         """Return a numpy representation of the data"""
@@ -664,8 +664,8 @@ class Expression(with_metaclass(Meta)):
         """Returns the number of missing values in the expression."""
         return self.ismissing().astype('int').sum().item()  # so the output is int, not array
 
-    def evaluate(self, i1=None, i2=None, out=None, selection=None):
-        return self.ds.evaluate(self, i1, i2, out=out, selection=selection)
+    def evaluate(self, i1=None, i2=None, out=None, selection=None, parallel=True):
+        return self.ds.evaluate(self, i1, i2, out=out, selection=selection, parallel=parallel)
 
     # TODO: it is not so elegant we need to have a custom version of this
     # it now also misses the docstring, reconsider how the the meta class auto

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2033,6 +2033,7 @@ def format(x, format):
 for name in dir(scopes['str']):
     if name.startswith('__'):
         continue
+    force_string = ['get']
     def pandas_wrapper(name=name):
         def wrapper(*args, **kwargs):
             import pandas
@@ -2045,7 +2046,10 @@ for name in dir(scopes['str']):
             args = args[1:]
             series = pandas.Series(x)
             method = getattr(series.str, name)
-            return method(*args, **kwargs)
+            value = method(*args, **kwargs)
+            if name in force_string:
+                value = _to_string_column(value.values, force=True)
+            return value
         return wrapper
     wrapper = pandas_wrapper()
     wrapper.__doc__ = "Wrapper around pandas.Series.%s" % name

--- a/packages/vaex-core/vaex/remote.py
+++ b/packages/vaex-core/vaex/remote.py
@@ -611,10 +611,10 @@ class DatasetRest(DataFrameRemote):
     def __call__(self, *expressions, **kwargs):
         return SubspaceRemote(self, expressions, kwargs.get("executor") or self.executor, delay=kwargs.get("delay", False))
 
-    def evaluate(self, expression, i1=None, i2=None, out=None, selection=None, delay=False):
+    def evaluate(self, expression, i1=None, i2=None, out=None, selection=None, parallel=True, delay=False):
         expression = _ensure_strings_from_expressions(expression)
         """basic support for evaluate at server, at least to run some unittest, do not expect this to work from strings"""
-        result = self.server._call_dataset("evaluate", self, expression=expression, i1=i1, i2=i2, selection=selection, delay=delay)
+        result = self.server._call_dataset("evaluate", self, expression=expression, i1=i1, i2=i2, selection=selection, parallel=parallel, delay=delay)
         # TODO: we ignore out
         return result
 

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -498,11 +498,18 @@ class TaskAggregate(Task):
         self.expressions_all.extend(aggregator_descriptor.expressions)
         self.expressions_all = list(set(self.expressions_all))
         self.dtypes = {expr: self.df.dtype(expr) for expr in self.expressions_all}
+        def chain_reject(x):
+            task.reject(x)
+            return x
+        self.then(None, chain_reject)
         return task
 
-    def map(self, thread_index, i1, i2, *blocks):
+    def check(self):
         if not self.aggregations:
             raise RuntimeError('Aggregation tasks started but nothing to do, maybe adding operations failed?')
+
+    def map(self, thread_index, i1, i2, *blocks):
+        self.check()
         grid = self.grids[thread_index]
         def check_array(x, dtype):
             if dtype == str_type:

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -538,7 +538,8 @@ def filename_shorten(path, max_length=150):
 
 
 def listify(*args):
-    if isinstance(args[0], six.string_types):
+    import vaex.expression
+    if isinstance(args[0], (six.string_types, vaex.expression.Expression)):
         return False, [[x] for x in args]
     try:
         _ = args[0][0]

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -205,7 +205,7 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
                         column_names.remove(column_name)
                 array[0] = array[0]  # make sure the array really exists
 
-                data = dataset.evaluate(column_name, 0, 1)
+                data = dataset.evaluate(column_name, 0, 1, parallel=False)
                 if np.ma.isMaskedArray(data):
                     mask = h5column_output.require_dataset('mask', shape=shape, dtype=np.bool)
                     mask[0] = mask[0]  # make sure the array really exists

--- a/tests/concat_test.py
+++ b/tests/concat_test.py
@@ -21,7 +21,7 @@ def test_concat():
     ww = ds1.concat(ds2)
 
     # Test if the concatination of two arrays with the vaex method is the same as with the dataset method
-    assert (np.array(dd.evaluate('x,y,z,w')) == np.array(ww.evaluate('x,y,z,w'))).all()
+    assert (np.array(dd.evaluate('x,y,z,w'.split(','))) == np.array(ww.evaluate('x,y,z,w'.split(',')))).all()
 
     # Test if the concatination of multiple datasets works
     dd = vaex.concat([ds1, ds2, ds3])

--- a/tests/graphql_test.py
+++ b/tests/graphql_test.py
@@ -1,6 +1,9 @@
 from common import *
 
 
+if vaex.utils.devmode:
+    pytest.skip('runs too slow when developing', allow_module_level=True)
+
 def test_aggregates(df_local):
     df = df_local
 

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -194,7 +194,7 @@ def test_string_find(dfs, sub, start, end):
 
 @pytest.mark.parametrize("i", [-1, 3, 5, 10])
 def test_string_get(dfs, i):
-	x = dfs.s.str_pandas.get(i).values.values
+	x = dfs.s.str_pandas.get(i).tolist()
 	assert dfs.s.str.get(i).tolist() == [k[i] if i < len(k) else '' for k in string_list]
 
 @pytest.mark.parametrize("sub", ["v", "æ"])

--- a/tests/trim_test.py
+++ b/tests/trim_test.py
@@ -20,6 +20,7 @@ def test_trim(ds_local):
     # trim on trimmed
     ds_trimmed.set_active_range(1, 4)
     ds_trimmed = ds_trimmed.trim()
+
     assert ds_trimmed.length_original() == ds_trimmed.length_unfiltered() == 3
     assert ds_trimmed.get_active_range() == (0, ds_trimmed.length_original()) == (0, 3)
     assert ds_trimmed.evaluate('x').tolist() == np.arange(6, 9.).tolist()


### PR DESCRIPTION
Evaluate has become quite a beast, but there need to be 2 modes, parallel (default for users), and non-parallel (interally mostly, but also if someone else already does the multithreading).

For vaex internally, if it's in a task (say map reduce), it can call `df.dtype(..)`, which may call `df.evaluate`, which will start another task, which is not supported.

These are the two reasons why evaluate has a parallel and non-parallel mode.