### PR TITLE
vaex-ml: Lazy function in predictors is made unique

### DIFF
--- a/packages/vaex-ml/vaex/ml/catboost.py
+++ b/packages/vaex-ml/vaex/ml/catboost.py
@@ -77,7 +77,7 @@ class CatBoostModel(state.HasState):
         :rtype: DataFrame
         '''
         copy = df.copy()
-        lazy_function = copy.add_function('catboost_prediction_function', self)
+        lazy_function = copy.add_function('catboost_prediction_function', self, unique=True)
         expression = lazy_function(*self.features)
         copy.add_virtual_column(self.prediction_name, expression, unique=False)
         return copy

--- a/packages/vaex-ml/vaex/ml/lightgbm.py
+++ b/packages/vaex-ml/vaex/ml/lightgbm.py
@@ -79,7 +79,7 @@ class LightGBMModel(state.HasState):
         :rtype: DataFrame
         '''
         copy = df.copy()
-        lazy_function = copy.add_function('lightgbm_prediction_function', self)
+        lazy_function = copy.add_function('lightgbm_prediction_function', self, unique=True)
         expression = lazy_function(*self.features)
         copy.add_virtual_column(self.prediction_name, expression, unique=False)
         return copy

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -81,7 +81,7 @@ class SKLearnPredictor(state.HasState):
         :rtype: DataFrame
         '''
         copy = df.copy()
-        lazy_function = copy.add_function('sklearn_prediction_function', self)
+        lazy_function = copy.add_function('sklearn_prediction_function', self, unique=True)
         expression = lazy_function(*self.features)
         copy.add_virtual_column(self.prediction_name, expression, unique=False)
         return copy

--- a/packages/vaex-ml/vaex/ml/xgboost.py
+++ b/packages/vaex-ml/vaex/ml/xgboost.py
@@ -73,7 +73,7 @@ class XGBoostModel(state.HasState):
         :rtype: DataFrame
         '''
         copy = df.copy()
-        lazy_function = copy.add_function('xgboost_prediction_function', self)
+        lazy_function = copy.add_function('xgboost_prediction_function', self, unique=True)
         expression = lazy_function(*self.features)
         copy.add_virtual_column(self.prediction_name, expression, unique=False)
         return copy


### PR DESCRIPTION
The lazy function in the vaex-ml model predictors wrappers is now made unique. This allows for the wrappers to be used multiple times in different context (different features, different parameters etc..) in the same runtime. 

- [x] `lazy_function(... unique=True)`
- [ ] review