### PR TITLE
Feat filter options

### DIFF
--- a/packages/vaex-core/vaex/selections.py
+++ b/packages/vaex-core/vaex/selections.py
@@ -124,7 +124,12 @@ class SelectionExpression(Selection):
             previous_mask = df._evaluate_selection_mask(name, i1, i2, selection=self.previous_selection)
         else:
             previous_mask = None
-        current_mask = df._evaluate_selection_mask(self.boolean_expression, i1, i2).astype(np.bool)
+        result = df._evaluate_selection_mask(self.boolean_expression, i1, i2)
+        if isinstance(result, bool):
+            N = i2 - i1
+            current_mask = np.full(N, result)
+        else:
+            current_mask = result.astype(np.bool)
         if previous_mask is None:
             logger.debug("setting mask")
             mask = current_mask

--- a/tests/selection_test.py
+++ b/tests/selection_test.py
@@ -1,6 +1,4 @@
-import numpy as np
-
-import vaex
+from common import *
 
 
 def test_selection_and_filter():
@@ -14,7 +12,18 @@ def test_selection_and_filter():
     df_filtered = df[df.x < 0]
     filtered_list = df_filtered['x'].tolist()
     assert filtered_list == selected_list
+    repr(df_filtered)
 
     # make sure we can slice, and repr
     df_sliced = df_filtered[:5]
-    repr(df_filtered)
+    repr(df_sliced)
+
+
+def test_filter(df):
+    dff = df[df.x>4]
+    assert dff.x.tolist() == list(range(5,10))
+
+    # vaex can have filters 'grow'
+    dff_bigger = dff.filter(dff.x < 3, mode="or")
+    dff_bigger = dff_bigger.filter(dff_bigger.x >= 0, mode="and")  # restore old filter (df_filtered)
+    assert dff_bigger.x.tolist() == list(range(3)) + list(range(5,10))

--- a/tests/selection_test.py
+++ b/tests/selection_test.py
@@ -27,3 +27,13 @@ def test_filter(df):
     dff_bigger = dff.filter(dff.x < 3, mode="or")
     dff_bigger = dff_bigger.filter(dff_bigger.x >= 0, mode="and")  # restore old filter (df_filtered)
     assert dff_bigger.x.tolist() == list(range(3)) + list(range(5,10))
+
+
+def test_filter_boolean_scalar_variable(df):
+    df = df[df.x>4]
+    assert df.x.tolist() == list(range(5,10))
+    df.add_variable("production", True)
+    df = df.filter("production", mode="or")
+    df = df[df.x>=0] # restore old filter (df_filtered)
+    df = df[df.x<10] # restore old filter (df_filtered)
+    assert df.x.tolist() == list(range(10))


### PR DESCRIPTION
The first feature is to refactor `df[<expr>]` to make use of the more general df.filter, which is analogous to `df.select`, and allows filter to 'grow the selection' (i.e. select **more** rows), which would never be possible with numpy/pandas, or any framework that uses immediate evaluation and memory copies. Also, by allowing selections/filters so have boolean scalar values (such as dataframe variables), we can create really flexible filters:
This enabled filters to be as flexible as selections, e.g.:
```python
df = df[df.x>4]
df.add_variable("production", False)
df = df.filter("production", mode="or")
```

By transferring this state to another dataframe, and setting the variable `production` to True, we affect the filter (in this case disable it, since production will evaluate to True and short circuit the rest of the filter). 