### PR TITLE
feat(ml): IncrementalPredictor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
       * Filtering (using df.filter) allows more flexible (and growing/expanding!) filter. [#489](https://github.com/vaexio/vaex/pull/489)
       * Filtering and selections allow for booleans (True or False) to auto 'broadcast', to allow 'conditional filtering'. [#489](https://github.com/vaexio/vaex/pull/489)
 
-## vaex-ml 0.6.3-dev
+# vaex-ml 0.7.0-dev
+   * Features
+      * IncrementalPredictor for `scikit-learn` models that support the `.partial_fit` method [#497](https://github.com/vaexio/vaex/pull/497)
    * Fixes
       * Adding unique function names to dataframes to enable adding a predictor twice [#492](https://github.com/vaexio/vaex/pull/492)
 

--- a/packages/vaex-meta/setup.py
+++ b/packages/vaex-meta/setup.py
@@ -23,7 +23,7 @@ install_requires = [
       'vaex-astro>=0.6.1,<0.7',
       'vaex-arrow>=0.4.1,<0.5',
       'vaex-jupyter>=0.4.1,<0.5',
-      'vaex-ml>=0.6.3-dev,<0.7',
+      'vaex-ml>=0.7.0-dev,<0.8',
       # vaex-graphql it not on conda-forge yet
 ]
 

--- a/packages/vaex-ml/vaex/ml/_version.py
+++ b/packages/vaex-ml/vaex/ml/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.6.3-dev'
-__version_tuple__ = (0, 6, 3, "dev")
+__version__ = '0.7.0-dev'
+__version_tuple__ = (0, 7, 0, 'dev')

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -95,3 +95,146 @@ class SKLearnPredictor(state.HasState):
         X = df[self.features].values
         y = df.evaluate(target)
         self.model.fit(X=X, y=y, **kwargs)
+
+
+@vaex.serialize.register
+@generate.register
+class IncrementalPredictor(state.HasState):
+    '''This class wraps any scikit-learn estimator (a.k.a predictions) that has
+    a `.partial_fit` method, and makes it a vaex pipeline object.
+
+    By wrapping "on-line" scikit-learn estimators with this class, they become a vaex
+    pipeline object. Thus, they can take full advantage of the serialization and
+    pipeline system of vaex. While the underlying estimator need to call the
+    `.partial_fit` method, this class contains the standard `.fit` method, and
+    the rest happens behind the scenes. One can also iterate over the data
+    multiple times (epochs), and optionally shuffle each batch before it is sent
+    to the estimator. The `predict` method returns a numpy array, while the `transform`
+    method adds the prediction as a virtual column to a vaex DataFrame.
+
+    Note: the `.fit` method will use as much memory as needed to copy one
+    batch of data, while the `.predict` method will require as much memory as
+    needed to output the predictions as a numpy array. The `transform` method is
+    evaluated lazily, and no memory copies are made.
+
+    Note: we are using normal sklearn without modifications here.
+
+    Example:
+
+    >>> import vaex
+    >>> import vaex.ml
+    >>> from vaex.ml.sklearn import IncrementalPredictor
+    >>> from sklearn.linear_model import SGDRegressor
+    >>>
+    >>> df = vaex.example()
+    >>>
+    >>> features = df.column_names[:6]
+    >>> target = 'FeH'
+    >>>
+    >>> standard_scaler = vaex.ml.StandardScaler(features=features)
+    >>> df = standard_scaler.fit_transform(df)
+    >>>
+    >>> features = df.get_column_names(regex='^standard')
+    >>> model = SGDRegressor(learning_rate='constant', eta0=0.01, random_state=42)
+    >>>
+    >>> incremental = IncrementalPredictor(model=model,
+    ...                                    features=features,
+    ...                                    batch_size=10_000,
+    ...                                    num_epochs=3,
+    ...                                    shuffle=True,
+    ...                                    prediction_name='pred_FeH')
+    >>> incremental.fit(df=df, target=target)
+    >>> df = incremental.transform(df)
+    >>> df.head(5)[['FeH', 'pred_FeH']]
+      #        FeH    pred_FeH
+      0  -2.30923     -1.66226
+      1  -1.78874     -1.68218
+      2  -0.761811    -1.59562
+      3  -1.52088     -1.62225
+      4  -2.65534     -1.61991
+    '''
+
+    model = traitlets.Any(default_value=None, allow_none=True, help='A scikit-learn estimator with `.fit_predict` method.').tag(**serialize_pickle)
+    features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
+    batch_size = traitlets.Int(default_value=1_000_000, allow_none=False, help='Number of samples to be sent to the model in each batch.')
+    num_epochs = traitlets.Int(default_value=1, allow_none=False, help='Number of times each batch is sent to the model.')
+    shuffle = traitlets.Bool(default_value=False, allow_none=False, help='If True, shuffle the samples before sending them to the model.')
+    prediction_name = traitlets.Unicode(default_value='prediction', help='The name of the virtual column housing the predictions.')
+
+    def __call__(self, *args):
+        X = np.vstack([arg.astype(np.float64) for arg in args]).T.copy()
+        return self.model.predict(X)
+
+    def predict(self, df):
+        '''Get an in-memory numpy array with the predictions of the SKLearnPredictor.self
+
+        :param df: A vaex DataFrame, containing the input features.
+        :returns: A in-memory numpy array containing the SKLearnPredictor predictions.
+        :rtype: numpy.array
+        '''
+
+        return self.transform(df)[self.prediction_name].values
+
+    def transform(self, df):
+        '''Transform a DataFrame such that it contains the predictions of the IncrementalPredictor.
+        in form of a virtual column.
+
+        :param df: A vaex DataFrame.
+
+        :return copy: A shallow copy of the DataFrame that includes the IncrementalPredictor prediction as a virtual column.
+        :rtype: DataFrame
+        '''
+        copy = df.copy()
+        lazy_function = copy.add_function('incremental_prediction_function', self, unique=True)
+        expression = lazy_function(*self.features)
+        copy.add_virtual_column(self.prediction_name, expression, unique=False)
+        return copy
+
+    def fit(self, df, target, progress=None, **kwargs):
+        '''Fit the IncrementalPredictor to the DataFrame.
+
+        :param df: A vaex DataFrame containing the features on which to train the model.
+        :param target: The name of the column containing the target variable.
+        '''
+        # Check whether the model is appropriate
+        assert hasattr(self.model, 'partial_fit'), 'The model must have a `.partial_fit` method.'
+
+        # Number of batches to send (or training rounds)
+        N_total = len(df)
+        num_batches = (N_total + self.batch_size -1) // self.batch_size  # round up int
+
+        # For slicing the df
+        index_min = 0
+        index_max = self.batch_size
+
+        # For reference: tqdm version was - would be nice to have an informative progress bar
+        # for i in tqdm(range(num_batches), leave=True, desc='Training in batches...'):
+
+        progressbar = vaex.utils.progressbars(progress)
+
+        # Main loop: pass on batches to the model
+        for i, batch in enumerate(range(num_batches)):
+            # Get data for this batch
+            X = df[index_min:index_max][self.features].values
+            y = df[index_min:index_max][target].values
+
+            # For reference: tqdm version was - would be nice to have an informative progress bar
+            # for j in tqdm(range(num_epochs), leave=False, desc='Iterating over batch...'):
+
+            # Loop over for each epoch
+            for j, epoch in enumerate(range(self.num_epochs)):
+                progressbar((i * self.num_epochs + j) / (num_batches * self.num_epochs))
+                if self.shuffle:
+                    shuffle_index = np.arange(len(X))
+                    np.random.shuffle(shuffle_index)
+                    X = X[shuffle_index]
+                    y = y[shuffle_index]
+
+                # train the model
+                self.model.partial_fit(X, y)
+
+            # update the slicing indices to be ready for the next batch
+            index_min += self.batch_size
+            index_max += self.batch_size
+            index_max = min(N_total, index_max)  # clip upper value
+        progressbar(1.0)


### PR DESCRIPTION
This PR adds a `veax.ml.sklearn.IncrementalPredictor` class that wraps any `scikit-learn` estimator (a.k.a predictor) that has the `.partial_fit` method. 

This means that we can send batches of data from `vaex` to such a predictor, while controlling the memory needed. 

Each batch can be "seen" by the predictor multiple times (epochs), and optionally it can be shuffled.

- [x] Implementation
- [x] Unit-tests
- [ ] Documentation
- [ ] Code review