### PR TITLE
fix(ml.ipynb): fixed a typo in the one hot encoder example

### DIFF
--- a/docs/source/ml.ipynb
+++ b/docs/source/ml.ipynb
@@ -966,7 +966,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "encoder = df.ml_one_hot_encoder([df.col.class_])\n",
+    "encoder = df.ml.one_hot_encoder([df.col.class_])\n",
     "df_encoded = encoder.transform(df)"
    ]
   },


### PR DESCRIPTION
Fixed a typo in the one hot encoder example