### PR TITLE
Duplicated columns when joining on the same column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+# vaex 2.4.1-dev (unreleased)
+
+# vaex-core 1.3.1-dev
+   * Fixes
+      * Do not duplicate column when joining DataFrames on a column with the same name [#480](https://github.com/vaexio/vaex/pull/480)
+
 # vaex 2.4.0 (2019-11-26)
+
 ## vaex-core 1.3.0
-    
+
    * Performance
       * Parallel df.evaluate [#474](https://github.com/vaexio/vaex/pull/474)
       * Avoid calling df.get_column_names (1000x for 1 billion rows per column use) [#473](https://github.com/vaexio/vaex/pull/473)
@@ -21,7 +28,7 @@
    * Fixes:
       * bqplot 0.12 revealed a bug/inconsistency with heatmap [#465](https://github.com/vaexio/vaex/pull/465)
 
-## vaex-arrow 0.4.1 
+## vaex-arrow 0.4.1
    * Fixes
       *  Support for Apache Arrow >= 0.15
 
@@ -33,10 +40,12 @@
    * initial release 0.1
 
 # vaex 2.3.0 (2019-10-15)
+
 ## vaex-core 1.2.0
    * feature: auto upcasting for sum [#435](https://github.com/vaexio/vaex/pull/435)
    * fix: selection/filtering fix when using masked values [#431](https://github.com/vaexio/vaex/pull/431)
    * fix: masked string array fixes [#434](https://github.com/vaexio/vaex/pull/434)
    * fix: memory usage fix for joins [#439](https://github.com/vaexio/vaex/pull/439)
+
 ## vaex-arrow 0.4.1
  * fix: support for Apache Arrow >= 0.15

--- a/packages/vaex-core/vaex/core/_version.py
+++ b/packages/vaex-core/vaex/core/_version.py
@@ -1,2 +1,2 @@
-__version_tuple__ = (1, 3, 0)
-__version__ = '1.3.0'
+__version_tuple__ = (1, 3, 1, 'dev')
+__version__ = '1.3.1-dev'

--- a/packages/vaex-meta/setup.py
+++ b/packages/vaex-meta/setup.py
@@ -16,7 +16,7 @@ version = version.__version__
 url = 'https://www.github.com/maartenbreddels/vaex'
 
 install_requires = [
-      'vaex-core>=1.3.0,<2',
+      'vaex-core>=1.3.1-dev,<2',
       'vaex-viz>=0.3.8,<0.4',
       'vaex-server>=0.2.1,<0.3',
       'vaex-hdf5>=0.5.6,<0.6',

--- a/packages/vaex-meta/vaex/meta/_version.py
+++ b/packages/vaex-meta/vaex/meta/_version.py
@@ -1,2 +1,2 @@
-__version_tuple__ = (2, 4, 0)
-__version__ = '2.4.0'
+__version_tuple__ = (2, 4, 1, 'dev')
+__version__ = '2.4.1-dev'

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -202,3 +202,15 @@ def test_join_filtered_inner():
     df = df[df.x > 5]
     dfj = df.join(df, on='x', rsuffix='right_', how='inner')
     repr(dfj)  # trigger issue with selection cache
+
+
+def test_join_duplicate_column():
+    df_left = vaex.from_arrays(index=[1, 2, 3], x=[10, 20, 30])
+    df_right = vaex.from_arrays(index=[1, 2, 3], y=[0.1, 0.2, 0.3])
+
+    df = df_left.join(df_right, on='index')
+    assert df.column_count() == 3
+    assert set(df.column_names) == {'index', 'x', 'y'}
+    assert df['index'] == [1, 2, 3]
+    assert df.x.tolist() == [10, 20, 30]
+    assert df.y.tolist() == [0.1, 0.2, 0.3]


### PR DESCRIPTION
Remove duplications of columns when joining DataFrames on the same column name:

- [x] Unit-test
- [ ] Modify join
- [ ] Review