### PR TITLE
Adding a GroupByTransformer in vaex.ml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# vaex 3.0.x (unreleased)
+# vaex 3.1.0 (unreleased)
+
+## vaex-ml 0.10.0
+   * Features
+      * Implementation of `GroupbyTransformer` [#479](https://github.com/vaexio/vaex/pull/479)
 
 # vaex-hdf5 0.6.1 (2020-6-2)
    * Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 # vaex-core 2.0.2 (2020-6-2)
    * Fixes
       * Masked arrays supported in hdf5 files on s3
+      * Expression.map always uses masked arrays to be state transferrable (a new dataset might have missing values) [#479](https://github.com/vaexio/vaex/pull/479)
 
 # vaex-core 2.0.1 (2020-5-28)
    * Fixes

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -916,6 +916,8 @@ def f({0}):
         use_masked_array = False
         if default_value is not None:
             allow_missing = True
+        if allow_missing:
+            use_masked_array = True
         if not set(mapper_keys).issuperset(found_keys):
             missing = set(found_keys).difference(mapper_keys)
             missing0 = list(missing)[0]
@@ -924,8 +926,6 @@ def f({0}):
                 if default_value is not None:
                     value0 = list(mapper.values())[0]
                     assert np.issubdtype(type(default_value), np.array(value0).dtype), "default value has to be of similar type"
-                else:
-                    use_masked_array = True
             else:
                 if only_has_nan:
                     pass  # we're good, the hash mapper deals with nan

--- a/packages/vaex-meta/setup.py
+++ b/packages/vaex-meta/setup.py
@@ -23,7 +23,7 @@ install_requires = [
       'vaex-astro>=0.7.0,<0.8',
       'vaex-arrow>=0.5.0,<0.6',
       'vaex-jupyter>=0.5.0,<0.6',
-      'vaex-ml>=0.9.0,<0.10',
+      'vaex-ml>=0.10.0-dev.0,<0.11',
       # vaex-graphql it not on conda-forge yet
 ]
 

--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -102,6 +102,19 @@ class DataFrameAccessorML(object):
         minmax_scaler.fit(self.df)
         return minmax_scaler
 
+    def groupby_transformer(self, by, agg, rprefix='', rsuffix=''):
+        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.GroupByTransformer` and fit it.
+
+        :param by: The feature on which to do the grouping.
+        :param agg: Dict where the keys are feature names and the values are vaex.agg objects.
+        :param rprefix: Prefix for the names of the aggregate features in case of a collision.
+        :param rsuffix: Suffix for the names of the aggregate features in case of a collision.
+        :return vaex.ml.transformations.GroupByTransformer: Fitted GroupByTransformer.
+        '''
+
+        group_trans = GroupByTransformer(by=by, agg=agg, rprefix=rprefix, rsuffix=rsuffix)
+        group_trans.fit(self.df)
+        return group_trans
 
     def xgboost_model(self, target, features=None, num_boost_round=100, params={}, prediction_name='xgboost_prediction'):
         '''Requires vaex.ml: create a XGBoost model and train/fit it.
@@ -230,3 +243,4 @@ from .transformations import LabelEncoder, OneHotEncoder, FrequencyEncoder
 from .transformations import CycleTransformer
 from .transformations import BayesianTargetEncoder
 from .transformations import WeightOfEvidenceEncoder
+from .transformations import GroupByTransformer

--- a/packages/vaex-ml/vaex/ml/_version.py
+++ b/packages/vaex-ml/vaex/ml/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.9.0'
-__version_tuple__ = (0, 9, 0)
+__version__ = '0.10.0-dev.0'
+__version_tuple__ = (0, 10, 0, "dev.0")

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -363,3 +363,40 @@ def test_weight_of_evidence_encoder_bad_values():
     y = np.ma.array([1, 0], mask=[True, True])
     df = vaex.from_arrays(x=['a', 'b'], y=y)
     trans.fit_transform(df)
+
+
+def test_groupby_transformer_basics():
+    df_train = vaex.from_arrays(x=['dog', 'dog', 'dog', 'cat', 'cat'], y=[2, 3, 4, 10, 20])
+    df_test = vaex.from_arrays(x=['dog', 'cat', 'dog', 'mouse'], y=[5, 5, 5, 5])
+
+    group_trans = vaex.ml.GroupByTransformer(by='x', agg={'mean_y': vaex.agg.mean('y')}, rsuffix='_agg')
+    df_train_trans = group_trans.fit_transform(df_train)
+    df_test_trans = group_trans.transform(df_test)
+
+    assert df_train_trans.mean_y.tolist() == [3.0, 3.0, 3.0, 15.0, 15.0]
+    assert df_test_trans.mean_y.tolist() == [3.0, 15, 3.0, None]
+    assert df_test_trans.x.tolist() == ['dog', 'cat', 'dog', 'mouse']
+    assert df_test_trans.y.tolist() == [5, 5, 5, 5]
+
+    # Alternative API
+    trans = df_train.ml.groupby_transformer(by='x', agg={'mean_y': vaex.agg.mean('y')}, rsuffix='_agg')
+    df_test_trans_2 = trans.transform(df_test)
+    assert df_test_trans.mean_y.tolist() == df_test_trans_2.mean_y.tolist()
+    assert df_test_trans.x.tolist() == df_test_trans_2.x.tolist()
+    assert df_test_trans.y.tolist() == df_test_trans_2.y.tolist()
+
+
+def test_groupby_transformer_serialization():
+    df_train = vaex.from_arrays(x=['dog', 'dog', 'dog', 'cat', 'cat'], y=[2, 3, 4, 10, 20])
+    df_test = vaex.from_arrays(x=['dog', 'cat', 'dog', 'mouse'], y=[5, 5, 5, 5])
+
+    group_trans = vaex.ml.GroupByTransformer(by='x', agg={'mean_y': vaex.agg.mean('y')}, rsuffix='_agg')
+    df_train_trans = group_trans.fit_transform(df_train)
+
+    state = df_train_trans.state_get()
+    df_test.state_set(state)
+
+    assert df_train_trans.mean_y.tolist() == [3.0, 3.0, 3.0, 15.0, 15.0]
+    assert df_test.mean_y.tolist() == [3.0, 15, 3.0, None]
+    assert df_test.x.tolist() == ['dog', 'cat', 'dog', 'mouse']
+    assert df_test.y.tolist() == [5, 5, 5, 5]


### PR DESCRIPTION
Adding a `vaex.ml.GroupByTransformer`. This transformer creates aggregation of features just like a `groupby` operation which are then added to a DataFrame. With the `.transform` method, the same aggregations can be added to different DataFrames (e.g. validation, test sets).
This is useful for creating aggregate features useful for certain ML tasks.

- [x] Implement `GroupbyTransformer`
- [x] Implement alternative API
- [x] Unit-test
- [ ] Code review