### PR TITLE
Feat:  evaluate iterator / parallel chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# vaex 2.6.0-dev (unreleased)
+
+# vaex-core 1.5.0-dev
+   * Features
+      * df.evalute_iterator for efficient parallel chunked evaluation [#???](https://github.com/vaexio/vaex/pull/???)
+
 # vaex 2.5.0 (2019-12-16)
 
 # vaex-core 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 # vaex-core 1.5.0-dev
    * Features
-      * df.evalute_iterator for efficient parallel chunked evaluation [#???](https://github.com/vaexio/vaex/pull/???)
+      * df.evalute_iterator for efficient parallel chunked evaluation [#515](https://github.com/vaexio/vaex/pull/515)
+
+# vaex-ml 0.7.1-dev
+   * Performance
+      * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/packages/vaex-core/src/superutils.cpp
+++ b/packages/vaex-core/src/superutils.cpp
@@ -46,6 +46,22 @@ public:
         }
         return {start, end};
     }
+    int64_t raw_offset(int64_t logical_offset) {
+        // if(offset >= length) {
+        //     throw std::runtime_error("offset should be smaller than length");
+        // }
+        int64_t counted = 0;
+        int64_t start = -1, end = -1;
+        for(int64_t i = 0; i < length; i++) {
+            if(mask_data[i] == 1) {
+                counted++;
+                if(counted == logical_offset) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
     void reset() {
         py::gil_scoped_release release;
         std::fill(mask_data, mask_data+length, 2);
@@ -154,6 +170,7 @@ PYBIND11_MODULE(superutils, m) {
             }
         )
         .def("indices", &Mask::indices)
+        .def("raw_offset", &Mask::raw_offset)
         .def("count", &Mask::count)
         .def("first", &Mask::first)
         .def("last", &Mask::last)

--- a/packages/vaex-core/vaex/core/_version.py
+++ b/packages/vaex-core/vaex/core/_version.py
@@ -1,2 +1,2 @@
-__version_tuple__ = (1, 4, 0)
-__version__ = '1.4.0'
+__version_tuple__ = (1, 5, 0, "dev")
+__version__ = '1.5.0-dev'

--- a/packages/vaex-meta/setup.py
+++ b/packages/vaex-meta/setup.py
@@ -16,7 +16,7 @@ version = version.__version__
 url = 'https://www.github.com/maartenbreddels/vaex'
 
 install_requires = [
-      'vaex-core>=1.4.0,<2',
+      'vaex-core>=1.5.0-dev,<2',
       'vaex-viz>=0.3.8,<0.4',
       'vaex-server>=0.2.1,<0.3',
       'vaex-hdf5>=0.5.6,<0.6',

--- a/packages/vaex-meta/vaex/meta/_version.py
+++ b/packages/vaex-meta/vaex/meta/_version.py
@@ -1,2 +1,2 @@
-__version_tuple__ = (2, 5, 0)
-__version__ = '2.5.0'
+__version_tuple__ = (2, 6, 0, "dev")
+__version__ = '2.6.0-dev'

--- a/packages/vaex-ml/setup.py
+++ b/packages/vaex-ml/setup.py
@@ -12,7 +12,7 @@ author_email= 'jovan.veljanoski@gmail.com'
 license     = 'MIT'
 version     = version.__version__
 url         = 'https://www.github.com/vaexio/vaex'
-install_requires_ml = ['vaex-core>=1.0.0,<2', 'numba', 'traitlets','jinja2']
+install_requires_ml = ['vaex-core>=1.5.0-dev,<2', 'numba', 'traitlets','jinja2']
 
 setup(name=name + '-ml',
       version=version,

--- a/packages/vaex-ml/vaex/ml/_version.py
+++ b/packages/vaex-ml/vaex/ml/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.7.0'
-__version_tuple__ = (0, 7, 0)
+__version__ = '0.7.1-dev'
+__version_tuple__ = (0, 7, 1, "dev")

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -1,5 +1,18 @@
-import vaex
-import numpy as np
+from common import *
+
+
+@pytest.mark.parametrize("chunk_size", list(range(1, 13)))
+@pytest.mark.parametrize("prefetch", [True, False])
+@pytest.mark.parametrize("parallel", [True, False])
+def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df_local.evaluate_iterator('x', chunk_size=chunk_size, prefetch=prefetch, parallel=parallel):
+        assert x[i1:i2].tolist() == chunk.tolist()
+        total += chunk.sum()
+    assert total == x.sum()
+
 
 def test_evaluate_function_filtered_df():
     # Custom function to be applied to a filtered DataFrame

--- a/tests/internal/chunking_test.py
+++ b/tests/internal/chunking_test.py
@@ -1,0 +1,38 @@
+import vaex
+import numpy as np
+
+def test_chunking():
+    x = np.arange(10)
+    y = x**2
+    df = vaex.from_arrays(x=x, y=y)
+    def indices(df, chunk_size):
+        logical_length = len(df)
+        if df.filtered:
+            full_mask = df._selection_masks[vaex.dataframe.FILTER_SELECTION_NAME]
+            for l1, l2, i1, i2 in vaex.utils.subdivide_mask(full_mask, max_length=chunk_size, logical_length=logical_length):
+                yield i1
+            yield i2
+        else:
+            for i1, i2 in vaex.utils.subdivide(logical_length, max_length=chunk_size):
+                yield i1
+            yield i2
+
+    assert list(indices(df, 2)) == [0, 2, 4, 6, 8, 10]
+    assert list(indices(df, 3)) == [0, 3, 6, 9, 10]
+    assert list(indices(df, 4)) == [0, 4, 8, 10]
+    assert list(indices(df, 5)) == [0, 5, 10]
+    assert list(indices(df, 6)) == [0, 6, 10]
+    assert list(indices(df, 7)) == [0, 7, 10]
+    assert list(indices(df, 12)) == [0, 10]
+    dff = df[(df.x != 0) & (df.x != 5)  & (df.x != 8) ]
+    assert list(indices(dff, 2)) == [1, 3, 5, 8, 10]
+    assert list(indices(dff, 3)) == [1, 4, 8, 10]
+    assert list(indices(dff, 4)) == [1, 5, 10]
+    full_mask = np.array(dff._selection_masks[vaex.dataframe.FILTER_SELECTION_NAME], np.uint8)
+    for n in [2, 3, 4]:
+        total = 0
+        for l1, l2, i1, i2 in dff._unfiltered_chunk_slices(n):
+            part = full_mask[i1:i2]
+            total += part.sum()
+            assert part.sum() <= n
+        assert total == 7


### PR DESCRIPTION
This introduces parallel chunking support for evaluate. e.g.:
```
        >>> import vaex
        >>> df = vaex.example()
        >>> for i1, i2, chunk in df.evaluate_iterator(df.x, chunk_size=100_000):
        ...     print(f"Total of {i1} to {i2} = {chunk.sum()}")
        ...
        Total of 0 to 100000 = -7460.610158279056
        Total of 100000 to 200000 = -4964.85827154921
        Total of 200000 to 300000 = -7303.271340043915
        Total of 300000 to 330000 = -2424.65234724951
```

An implementation default that matters, by default prefetch=True, meaning that before the first chunk is yielded, the second chunk will already start computing. This means that if the main thread if single-threaded (e.g. some scikit-learn algorithm), we make maximum use of the CPU. 

Speedup seen on 1 billion rows: before 12 minutes, after 6.

