### PR TITLE
feat: autogenerate fast api

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -85,6 +85,9 @@ jobs:
       shell: bash
       run: |
         ./ci/04-run-test-suite.sh
+        source activate vaex-dev
+        python -m vaex.ml.spec packages/vaex-ml/vaex/ml/spec_new.json
+        diff packages/vaex-ml/vaex/ml/spec_new.json packages/vaex-ml/vaex/ml/spec.json
     - name: Test notebooks
       if: matrix.os != 'windows-latest'
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@
    * Features
       * Normalize histogram and change selection mode. [#826](https://github.com/vaexio/vaex/pull/826)
 
-## vaex-core 2.0.3 (unreleased)
+## vaex-ml 0.11.0-dev0 (unreleased)
+    * Features
+      * Autogenerate the fast (or functional) API [#512](https://github.com/vaexio/vaex/pull/512)
+
+## vaex-core 2.0.3 (2020-6-10)
    * Performance
       * isin uses hashmaps, leading to a 2x-4x performance increase for primitives, 200x for strings in some cases [#822](https://github.com/vaexio/vaex/pull/822)
 

--- a/packages/vaex-ml/MANIFEST.in
+++ b/packages/vaex-ml/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE.txt
 include vaex/ml/datasets/iris.hdf5
 include vaex/ml/datasets/titanic.hdf5
+include vaex/ml/datasets/titanic.hdf5
+include vaex/ml/spec.json

--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -1,207 +1,16 @@
 import warnings
+import json
+import os
 
 import vaex
-import vaex.dataframe
 from . import datasets
 from .pipeline import Pipeline
-
-from vaex.utils import InnerNamespace
 from vaex.utils import _ensure_strings_from_expressions
 
 
 class DataFrameAccessorML(object):
     def __init__(self, df):
         self.df = df
-
-    def pca(self, n_components=2, features=None, prefix='PCA_', progress=False):
-        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.PCA` and fit it.
-
-        :param n_components: Number of components to retain. If None, all the components will be retained.
-        :param features: List of features to transform.
-        :param prefix: Prefix for the names of the transformed features.
-        :param progress: If True, display a progressbar of the PCA fitting process.
-        '''
-        features = features or self.df.get_column_names()
-        features = _ensure_strings_from_expressions(features)
-        pca = PCA(n_components=n_components, features=features, progress=progress)
-        pca.fit(self.df)
-        return pca
-
-
-    def label_encoder(self, features=None, prefix='label_encoded_', allow_unseen=False):
-        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.LabelEncoder` and fit it.
-
-        :param features: List of features to encode.
-        :param prefix: Prefix for the names of the encoded features.
-        :param allow_unseen: If True, encode unseen value as -1, otherwise an error is raised.
-        '''
-        features = features or self.df.get_column_names()
-        features = _ensure_strings_from_expressions(features)
-        label_encoder = LabelEncoder(features=features, prefix=prefix, allow_unseen=allow_unseen)
-        label_encoder.fit(self.df)
-        return label_encoder
-
-
-    def one_hot_encoder(self, features=None, one=1, zero=0, prefix=''):
-        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.OneHotEncoder` and fit it.
-
-        :param features: List of features to encode.
-        :param one: What value to use instead of "1".
-        :param zero: What value to use instead of "0".
-        :param prefix: Prefix for the names of the encoded features.
-        :returns one_hot_encoder: vaex.ml.transformations.OneHotEncoder object.
-        '''
-        if features is None:
-            raise ValueError('Please give at least one categorical feature.')
-        features = _ensure_strings_from_expressions(features)
-        one_hot_encoder = OneHotEncoder(features=features, one=one, zero=zero, prefix=prefix)
-        one_hot_encoder.fit(self.df)
-        return one_hot_encoder
-
-
-    def frequency_encoder(self, features=None, unseen='nan', prefix='frequency_encoded_'):
-        '''
-        Requires vaex.ml: Create :class:`vaex.ml.transformations.FrequencyEncoder` and fit it.
-
-        :param features: List of features to encode.
-        :param unseen: Strategy to deal with unseen values. Accepted arguments are "zero" or "nan".
-        :param prefix: Prefix for the names of the encoded features.
-        '''
-        features = features or self.df.get_column_names()
-        features = _ensure_strings_from_expressions(features)
-        freq_encoder = FrequencyEncoder(features=features, prefix=prefix)
-        freq_encoder.fit(self.df)
-        return freq_encoder
-
-
-    def standard_scaler(self, features=None, with_mean=True, with_std=True, prefix='standard_scaled_'):
-        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.StandardScaler` and fit it.
-
-        :param features: List of features to scale.
-        :param with_mean: If True, remove the mean from each feature.
-        :param with_std: If True, scale each feature to unit variance.
-        :param prefix: Prefix for the names of the scaled features.
-        '''
-        features = features or self.df.get_column_names()
-        features = _ensure_strings_from_expressions(features)
-        standard_scaler = StandardScaler(features=features, with_mean=with_mean, with_std=with_std, prefix=prefix)
-        standard_scaler.fit(self.df)
-        return standard_scaler
-
-
-    def minmax_scaler(self, features=None, feature_range=[0, 1], prefix='minmax_scaled_'):
-        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.MinMaxScaler` and fit it.
-
-        :param features: List of features to scale.
-        :param feature_range: The range the features are scaled to.
-        :param prefix: Prefix for the names of the scaled features.
-        '''
-        features = features or self.df.get_column_names()
-        features = _ensure_strings_from_expressions(features)
-        minmax_scaler = MinMaxScaler(features=features, feature_range=feature_range, prefix=prefix)
-        minmax_scaler.fit(self.df)
-        return minmax_scaler
-
-    def groupby_transformer(self, by, agg, rprefix='', rsuffix=''):
-        '''Requires vaex.ml: Create :class:`vaex.ml.transformations.GroupByTransformer` and fit it.
-
-        :param by: The feature on which to do the grouping.
-        :param agg: Dict where the keys are feature names and the values are vaex.agg objects.
-        :param rprefix: Prefix for the names of the aggregate features in case of a collision.
-        :param rsuffix: Suffix for the names of the aggregate features in case of a collision.
-        :return vaex.ml.transformations.GroupByTransformer: Fitted GroupByTransformer.
-        '''
-
-        group_trans = GroupByTransformer(by=by, agg=agg, rprefix=rprefix, rsuffix=rsuffix)
-        group_trans.fit(self.df)
-        return group_trans
-
-    def xgboost_model(self, target, features=None, num_boost_round=100, params={}, prediction_name='xgboost_prediction'):
-        '''Requires vaex.ml: create a XGBoost model and train/fit it.
-
-        :param target: The name of the target column.
-        :param features: List of features to use when training the model. If None, all columns except the target will be used as features.
-        :param num_boost_round: Number of boosting rounds.
-        :return vaex.ml.xgboost.XGBoostModel: Fitted XGBoost model.
-        '''
-        from .xgboost import XGBoostModel
-        df = self.df
-        target = _ensure_strings_from_expressions(target)
-        features = features or self.df.get_column_names(virtual=True).remove(target)
-        features = _ensure_strings_from_expressions(features)
-        booster = XGBoostModel(prediction_name=prediction_name,
-                               num_boost_round=num_boost_round,
-                               features=features,
-                               target=target,
-                               params=params)
-        booster.fit(df)
-        return booster
-
-
-    def lightgbm_model(self, target, features=None, num_boost_round=100, copy=False, params={}, prediction_name='lightgbm_prediction'):
-        '''Requires vaex.ml: create a lightgbm model and train/fit it.
-
-        :param target: The name of the target column.
-        :param features: List of features to use when training the model. If None, all columns except the target will be used as features.
-        :param num_boost_round: Number of boosting rounds.
-        :param bool copy: If True Copy the data, otherwise use a more memory efficient data transfer method.
-        :return vaex.ml.lightgbm.LightGBMModel: Fitted LightGBM model.
-        '''
-        from .lightgbm import LightGBMModel
-        dataframe = self.df
-        target = _ensure_strings_from_expressions(target)
-        features = features or self.df.get_column_names(virtual=True).remove(target)
-        features = _ensure_strings_from_expressions(features)
-
-        booster = LightGBMModel(prediction_name=prediction_name,
-                                num_boost_round=num_boost_round,
-                                features=features,
-                                target=target,
-                                params=params)
-        booster.fit(dataframe, copy=copy)
-        return booster
-
-
-    def catboost_model(self, target, features=None, num_boost_round=100, params=None, prediction_name='catboost_prediction'):
-        '''Requires vaex.ml: create a CatBoostModel model and train/fit it.
-
-        :param target: The name of the target column.
-        :param features: List of features to use when training the model. If None, all columns except the target will be used as features.
-        :param num_boost_round: Number of boosting rounds.
-        :return vaex.ml.catboost.CatBoostModel: Fitted CatBoostModel model.
-        '''
-        from .catboost import CatBoostModel
-        dataframe = self.df
-        target = _ensure_strings_from_expressions(target)
-        features = features or self.df.get_column_names(virtual=True).remove(target)
-        features = _ensure_strings_from_expressions(features)
-        booster = CatBoostModel(prediction_name=prediction_name,
-                                num_boost_round=num_boost_round,
-                                features=features,
-                                target=target,
-                                params=params)
-        booster.fit(dataframe)
-        return booster
-
-
-    def pygbm_model(self, label, max_iter, features=None, param={}, classifier=False, prediction_name='pygbm_prediction', **kwargs):
-        '''Requires vaex.ml: create a pygbm model and train/fit it.
-
-        :param label: Label to train/fit on
-        :param max_iter: Max number of iterations/trees
-        :param features: List of features to train on
-        :param bool classifier: If true, return a the classifier (will use argmax on the probabilities)
-        :return vaex.ml.pygbm.PyGBMModel or vaex.ml.pygbm.PyGBMClassifier: Fitted PyGBM model
-        '''
-        from .incubator.pygbm import PyGBMModel, PyGBMClassifier
-        dataframe = self.df
-        features = features or self.df.get_column_names()
-        features = _ensure_strings_from_expressions(features)
-        cls = PyGBMClassifier if classifier else PyGBMModel
-        b = cls(prediction_name=prediction_name, max_iter=max_iter, features=features, param=param, **kwargs)
-        b.fit(dataframe, label)
-        return b
-
 
     def state_transfer(self):
         from .transformations import StateTransfer
@@ -235,6 +44,52 @@ class DataFrameAccessorML(object):
             if initial is not None:
                 df.set_active_range(*initial)
         return train, test
+
+
+filename_spec = os.path.join(os.path.dirname(__file__), 'spec.json')
+
+if os.path.exists(filename_spec):
+    # add DataFrameAccessorML.<snake_name> wrapper methods
+    with open(filename_spec) as f:
+        try:
+            spec = json.load(f)
+        except json.decoder.JSONDecodeError:
+            pass  # we are generating the file probably
+        else:
+            for class_spec in spec:
+                def closure(class_spec=class_spec):
+                    def wrapper(self, features=None, transform=True, **kwargs):
+                        kwargs = kwargs.copy()  # we do modifications, so make a copy
+                        features = features or self.df.get_column_names()
+                        features = _ensure_strings_from_expressions(features)
+                        import importlib
+                        module = importlib.import_module(class_spec['module'])
+                        cls = getattr(module, class_spec['classname'])
+                        if 'target' in kwargs:
+                            kwargs['target'] = str(kwargs['target'])
+
+                        object = cls(features=features, **kwargs)
+                        object.fit(self.df)
+                        if transform:
+                            dft = object.transform(self.df)
+                            return dft
+                        else:
+                            return object
+
+                    # Append trait help strings to the docstring
+                    doc = '\n'
+                    for trait in class_spec['traits']:
+                        doc += f':param {trait["name"]}: {trait["help"]} \n'
+                    doc += ':param transform: If True, return a shallow copy of the transformed DataFrame, otherwise the return fitted transformer. \n'
+                    try:
+                        wrapper.__doc__= class_spec['doc'] + doc
+                    except TypeError:  # unsupported operand type(s) for +: 'NoneType' and 'str'
+                        wrapper.__doc__= doc
+
+                    return wrapper
+                accessor = DataFrameAccessorML
+                name = class_spec['snake_name']
+                setattr(accessor, name, closure())
 
 
 from .transformations import PCA

--- a/packages/vaex-ml/vaex/ml/_version.py
+++ b/packages/vaex-ml/vaex/ml/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.10.0'
-__version_tuple__ = (0, 10, 0)
+__version__ = '0.11.0-dev.0'
+__version_tuple__ = (0, 11, 0, 'dev.0')

--- a/packages/vaex-ml/vaex/ml/catboost.py
+++ b/packages/vaex-ml/vaex/ml/catboost.py
@@ -54,7 +54,7 @@ class CatBoostModel(state.HasState):
     1             6.1            3               4.6            1.4         1  [0.00350424 0.9882139  0.00828186]
     2             6.6            2.9             4.6            1.3         1  [0.00325705 0.98891631 0.00782664]
     '''
-
+    snake_name = "catboost_model"
     features = traitlets.List(traitlets.Unicode(), help='List of features to use when fitting the CatBoostModel.')
     target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
     num_boost_round = traitlets.CInt(default_value=None, allow_none=True, help='Number of boosting iterations.')

--- a/packages/vaex-ml/vaex/ml/generate.py
+++ b/packages/vaex-ml/vaex/ml/generate.py
@@ -13,6 +13,7 @@ registry = []
 
 
 def register(cls):
+    registry.append(cls)
     docstring_args_template = Template("""
 {% for arg in docargs %}
 :param {{ arg.name }}: {{ arg.help }}{% endfor %}

--- a/packages/vaex-ml/vaex/ml/lightgbm.py
+++ b/packages/vaex-ml/vaex/ml/lightgbm.py
@@ -60,7 +60,9 @@ class LightGBMModel(state.HasState):
      1            3               4.6             6.1            1.4         1    [0.00182039 0.98491357 0.01326604]
      2            2.9             4.6             6.6            1.3         1    [2.50915444e-04 9.98431777e-01 1.31730785e-03]
     '''
+    snake_name = 'lightgbm_model'
     features = traitlets.List(traitlets.Unicode(), help='List of features to use when fitting the LightGBMModel.')
+    copy = traitlets.Bool(False, help='Copy data or use the modified xgboost library for efficient transfer.')
     target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
     num_boost_round = traitlets.CInt(help='Number of boosting iterations.')
     params = traitlets.Dict(help='parameters to be passed on the to the LightGBM model.')

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -51,7 +51,7 @@ class Predictor(state.HasState):
      1             6.1            3               4.6            1.4         1  1.56469
      2             6.6            2.9             4.6            1.3         1  1.44276
     '''
-
+    snake_name = 'sklearn_predictor'
     model = traitlets.Any(default_value=None, allow_none=True, help='A scikit-learn estimator.').tag(**serialize_pickle)
     features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
     target = traitlets.Unicode(allow_none=False, help='The name of the target column.')

--- a/packages/vaex-ml/vaex/ml/spec.json
+++ b/packages/vaex-ml/vaex/ml/spec.json
@@ -1,0 +1,920 @@
+[
+    {
+        "classname": "PCA",
+        "doc": "Transform a set of features using a Principal Component Analysis.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10])\n    >>> df\n     #   x   y\n     0   2   -2\n     1   5   3\n     2   7   0\n     3   2   0\n     4   15  10\n    >>> pca = vaex.ml.PCA(n_components=2, features=['x', 'y'])\n    >>> pca.fit_transform(df)\n     #    x    y       PCA_0      PCA_1\n     0    2   -2    5.92532    0.413011\n     1    5    3    0.380494  -1.39112\n     2    7    0    0.840049   2.18502\n     3    2    0    4.61287   -1.09612\n     4   15   10  -11.7587    -0.110794\n\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "pca",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The eigen values that correspond to each feature.",
+                "name": "eigen_values_",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The eigen vectors corresponding to each feature",
+                "name": "eigen_vectors_",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The mean of each feature",
+                "name": "means_",
+                "type": "List"
+            },
+            {
+                "default": 0,
+                "has_default": false,
+                "help": "Number of components to retain. If None, all the components will be retained.",
+                "name": "n_components",
+                "type": "Int"
+            },
+            {
+                "default": "PCA_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": false,
+                "has_default": false,
+                "help": "If True, display a progressbar of the PCA fitting process.",
+                "name": "progress",
+                "type": "CBool"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "LabelEncoder",
+        "doc": "Encode categorical columns with integer values between 0 and num_classes-1.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(color=['red', 'green', 'green', 'blue', 'red'])\n    >>> df\n     #  color\n     0  red\n     1  green\n     2  green\n     3  blue\n     4  red\n    >>> encoder = vaex.ml.LabelEncoder(features=['color'])\n    >>> encoder.fit_transform(df)\n     #  color      label_encoded_color\n     0  red                          2\n     1  green                        1\n     2  green                        1\n     3  blue                         0\n     4  red                          2\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "label_encoder",
+        "traits": [
+            {
+                "default": false,
+                "has_default": false,
+                "help": "If True, unseen values will be                                   encoded with -1, otherwise an error is raised",
+                "name": "allow_unseen",
+                "type": "Bool"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The encoded labels of each feature.",
+                "name": "labels_",
+                "type": "Dict"
+            },
+            {
+                "default": "label_encoded_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "OneHotEncoder",
+        "doc": "Encode categorical columns according ot the One-Hot scheme.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(color=['red', 'green', 'green', 'blue', 'red'])\n    >>> df\n     #  color\n     0  red\n     1  green\n     2  green\n     3  blue\n     4  red\n    >>> encoder = vaex.ml.OneHotEncoder(features=['color'])\n    >>> encoder.fit_transform(df)\n     #  color      color_blue    color_green    color_red\n     0  red                 0              0            1\n     1  green               0              1            0\n     2  green               0              1            0\n     3  blue                1              0            0\n     4  red                 0              0            1\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "one_hot_encoder",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": 1,
+                "has_default": false,
+                "help": "Value to encode when a category is present.",
+                "name": "one",
+                "type": "Any"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The unique elements found in each feature.",
+                "name": "uniques_",
+                "type": "List"
+            },
+            {
+                "default": 0,
+                "has_default": false,
+                "help": "Value to encode when category is absent.",
+                "name": "zero",
+                "type": "Any"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "FrequencyEncoder",
+        "doc": "Encode categorical columns by the frequency of their respective samples.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(color=['red', 'green', 'green', 'blue', 'red', 'green'])\n    >>> df\n     #  color\n     0  red\n     1  green\n     2  green\n     3  blue\n     4  red\n    >>> encoder = vaex.ml.FrequencyEncoder(features=['color'])\n    >>> encoder.fit_transform(df)\n     #  color      frequency_encoded_color\n     0  red                       0.333333\n     1  green                     0.5\n     2  green                     0.5\n     3  blue                      0.166667\n     4  red                       0.333333\n     5  green                     0.5\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "frequency_encoder",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "",
+                "name": "mappings_",
+                "type": "Dict"
+            },
+            {
+                "default": "frequency_encoded_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": "nan",
+                "has_default": false,
+                "help": "Strategy to deal with unseen values.",
+                "name": "unseen",
+                "type": "Enum"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "StandardScaler",
+        "doc": "Standardize features by removing thir mean and scaling them to unit variance.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10])\n    >>> df\n     #    x    y\n     0    2   -2\n     1    5    3\n     2    7    0\n     3    2    0\n     4   15   10\n    >>> scaler = vaex.ml.StandardScaler(features=['x', 'y'])\n    >>> scaler.fit_transform(df)\n     #    x    y    standard_scaled_x    standard_scaled_y\n     0    2   -2            -0.876523            -0.996616\n     1    5    3            -0.250435             0.189832\n     2    7    0             0.166957            -0.522037\n     3    2    0            -0.876523            -0.522037\n     4   15   10             1.83652              1.85086\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "standard_scaler",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The mean of each feature",
+                "name": "mean_",
+                "type": "List"
+            },
+            {
+                "default": "standard_scaled_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The standard deviation of each feature.",
+                "name": "std_",
+                "type": "List"
+            },
+            {
+                "default": true,
+                "has_default": false,
+                "help": "If True, remove the mean from each feature.",
+                "name": "with_mean",
+                "type": "CBool"
+            },
+            {
+                "default": true,
+                "has_default": false,
+                "help": "If True, scale each feature to unit variance.",
+                "name": "with_std",
+                "type": "CBool"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "MinMaxScaler",
+        "doc": "Will scale a set of features to a given range.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10])\n    >>> df\n     #    x    y\n     0    2   -2\n     1    5    3\n     2    7    0\n     3    2    0\n     4   15   10\n    >>> scaler = vaex.ml.MinMaxScaler(features=['x', 'y'])\n    >>> scaler.fit_transform(df)\n     #    x    y    minmax_scaled_x    minmax_scaled_y\n     0    2   -2           0                  0\n     1    5    3           0.230769           0.416667\n     2    7    0           0.384615           0.166667\n     3    2    0           0                  0.166667\n     4   15   10           1                  1\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "minmax_scaler",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The range the features are scaled to.",
+                "name": "feature_range",
+                "type": "Tuple"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The minimum value of a feature.",
+                "name": "fmax_",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The maximum value of a feature.",
+                "name": "fmin_",
+                "type": "List"
+            },
+            {
+                "default": "minmax_scaled_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "MaxAbsScaler",
+        "doc": " Scale features by their maximum absolute value.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10])\n    >>> df\n     #    x    y\n     0    2   -2\n     1    5    3\n     2    7    0\n     3    2    0\n     4   15   10\n    >>> scaler = vaex.ml.MaxAbsScaler(features=['x', 'y'])\n    >>> scaler.fit_transform(df)\n     #    x    y    absmax_scaled_x    absmax_scaled_y\n     0    2   -2           0.133333               -0.2\n     1    5    3           0.333333                0.3\n     2    7    0           0.466667                0\n     3    2    0           0.133333                0\n     4   15   10           1                       1\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "max_abs_scaler",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "Tha maximum absolute value of a feature.",
+                "name": "absmax_",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": "absmax_scaled_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "RobustScaler",
+        "doc": " The RobustScaler removes the median and scales the data according to a\n    given percentile range. By default, the scaling is done between the 25th and\n    the 75th percentile. Centering and scaling happens independently for each\n    feature (column).\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10])\n    >>> df\n     #    x    y\n     0    2   -2\n     1    5    3\n     2    7    0\n     3    2    0\n     4   15   10\n    >>> scaler = vaex.ml.MaxAbsScaler(features=['x', 'y'])\n    >>> scaler.fit_transform(df)\n     #    x    y    robust_scaled_x    robust_scaled_y\n     0    2   -2       -0.333686             -0.266302\n     1    5    3       -0.000596934           0.399453\n     2    7    0        0.221462              0\n     3    2    0       -0.333686              0\n     4   15   10        1.1097                1.33151\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "robust_scaler",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The median of each feature.",
+                "name": "center_",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The percentile range to which to scale each feature to.",
+                "name": "percentile_range",
+                "type": "Tuple"
+            },
+            {
+                "default": "robust_scaled_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The percentile range for each feature.",
+                "name": "scale_",
+                "type": "List"
+            },
+            {
+                "default": true,
+                "has_default": false,
+                "help": "If True, remove the median.",
+                "name": "with_centering",
+                "type": "CBool"
+            },
+            {
+                "default": true,
+                "has_default": false,
+                "help": "If True, scale each feature between the specified percentile range.",
+                "name": "with_scaling",
+                "type": "CBool"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "CycleTransformer",
+        "doc": "A strategy for transforming cyclical features (e.g. angles, time).\n\n    Think of each feature as an angle of a unit circle in polar coordinates,\n    and then and then obtaining the x and y coordinate projections,\n    or the cos and sin components respectively.\n\n    Suitable for a variaty of machine learning tasks.\n    It preserves the cyclical continuity of the feature.\n    Inspired by: http://blog.davidkaleko.com/feature-engineering-cyclical-features.html\n    >>> df = vaex.from_arrays(days=[0, 1, 2, 3, 4, 5, 6])\n    >>> cyctrans = vaex.ml.CycleTransformer(n=7, features=['days'])\n    >>> cyctrans.fit_transform(df)\n      #    days     days_x     days_y\n      0       0   1          0\n      1       1   0.62349    0.781831\n      2       2  -0.222521   0.974928\n      3       3  -0.900969   0.433884\n      4       4  -0.900969  -0.433884\n      5       5  -0.222521  -0.974928\n      6       6   0.62349   -0.781831\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "cycle_transformer",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": 0,
+                "has_default": false,
+                "help": "The number of elements in one cycle.",
+                "name": "n",
+                "type": "CInt"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "Prefix for the x-component of the transformed features.",
+                "name": "prefix_x",
+                "type": "Unicode"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "Prefix for the y-component of the transformed features.",
+                "name": "prefix_y",
+                "type": "Unicode"
+            },
+            {
+                "default": "_x",
+                "has_default": false,
+                "help": "Suffix for the x-component of the transformed features.",
+                "name": "suffix_x",
+                "type": "Unicode"
+            },
+            {
+                "default": "_y",
+                "has_default": false,
+                "help": "Suffix for the y-component of the transformed features.",
+                "name": "suffix_y",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "BayesianTargetEncoder",
+        "doc": "Encode categorical variables with a Bayesian Target Encoder.\n\n    The categories are encoded by the mean of their target value,\n    which is adjusted by the global mean value of the target variable\n    using a Bayesian schema. For a larger `weight` value, the target\n    encodings are smoothed toward the global mean, while for a\n    `weight` of 0, the encodings are just the mean target value per\n    class.\n\n    Reference: https://www.wikiwand.com/en/Bayes_estimator#/Practical_example_of_Bayes_estimators\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml\n    >>> df = vaex.from_arrays(x=['a', 'a', 'a', 'a', 'b', 'b', 'b', 'b'],\n    ...                       y=[1, 1, 1, 0, 0, 0, 0, 1])\n    >>> target_encoder = vaex.ml.BayesianTargetEncoder(features=['x'], weight=4)\n    >>> target_encoder.fit_transform(df, 'y')\n      #  x      y    mean_encoded_x\n      0  a      1             0.625\n      1  a      1             0.625\n      2  a      1             0.625\n      3  a      0             0.625\n      4  b      0             0.375\n      5  b      0             0.375\n      6  b      0             0.375\n      7  b      1             0.375\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "bayesian_target_encoder",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "",
+                "name": "mappings_",
+                "type": "Dict"
+            },
+            {
+                "default": "mean_encoded_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The name of the column containing the target variable.",
+                "name": "target",
+                "type": "Unicode"
+            },
+            {
+                "default": "nan",
+                "has_default": false,
+                "help": "Strategy to deal with unseen values.",
+                "name": "unseen",
+                "type": "Enum"
+            },
+            {
+                "default": 100,
+                "has_default": false,
+                "help": "Weight to be applied to the mean encodings (smoothing parameter).",
+                "name": "weight",
+                "type": "CFloat"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "WeightOfEvidenceEncoder",
+        "doc": "Encode categorical variables with a Weight of Evidence Encoder.\n\n    Weight of Evidence measures how well a particular feature supports\n    the given hypothesis (i.e. the target variable). With this\n    encoder, each category in a categorical feature is encoded by its\n    \"strength\" i.e. Weight of Evidence value. The target feature can be\n    a boolean or numerical column, where True/1 is seen as 'Good', and\n    False/0 is seen as 'Bad'\n\n    Reference: https://www.listendata.com/2015/03/weight-of-evidence-woe-and-information.html\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml\n    >>> df = vaex.from_arrays(x=['a', 'a', 'b', 'b', 'b', 'c', 'c'],\n    ...                       y=[1, 1, 0, 0, 1, 1, 0])\n    >>> woe_encoder = vaex.ml.WeightOfEvidenceEncoder(target='y', features=['x'])\n    >>> woe_encoder.fit_transform(df)\n      #  x      y    mean_encoded_x\n      0  a      1         13.8155\n      1  a      1         13.8155\n      2  b      0         -0.693147\n      3  b      0         -0.693147\n      4  b      1         -0.693147\n      5  c      1          0\n      6  c      0          0\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "weight_of_evidence_encoder",
+        "traits": [
+            {
+                "default": 1e-06,
+                "has_default": false,
+                "help": "Small value taken as minimum fot the negatives, to avoid a division by zero",
+                "name": "epsilon",
+                "type": "Float"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "",
+                "name": "mappings_",
+                "type": "Dict"
+            },
+            {
+                "default": "woe_encoded_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The name of the column containing the target variable.",
+                "name": "target",
+                "type": "Unicode"
+            },
+            {
+                "default": "nan",
+                "has_default": false,
+                "help": "Strategy to deal with unseen values.",
+                "name": "unseen",
+                "type": "Enum"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "KBinsDiscretizer",
+        "doc": "Bin continous features into discrete bins.\n\n    A stretegy to encode continuous features into discrete bins. The transformed\n    columns contain the bin label each sample falls into. In a way this\n    transformer Label/Ordinal encodes continous features.\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml\n    >>> df = vaex.from_arrays(x=[0, 2.5, 5, 7.5, 10, 12.5, 15])\n    >>> bin_trans = vaex.ml.KBinsDiscretizer(features=['x'], n_bins=3, strategy='uniform')\n    >>> bin_trans.fit_transform(df)\n      #     x    binned_x\n      0   0             0\n      1   2.5           0\n      2   5             1\n      3   7.5           1\n      4  10             2\n      5  12.5           2\n      6  15             2\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "kbins_discretizer",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The bin edges for each binned feature",
+                "name": "bin_edges_",
+                "type": "Dict"
+            },
+            {
+                "default": 1e-08,
+                "has_default": false,
+                "help": "Tiny value added to the bin edges ensuring samples close to the bin edges are binned correcly.",
+                "name": "epsilon",
+                "type": "Float"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": 5,
+                "has_default": false,
+                "help": "Number of bins. Must be greater than 1.",
+                "name": "n_bins",
+                "type": "Int"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "Number of bins per feature.",
+                "name": "n_bins_",
+                "type": "Dict"
+            },
+            {
+                "default": "binned_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": "uniform",
+                "has_default": false,
+                "help": "Strategy used to define the widths of the bins.",
+                "name": "strategy",
+                "type": "Enum"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "GroupByTransformer",
+        "doc": "The GroupByTransformer creates aggregations via the groupby operation, which are\n    joined to a DataFrame. This is useful for creating aggregate features.\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml\n    >>> df_train = vaex.from_arrays(x=['dog', 'dog', 'dog', 'cat', 'cat'], y=[2, 3, 4, 10, 20])\n    >>> df_test = vaex.from_arrays(x=['dog', 'cat', 'dog', 'mouse'], y=[5, 5, 5, 5])\n    >>> group_trans = vaex.ml.GroupByTransformer(by='x', agg={'mean_y': vaex.agg.mean('y')}, rsuffix='_agg')\n    >>> group_trans.fit_transform(df_train)\n      #  x      y  x_agg      mean_y\n      0  dog    2  dog             3\n      1  dog    3  dog             3\n      2  dog    4  dog             3\n      3  cat   10  cat            15\n      4  cat   20  cat            15\n    >>> group_trans.transform(df_test)\n      #  x        y  x_agg    mean_y\n      0  dog      5  dog      3.0\n      1  cat      5  cat      15.0\n      2  dog      5  dog      3.0\n      3  mouse    5  --       --\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "groupby_transformer",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "Dict where the keys are feature names and the values are vaex.agg objects.",
+                "name": "agg",
+                "type": "Dict"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The feature on which to do the grouping.",
+                "name": "by",
+                "type": "Unicode"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "",
+                "name": "df_group_",
+                "type": "Instance"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "Prefix for the names of the aggregate features in case of a collision.",
+                "name": "rprefix",
+                "type": "Unicode"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "Suffix for the names of the aggregate features in case of a collision.",
+                "name": "rsuffix",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "Predictor",
+        "doc": "This class wraps any scikit-learn estimator (a.k.a predictor) making it a vaex pipeline object.\n\n    By wrapping any scikit-learn estimators with this class, it becomes a vaex\n    pipeline object. Thus, it can take full advantage of the serialization and\n    pipeline system of vaex. One can use the `predict` method to get a numpy\n    array as an output of a fitted estimator, or the `transform` method do add\n    such a prediction to a vaex DataFrame as a virtual column.\n\n    Note that a full memory copy of the data used is created when the `fit` and\n    `predict` are called. The `transform` method is evaluated lazily.\n\n    The scikit-learn estimators themselves are not modified at all, they are\n    taken from your local installation of scikit-learn.\n\n    Example:\n\n    >>> import vaex.ml\n    >>> from vaex.ml.sklearn import Predictor\n    >>> from sklearn.linear_model import LinearRegression\n    >>> df = vaex.ml.datasets.load_iris()\n    >>> features = ['sepal_width', 'petal_length', 'sepal_length']\n    >>> df_train, df_test = df.ml.train_test_split()\n    >>> model = Predictor(model=LinearRegression(), features=features, target='petal_width', prediction_name='pred')\n    >>> model.fit(df_train)\n    >>> df_train = model.transform(df_train)\n    >>> df_train.head(3)\n     #    sepal_length    sepal_width    petal_length    petal_width    class_      pred\n     0             5.4            3               4.5            1.5         1  1.64701\n     1             4.8            3.4             1.6            0.2         0  0.352236\n     2             6.9            3.1             4.9            1.5         1  1.59336\n    >>> df_test = model.transform(df_test)\n    >>> df_test.head(3)\n     #    sepal_length    sepal_width    petal_length    petal_width    class_     pred\n     0             5.9            3               4.2            1.5         1  1.39437\n     1             6.1            3               4.6            1.4         1  1.56469\n     2             6.6            2.9             4.6            1.3         1  1.44276\n    ",
+        "module": "vaex.ml.sklearn",
+        "snake_name": "sklearn_predictor",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to use.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": false,
+                "help": "A scikit-learn estimator.",
+                "name": "model",
+                "type": "Any"
+            },
+            {
+                "default": "prediction",
+                "has_default": false,
+                "help": "The name of the virtual column housing the predictions.",
+                "name": "prediction_name",
+                "type": "Unicode"
+            },
+            {
+                "default": "predict",
+                "has_default": false,
+                "help": "Which method to use to get the predictions.                                      Can be \"predict\", \"predict_proba\" or \"predict_log_proba\".",
+                "name": "prediction_type",
+                "type": "Enum"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The name of the target column.",
+                "name": "target",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "IncrementalPredictor",
+        "doc": "This class wraps any scikit-learn estimator (a.k.a predictions) that has\n    a `.partial_fit` method, and makes it a vaex pipeline object.\n\n    By wrapping \"on-line\" scikit-learn estimators with this class, they become a vaex\n    pipeline object. Thus, they can take full advantage of the serialization and\n    pipeline system of vaex. While the underlying estimator need to call the\n    `.partial_fit` method, this class contains the standard `.fit` method, and\n    the rest happens behind the scenes. One can also iterate over the data\n    multiple times (epochs), and optionally shuffle each batch before it is sent\n    to the estimator. The `predict` method returns a numpy array, while the `transform`\n    method adds the prediction as a virtual column to a vaex DataFrame.\n\n    Note: the `.fit` method will use as much memory as needed to copy one\n    batch of data, while the `.predict` method will require as much memory as\n    needed to output the predictions as a numpy array. The `transform` method is\n    evaluated lazily, and no memory copies are made.\n\n    Note: we are using normal sklearn without modifications here.\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml\n    >>> from vaex.ml.sklearn import IncrementalPredictor\n    >>> from sklearn.linear_model import SGDRegressor\n    >>>\n    >>> df = vaex.example()\n    >>>\n    >>> features = df.column_names[:6]\n    >>> target = 'FeH'\n    >>>\n    >>> standard_scaler = vaex.ml.StandardScaler(features=features)\n    >>> df = standard_scaler.fit_transform(df)\n    >>>\n    >>> features = df.get_column_names(regex='^standard')\n    >>> model = SGDRegressor(learning_rate='constant', eta0=0.01, random_state=42)\n    >>>\n    >>> incremental = IncrementalPredictor(model=model,\n    ...                                    features=features,\n    ...                                    target=target,\n    ...                                    batch_size=10_000,\n    ...                                    num_epochs=3,\n    ...                                    shuffle=True,\n    ...                                    prediction_name='pred_FeH')\n    >>> incremental.fit(df=df)\n    >>> df = incremental.transform(df)\n    >>> df.head(5)[['FeH', 'pred_FeH']]\n      #        FeH    pred_FeH\n      0  -2.30923     -1.66226\n      1  -1.78874     -1.68218\n      2  -0.761811    -1.59562\n      3  -1.52088     -1.62225\n      4  -2.65534     -1.61991\n    ",
+        "module": "vaex.ml.sklearn",
+        "snake_name": "incremental_predictor",
+        "traits": [
+            {
+                "default": 1000000,
+                "has_default": false,
+                "help": "Number of samples to be sent to the model in each batch.",
+                "name": "batch_size",
+                "type": "Int"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to use.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": false,
+                "help": "A scikit-learn estimator with a `.fit_predict` method.",
+                "name": "model",
+                "type": "Any"
+            },
+            {
+                "default": 1,
+                "has_default": false,
+                "help": "Number of times each batch is sent to the model.",
+                "name": "num_epochs",
+                "type": "Int"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "A dictionary of key word arguments to be passed on to the `fit_predict` method of the `model`.",
+                "name": "partial_fit_kwargs",
+                "type": "Dict"
+            },
+            {
+                "default": "prediction",
+                "has_default": false,
+                "help": "The name of the virtual column housing the predictions.",
+                "name": "prediction_name",
+                "type": "Unicode"
+            },
+            {
+                "default": "predict",
+                "has_default": false,
+                "help": "Which method to use to get the predictions.                                      Can be \"predict\", \"predict_proba\" or \"predict_log_proba\".",
+                "name": "prediction_type",
+                "type": "Enum"
+            },
+            {
+                "default": false,
+                "has_default": false,
+                "help": "If True, shuffle the samples before sending them to the model.",
+                "name": "shuffle",
+                "type": "Bool"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The name of the target column.",
+                "name": "target",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "CatBoostModel",
+        "doc": "The CatBoost algorithm.\n\n    This class provides an interface to the CatBoost aloritham.\n    CatBoost is a fast, scalable, high performance Gradient Boosting on\n    Decision Trees library, used for ranking, classification, regression and\n    other machine learning tasks. For more information please visit\n    https://github.com/catboost/catboost\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml.catboost\n    >>> df = vaex.ml.datasets.load_iris()\n    >>> features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']\n    >>> df_train, df_test = df.ml.train_test_split()\n    >>> params = {\n        'leaf_estimation_method': 'Gradient',\n        'learning_rate': 0.1,\n        'max_depth': 3,\n        'bootstrap_type': 'Bernoulli',\n        'objective': 'MultiClass',\n        'eval_metric': 'MultiClass',\n        'subsample': 0.8,\n        'random_state': 42,\n        'verbose': 0}\n    >>> booster = vaex.ml.catboost.CatBoostModel(features=features, target='class_', num_boost_round=100, params=params)\n    >>> booster.fit(df_train)\n    >>> df_train = booster.transform(df_train)\n    >>> df_train.head(3)\n    #    sepal_length    sepal_width    petal_length    petal_width    class_  catboost_prediction\n    0             5.4            3               4.5            1.5         1  [0.00615039 0.98024259 0.01360702]\n    1             4.8            3.4             1.6            0.2         0  [0.99034267 0.00526382 0.0043935 ]\n    2             6.9            3.1             4.9            1.5         1  [0.00688241 0.95190908 0.04120851]\n    >>> df_test = booster.transform(df_test)\n    >>> df_test.head(3)\n    #    sepal_length    sepal_width    petal_length    petal_width    class_  catboost_prediction\n    0             5.9            3               4.2            1.5         1  [0.00464228 0.98883351 0.00652421]\n    1             6.1            3               4.6            1.4         1  [0.00350424 0.9882139  0.00828186]\n    2             6.6            2.9             4.6            1.3         1  [0.00325705 0.98891631 0.00782664]\n    ",
+        "module": "vaex.ml.catboost",
+        "snake_name": "catboost_model",
+        "traits": [
+            {
+                "default": null,
+                "has_default": false,
+                "help": "If provided, will train in batches of this size.",
+                "name": "batch_size",
+                "type": "CInt"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "Weights to sum models at the end of training in batches.",
+                "name": "batch_weights",
+                "type": "List"
+            },
+            {
+                "default": "IntersectingCountersAverage",
+                "has_default": false,
+                "help": "Strategy for summing up models. Only used when training in batches. See the CatBoost documentation for more info.",
+                "name": "ctr_merge_policy",
+                "type": "Enum"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "Evaluation results",
+                "name": "evals_result_",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to use when fitting the CatBoostModel.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": false,
+                "help": "Number of boosting iterations.",
+                "name": "num_boost_round",
+                "type": "CInt"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "A dictionary of parameters to be passed on to the CatBoostModel model.",
+                "name": "params",
+                "type": "Dict"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "A dictionary of parameters to be passed to the Pool data object construction",
+                "name": "pool_params",
+                "type": "Dict"
+            },
+            {
+                "default": "catboost_prediction",
+                "has_default": false,
+                "help": "The name of the virtual column housing the predictions.",
+                "name": "prediction_name",
+                "type": "Unicode"
+            },
+            {
+                "default": "Probability",
+                "has_default": false,
+                "help": "The form of the predictions. Can be \"RawFormulaVal\", \"Probability\" or \"Class\".",
+                "name": "prediction_type",
+                "type": "Enum"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The name of the target column.",
+                "name": "target",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "LightGBMModel",
+        "doc": "The LightGBM algorithm.\n\n    This class provides an interface to the LightGBM algorithm, with some optimizations\n    for better memory efficiency when training large datasets. The algorithm itself is\n    not modified at all.\n\n    LightGBM is a fast gradient boosting algorithm based on decision trees and is\n    mainly used for classification, regression and ranking tasks. It is under the\n    umbrella of the Distributed Machine Learning Toolkit (DMTK) project of Microsoft.\n    For more information, please visit https://github.com/Microsoft/LightGBM/.\n\n    Example:\n\n    >>> import vaex.ml\n    >>> import vaex.ml.lightgbm\n    >>> df = vaex.ml.datasets.load_iris()\n    >>> features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']\n    >>> df_train, df_test = df.ml.train_test_split()\n    >>> params = {\n        'boosting': 'gbdt',\n        'max_depth': 5,\n        'learning_rate': 0.1,\n        'application': 'multiclass',\n        'num_class': 3,\n        'subsample': 0.80,\n        'colsample_bytree': 0.80}\n    >>> booster = vaex.ml.lightgbm.LightGBMModel(features=features, target='class_', num_boost_round=100, params=params)\n    >>> booster.fit(df_train)\n    >>> df_train = booster.transform(df_train)\n    >>> df_train.head(3)\n     #    sepal_width    petal_length    sepal_length    petal_width    class_    lightgbm_prediction\n     0            3               4.5             5.4            1.5         1    [0.00165619 0.98097899 0.01736482]\n     1            3.4             1.6             4.8            0.2         0    [9.99803930e-01 1.17346471e-04 7.87235133e-05]\n     2            3.1             4.9             6.9            1.5         1    [0.00107541 0.9848717  0.01405289]\n    >>> df_test = booster.transform(df_test)\n    >>> df_test.head(3)\n     #    sepal_width    petal_length    sepal_length    petal_width    class_    lightgbm_prediction\n     0            3               4.2             5.9            1.5         1    [0.00208904 0.9821348  0.01577616]\n     1            3               4.6             6.1            1.4         1    [0.00182039 0.98491357 0.01326604]\n     2            2.9             4.6             6.6            1.3         1    [2.50915444e-04 9.98431777e-01 1.31730785e-03]\n    ",
+        "module": "vaex.ml.lightgbm",
+        "snake_name": "lightgbm_model",
+        "traits": [
+            {
+                "default": false,
+                "has_default": false,
+                "help": "Copy data or use the modified xgboost library for efficient transfer.",
+                "name": "copy",
+                "type": "Bool"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to use when fitting the LightGBMModel.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": 0,
+                "has_default": false,
+                "help": "Number of boosting iterations.",
+                "name": "num_boost_round",
+                "type": "CInt"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "parameters to be passed on the to the LightGBM model.",
+                "name": "params",
+                "type": "Dict"
+            },
+            {
+                "default": "lightgbm_prediction",
+                "has_default": false,
+                "help": "The name of the virtual column housing the predictions.",
+                "name": "prediction_name",
+                "type": "Unicode"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The name of the target column.",
+                "name": "target",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "XGBoostModel",
+        "doc": "The XGBoost algorithm.\n\n    XGBoost is an optimized distributed gradient boosting library designed to be\n    highly efficient, flexible and portable. It implements machine learning\n    algorithms under the Gradient Boosting framework. XGBoost provides a parallel\n    tree boosting (also known as GBDT, GBM) that solves many data science\n    problems in a fast and accurate way.\n    (https://github.com/dmlc/xgboost)\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml.xgboost\n    >>> df = vaex.ml.datasets.load_iris()\n    >>> features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']\n    >>> df_train, df_test = df.ml.train_test_split()\n    >>> params = {\n        'max_depth': 5,\n        'learning_rate': 0.1,\n        'objective': 'multi:softmax',\n        'num_class': 3,\n        'subsample': 0.80,\n        'colsample_bytree': 0.80,\n        'silent': 1}\n    >>> booster = vaex.ml.xgboost.XGBoostModel(features=features, target='class_', num_boost_round=100, params=params)\n    >>> booster.fit(df_train)\n    >>> df_train = booster.transform(df_train)\n    >>> df_train.head(3)\n    #    sepal_length    sepal_width    petal_length    petal_width    class_    xgboost_prediction\n    0             5.4            3               4.5            1.5         1                     1\n    1             4.8            3.4             1.6            0.2         0                     0\n    2             6.9            3.1             4.9            1.5         1                     1\n    >>> df_test = booster.transform(df_test)\n    >>> df_test.head(3)\n    #    sepal_length    sepal_width    petal_length    petal_width    class_    xgboost_prediction\n    0             5.9            3               4.2            1.5         1                     1\n    1             6.1            3               4.6            1.4         1                     1\n    2             6.6            2.9             4.6            1.3         1                     1\n    ",
+        "module": "vaex.ml.xgboost",
+        "snake_name": "xgboost_model",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to use when fitting the XGBoostModel.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": 0,
+                "has_default": false,
+                "help": "Number of boosting iterations.",
+                "name": "num_boost_round",
+                "type": "CInt"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "A dictionary of parameters to be passed on to the XGBoost model.",
+                "name": "params",
+                "type": "Dict"
+            },
+            {
+                "default": "xgboost_prediction",
+                "has_default": false,
+                "help": "The name of the virtual column housing the predictions.",
+                "name": "prediction_name",
+                "type": "Unicode"
+            },
+            {
+                "default": "",
+                "has_default": false,
+                "help": "The name of the target column.",
+                "name": "target",
+                "type": "Unicode"
+            }
+        ],
+        "version": "1.0.0"
+    }
+]

--- a/packages/vaex-ml/vaex/ml/spec.py
+++ b/packages/vaex-ml/vaex/ml/spec.py
@@ -1,0 +1,58 @@
+import json
+import os
+import sys
+
+import traitlets
+
+from . import sklearn
+from . import generate
+from . import catboost
+from . import lightgbm
+from . import xgboost
+
+
+def lmap(f, values):
+    return list(map(f, values))
+
+
+def lmapstar(f, values):
+    return [f(*k) for k in values]
+
+
+def to_trait(name, trait):
+    return dict(
+        name=name,
+        has_default=trait.default_value is traitlets.Undefined,
+        default=None
+        if trait.default_value is traitlets.Undefined
+        else trait.default_value,
+        type=str(type(trait).__name__),
+        help=trait.help,
+    )
+
+
+def to_cls(cls):
+    return dict(
+        classname=cls.__name__,
+        snake_name=cls.__dict__.get(
+            "snake_name", generate.camel_to_underscore(cls.__name__)
+        ),
+        version=cls.__dict__.get("_version", "1.0.0"),
+        module=cls.__module__,
+        traits=lmapstar(to_trait, cls.class_traits().items()),
+        doc=cls.__doc__
+    )
+
+
+def main(args=sys.argv):
+    spec = lmap(to_cls, generate.registry)
+    json_data = json.dumps(spec, indent=4, sort_keys=True)
+    path = os.path.join(os.path.dirname(__file__), "spec.json")
+    if len(sys.argv) > 1:
+        path = sys.argv[1]
+    with open(path, "w") as f:
+        f.write(json_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -404,6 +404,7 @@ class MinMaxScaler(Transformer):
      3    2    0           0                  0.166667
      4   15   10           1                  1
     '''
+    snake_name = 'minmax_scaler'
     # title = Unicode(default_value='MinMax Scaler', read_only=True).tag(ui='HTML')
     feature_range = traitlets.Tuple(default_value=(0, 1), help='The range the features are scaled to.').tag().tag(ui='FloatRangeSlider')
     prefix = traitlets.Unicode(default_value="minmax_scaled_", help=help_prefix).tag(ui='Text')
@@ -816,6 +817,7 @@ class KBinsDiscretizer(Transformer):
       5  12.5           2
       6  15             2
     '''
+    snake_name = 'kbins_discretizer'
     n_bins = traitlets.Int(allow_none=False, default_value=5, help='Number of bins. Must be greater than 1.')
     strategy = traitlets.Enum(values=['uniform', 'quantile', 'kmeans'], default_value='uniform', help='Strategy used to define the widths of the bins.')
     prefix = traitlets.Unicode(default_value='binned_', help=help_prefix)
@@ -944,6 +946,7 @@ class GroupByTransformer(Transformer):
       3  mouse    5  --       --
     '''
 
+    snake_name = 'groupby_transformer'
     by = traitlets.Unicode(allow_none=False, help='The feature on which to do the grouping.')
     agg = traitlets.Dict(help='Dict where the keys are feature names and the values are vaex.agg objects.')
     rprefix = traitlets.Unicode(default_value='', help='Prefix for the names of the aggregate features in case of a collision.')

--- a/packages/vaex-ml/vaex/ml/xgboost.py
+++ b/packages/vaex-ml/vaex/ml/xgboost.py
@@ -54,7 +54,7 @@ class XGBoostModel(state.HasState):
     1             6.1            3               4.6            1.4         1                     1
     2             6.6            2.9             4.6            1.3         1                     1
     '''
-
+    snake_name = 'xgboost_model'
     features = traitlets.List(traitlets.Unicode(), help='List of features to use when fitting the XGBoostModel.')
     target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
     num_boost_round = traitlets.CInt(help='Number of boosting iterations.')

--- a/tests/ml/catboost_test.py
+++ b/tests/ml/catboost_test.py
@@ -129,12 +129,12 @@ def test_lightgbm_serialize(tmpdir):
     features = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width']
     target = 'class_'
 
-    gbm = ds.ml.catboost_model(target, features=features, num_boost_round=20, params=params_multiclass)
+    gbm = ds.ml.catboost_model(target=target, features=features, num_boost_round=20, params=params_multiclass, transform=False)
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
     pl.load(str(tmpdir.join('test.json')))
 
-    gbm = ds.ml.catboost_model(target, features=features, num_boost_round=20, params=params_multiclass)
+    gbm = ds.ml.catboost_model(target=target, features=features, num_boost_round=20, params=params_multiclass, transform=False)
     gbm.state_set(gbm.state_get())
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
@@ -170,14 +170,14 @@ def test_catboost_pipeline():
     train['r'] = np.sqrt(train.x**2 + train.y**2 + train.z**2)
     # Do a pca
     features = ['vx', 'vy', 'vz', 'Lz', 'L']
-    pca = train.ml.pca(n_components=3, features=features)
+    pca = train.ml.pca(n_components=3, features=features, transform=False)
     train = pca.transform(train)
     # Do state transfer
     st = train.ml.state_transfer()
     # now the catboost model thingy
     features = ['r', 'PCA_0', 'PCA_1', 'PCA_2']
     # define the boosting model
-    booster = train.ml.catboost_model(target='E', num_boost_round=10, features=features, params=params_reg)
+    booster = train.ml.catboost_model(target='E', num_boost_round=10, features=features, params=params_reg, transform=False)
     # Create a pipeline
     pp = vaex.ml.Pipeline([st, booster])
     # Use the pipeline

--- a/tests/ml/lightgbm_test.py
+++ b/tests/ml/lightgbm_test.py
@@ -77,12 +77,12 @@ def test_lightgbm_serialize(tmpdir):
     features = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width']
     target = 'class_'
 
-    gbm = ds.ml.lightgbm_model(target=target, features=features, num_boost_round=100, params=params)
+    gbm = ds.ml.lightgbm_model(target=target, features=features, num_boost_round=100, params=params, transform=False)
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
     pl.load(str(tmpdir.join('test.json')))
 
-    gbm = ds.ml.lightgbm_model(target=target, features=features, num_boost_round=100, params=params)
+    gbm = ds.ml.lightgbm_model(target=target, features=features, num_boost_round=100, params=params, transform=False)
     gbm.state_set(gbm.state_get())
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
@@ -101,7 +101,7 @@ def test_lightgbm_numerical_validation():
     lgb_pred = lgb_bst.predict(X)
 
     # Vaex.ml.lightgbm
-    booster = ds.ml.lightgbm_model(target=ds.class_, num_boost_round=3, features=features, params=params, copy=False)
+    booster = ds.ml.lightgbm_model(target=ds.class_, num_boost_round=3, features=features, params=params, copy=False, transform=False)
     vaex_pred = booster.predict(ds)
 
     # Comparing the the predictions of lightgbm vs vaex.ml
@@ -144,14 +144,14 @@ def test_lightgbm_pipeline():
     train['r'] = np.sqrt(train.x**2 + train.y**2 + train.z**2)
     # Do a pca
     features = ['vx', 'vy', 'vz', 'Lz', 'L']
-    pca = train.ml.pca(n_components=3, features=features)
+    pca = train.ml.pca(n_components=3, features=features, transform=False)
     train = pca.transform(train)
     # Do state transfer
     st = train.ml.state_transfer()
     # now the lightgbm model thingy
     features = ['r', 'PCA_0', 'PCA_1', 'PCA_2']
     # The booster model from vaex.ml
-    booster = train.ml.lightgbm_model(target='E', num_boost_round=10, features=features, params=params_reg)
+    booster = train.ml.lightgbm_model(target='E', num_boost_round=10, features=features, params=params_reg, transform=False)
     # Create a pipeline
     pp = vaex.ml.Pipeline([st, booster])
     # Use the pipeline

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -10,8 +10,8 @@ from sklearn.preprocessing import StandardScaler, MinMaxScaler, MaxAbsScaler, Ro
 
 def test_pca():
     ds = vaex.ml.datasets.load_iris()
-    pca1 = ds.ml.pca(features=[ds.petal_width, ds.petal_length], n_components=2)
-    pca2 = ds.ml.pca(features=[ds.sepal_width, ds.sepal_length, ds.petal_length], n_components=3)
+    pca1 = ds.ml.pca(features=[ds.petal_width, ds.petal_length], n_components=2, transform=False)
+    pca2 = ds.ml.pca(features=[ds.sepal_width, ds.sepal_length, ds.petal_length], n_components=3, transform=False)
     ds = pca1.transform(ds)
     print(ds.virtual_columns.keys())
     virtual_column_count1 = len(ds.virtual_columns.keys())
@@ -32,18 +32,17 @@ def test_valid_sklearn_pca():
     pca.fit(ds[features])
     sklearn_trans = pca.transform(ds[features])
     # vaex-ml approach
-    vaexpca = ds.ml.pca(n_components=3, features=features)
-    vpca = vaexpca.transform(ds[features])
+    ds_pca = ds.ml.pca(n_components=3, features=features)
     # Compare the two approaches
-    np.testing.assert_almost_equal(vpca.evaluate('PCA_0'), sklearn_trans[:, 0])
+    np.testing.assert_almost_equal(ds_pca.evaluate('PCA_0'), sklearn_trans[:, 0])
 
 
 def test_standard_scaler():
     ds = vaex.ml.datasets.load_iris()
-    ss1 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=True, with_std=True)
-    ss2 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=True, with_std=False)
-    ss3 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=False, with_std=True)
-    ss4 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=False, with_std=False)
+    ss1 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=True, with_std=True, transform=False)
+    ss2 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=True, with_std=False, transform=False)
+    ss3 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=False, with_std=True, transform=False)
+    ss4 = ds.ml.standard_scaler(features=[ds.petal_width, ds.petal_length], with_mean=False, with_std=False, transform=False)
     ds1 = ss1.transform(ds)
     print(ds.virtual_columns.keys())
     ds2 = ss2.transform(ds)
@@ -71,8 +70,8 @@ def test_standard_scaler():
 
 def test_minmax_scaler():
     ds = vaex.ml.datasets.load_iris()
-    mms1 = ds.ml.minmax_scaler(features=[ds.petal_width, ds.petal_length])
-    mms2 = ds.ml.minmax_scaler(features=[ds.petal_width, ds.petal_length], feature_range=(-5, 2))
+    mms1 = ds.ml.minmax_scaler(features=[ds.petal_width, ds.petal_length], transform=False)
+    mms2 = ds.ml.minmax_scaler(features=[ds.petal_width, ds.petal_length], feature_range=(-5, 2), transform=False)
     ds1 = mms1.transform(ds)
     print(ds.virtual_columns.keys())
     ds2 = mms2.transform(ds)
@@ -123,7 +122,7 @@ def test_frequency_encoder():
     test = vaex.from_arrays(animals=animals, numbers=numbers)
     features = ['animals', 'numbers']
 
-    fe = train.ml.frequency_encoder(features=features, unseen='nan')
+    fe = train.ml.frequency_encoder(features=features, unseen='nan', transform=False)
     fe.fit(train)
     test_a = fe.transform(test)
     np.testing.assert_almost_equal(test_a.frequency_encoded_animals.values,
@@ -159,7 +158,7 @@ def test_label_encoder():
     df_unseen = vaex.from_arrays(x=x3, y=y3)
 
     # # Label Encode with vaex.ml
-    label_encoder = df_train.ml.label_encoder(features=['x', 'y'], prefix='mypref_')
+    label_encoder = df_train.ml.label_encoder(features=['x', 'y'], prefix='mypref_', transform=False)
 
     # Assertions: makes sure that the categories are correctly identified:
     assert set(list(label_encoder.labels_['x'].keys())) == set(np.unique(x1))
@@ -178,7 +177,7 @@ def test_label_encoder():
         label_encoder.transform(df_unseen)
 
     # Now try again, but allow for unseen categories
-    label_encoder = df_train.ml.label_encoder(features=['x', 'y'], prefix='mypref_', allow_unseen=True)
+    label_encoder = df_train.ml.label_encoder(features=['x', 'y'], prefix='mypref_', allow_unseen=True, transform=False)
     df_unseen = label_encoder.transform(df_unseen)
     assert set(df_unseen[df_unseen.x == 'dragon'].mypref_x.tolist()) == {-1}
     assert set(df_unseen[df_unseen.y == 4].mypref_x.tolist()) == {-1}
@@ -196,12 +195,13 @@ def test_one_hot_encoding():
     # Create dataset
     ds = vaex.from_arrays(animals=x, kids=y, numbers=z)
     # First try to one-hot encode without specifying features: this should raise an exception
-    with pytest.raises(ValueError):
-        onehot = ds.ml.one_hot_encoder(features=None)
+    # TODO: should we do this?
+    # with pytest.raises(ValueError):
+    #     onehot = ds.ml.one_hot_encoder(features=None)
     # split in train and test
     train, test = ds.ml.train_test_split(test_size=.25, verbose=False)
     # fit onehot encoder on the train set
-    onehot = train.ml.one_hot_encoder(features=['kids', 'animals', 'numbers'], prefix='')
+    onehot = train.ml.one_hot_encoder(features=['kids', 'animals', 'numbers'], prefix='', transform=False)
     # transform the test set
     test = onehot.transform(test)
     # asses the success of the test
@@ -390,7 +390,7 @@ def test_groupby_transformer_basics():
     assert df_test_trans.y.tolist() == [5, 5, 5, 5]
 
     # Alternative API
-    trans = df_train.ml.groupby_transformer(by='x', agg={'mean_y': vaex.agg.mean('y')}, rsuffix='_agg')
+    trans = df_train.ml.groupby_transformer(by='x', agg={'mean_y': vaex.agg.mean('y')}, rsuffix='_agg', transform=False)
     df_test_trans_2 = trans.transform(df_test)
     assert df_test_trans.mean_y.tolist() == df_test_trans_2.mean_y.tolist()
     assert df_test_trans.x.tolist() == df_test_trans_2.x.tolist()

--- a/tests/ml/sklearn_test.py
+++ b/tests/ml/sklearn_test.py
@@ -116,7 +116,7 @@ def test_sklearn_estimator_pipeline():
     train['petal_scaled'] = train.petal_length * 0.2
     # Do a pca
     features = ['sepal_virtual', 'petal_scaled']
-    pca = train.ml.pca(n_components=2, features=features)
+    pca = train.ml.pca(n_components=2, features=features, transform=False)
     train = pca.transform(train)
     # Do state transfer
     st = train.ml.state_transfer()

--- a/tests/ml/xgboost_test.py
+++ b/tests/ml/xgboost_test.py
@@ -80,12 +80,12 @@ def test_xgboost_serialize(tmpdir):
     features = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width']
     target = 'class_'
 
-    gbm = ds.ml.xgboost_model(target=target, features=features, num_boost_round=20, params=params_multiclass)
+    gbm = ds.ml.xgboost_model(target=target, features=features, num_boost_round=20, params=params_multiclass, transform=False)
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
     pl.load(str(tmpdir.join('test.json')))
 
-    gbm = ds.ml.xgboost_model(target=target, features=features, num_boost_round=20, params=params_multiclass)
+    gbm = ds.ml.xgboost_model(target=target, features=features, num_boost_round=20, params=params_multiclass, transform=False)
     gbm.state_set(gbm.state_get())
     pl = vaex.ml.Pipeline([gbm])
     pl.save(str(tmpdir.join('test.json')))
@@ -121,14 +121,14 @@ def test_xgboost_pipeline():
     train['r'] = np.sqrt(train.x**2 + train.y**2 + train.z**2)
     # Do a pca
     features = ['vx', 'vy', 'vz', 'Lz', 'L']
-    pca = train.ml.pca(n_components=3, features=features)
+    pca = train.ml.pca(n_components=3, features=features, transform=False)
     train = pca.transform(train)
     # Do state transfer
     st = train.ml.state_transfer()
     # now the xgboost model thingy
     features = ['r', 'PCA_0', 'PCA_1', 'PCA_2']
     # define the boosting model
-    booster = train.ml.xgboost_model(target='E', num_boost_round=10, features=features, params=params_reg)
+    booster = train.ml.xgboost_model(target='E', num_boost_round=10, features=features, params=params_reg, transform=False)
     # Create a pipeline
     pp = vaex.ml.Pipeline([st, booster])
     # Use the pipeline


### PR DESCRIPTION
This is a way we can autogenerate the API.

There was an issue with this before, that in order the autogenerate the API, we had to import all packages, which is slow.

Instead, we now generate a spec:
```
$ python -m vaex.ml.spec packages/vaex-ml/vaex/ml/spec.json
```

Which allows us to build the API at runtime.

The spec also will allow us to track spec changes in the models, with CI helping us detect changes.

TODO:
 * [x] make the copy argument a trait
 * [x] make sure the spec file is packaged
 * [x] include CI checks to make sure the spec matches our classes.