### PR TITLE
Rename SKLearnPredictor to Predictor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 # vaex-ml 0.7.1-dev
    * Performance
       * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
+      * rename `vaex.ml.sklearn.SKLearnPredictor` to `vaex.ml.sklearn.Predictor` [#524](https://github.com/vaexio/vaex/pull/524)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 # vaex-ml 0.7.1-dev
    * Performance
       * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
+   * Fix
       * rename `vaex.ml.sklearn.SKLearnPredictor` to `vaex.ml.sklearn.Predictor` [#524](https://github.com/vaexio/vaex/pull/524)
 
 # vaex 2.5.0 (2019-12-16)

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -16,7 +16,7 @@ from vaex.ml.state import serialize_pickle
 class Predictor(state.HasState):
     '''This class wraps any scikit-learn estimator (a.k.a predictor) making it a vaex pipeline object.
 
-    By wrapping any scikit-learn estimators with this class, it becoes a vaex
+    By wrapping any scikit-learn estimators with this class, it becomes a vaex
     pipeline object. Thus, it can take full advantage of the serialization and
     pipeline system of vaex. One can use the `predict` method to get a numpy
     array as an output of a fitted estimator, or the `transform` method do add
@@ -99,49 +99,12 @@ class Predictor(state.HasState):
 @vaex.serialize.register
 @generate.register
 class SKLearnPredictor(Predictor):
-    '''This class is deprecated and it wil will be removed in vaex-ml 0.8. Please use vaex.ml.sklearn.Predictor instead.
 
-    This class wraps any scikit-learn estimator (a.k.a predictor) making it a vaex pipeline object.
-
-    By wrapping any scikit-learn estimators with this class, it becoes a vaex
-    pipeline object. Thus, it can take full advantage of the serialization and
-    pipeline system of vaex. One can use the `predict` method to get a numpy
-    array as an output of a fitted estimator, or the `transform` method do add
-    such a prediction to a vaex DataFrame as a virtual column.
-
-    Note that a full memory copy of the data used is created when the `fit` and
-    `predict` are called. The `transform` method is evaluated lazily.
-
-    The scikit-learn estimators themselves are not modified at all, they are
-    taken from your local installation of scikit-learn.
-
-    Example:
-
-    >>> import vaex.ml
-    >>> from vaex.ml.sklearn import SKLearnPredictor
-    >>> from sklearn.linear_model import LinearRegression
-    >>> df = vaex.ml.dataset00.load_iris()
-    >>> features = ['sepal_width', 'petal_length', 'sepal_length']
-    >>> df_train, df_test = vaex.ml.train_test_split(df)
-    >>> model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
-    >>> model.fit(df_train, df_train.petal_width)
-    >>> df_train = model.transform(df_train)
-    >>> df_train.head(3)
-     #    sepal_length    sepal_width    petal_length    petal_width    class_      pred
-     0             5.4            3               4.5            1.5         1  1.64701
-     1             4.8            3.4             1.6            0.2         0  0.352236
-     2             6.9            3.1             4.9            1.5         1  1.59336
-    >>> df_test = model.transform(df_test)
-    >>> df_test.head(3)
-     #    sepal_length    sepal_width    petal_length    petal_width    class_     pred
-     0             5.9            3               4.2            1.5         1  1.39437
-     1             6.1            3               4.6            1.4         1  1.56469
-     2             6.6            2.9             4.6            1.3         1  1.44276
-    '''
-
-    warnings.warn(message='''This class is deprecated and it wil will be removed in vaex-ml 0.8.
-                  Please use vaex.ml.sklearn.Predictor instead.''',
-                  category=DeprecationWarning)
+    def __init__(self):
+        super(SKLearnPredictor, self).__init__()
+        warnings.warn(message='''This class is deprecated and it will be removed in vaex-ml 0.8.
+                      Please use vaex.ml.sklearn.Predictor instead.''',
+                      category=DeprecationWarning)
 
 
 @vaex.serialize.register

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -1,6 +1,7 @@
 import pickle
 import base64
 import tempfile
+import warnings
 
 import traitlets
 import numpy as np
@@ -11,10 +12,9 @@ from vaex.ml import state
 from vaex.ml import generate
 from vaex.ml.state import serialize_pickle
 
-
 @vaex.serialize.register
 @generate.register
-class SKLearnPredictor(state.HasState):
+class Predictor(state.HasState):
     '''This class wraps any scikit-learn estimator (a.k.a predictor) making it a vaex pipeline object.
 
     By wrapping any scikit-learn estimators with this class, it becoes a vaex
@@ -32,12 +32,12 @@ class SKLearnPredictor(state.HasState):
     Example:
 
     >>> import vaex.ml
-    >>> from vaex.ml.sklearn import SKLearnPredictor
+    >>> from vaex.ml.sklearn import Predictor
     >>> from sklearn.linear_model import LinearRegression
     >>> df = vaex.ml.datasets.load_iris()
     >>> features = ['sepal_width', 'petal_length', 'sepal_length']
     >>> df_train, df_test = vaex.ml.train_test_split(df)
-    >>> model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
+    >>> model = Predictor(model=LinearRegression(), features=features, prediction_name='pred')
     >>> model.fit(df_train, df_train.petal_width)
     >>> df_train = model.transform(df_train)
     >>> df_train.head(3)
@@ -95,6 +95,54 @@ class SKLearnPredictor(state.HasState):
         X = df[self.features].values
         y = df.evaluate(target)
         self.model.fit(X=X, y=y, **kwargs)
+
+
+@vaex.serialize.register
+@generate.register
+class SKLearnPredictor(Predictor):
+    '''This class is deprecated and it wil will be removed in vaex-ml 0.8. Please use vaex.ml.sklearn.Predictor instead.
+
+    This class wraps any scikit-learn estimator (a.k.a predictor) making it a vaex pipeline object.
+
+    By wrapping any scikit-learn estimators with this class, it becoes a vaex
+    pipeline object. Thus, it can take full advantage of the serialization and
+    pipeline system of vaex. One can use the `predict` method to get a numpy
+    array as an output of a fitted estimator, or the `transform` method do add
+    such a prediction to a vaex DataFrame as a virtual column.
+
+    Note that a full memory copy of the data used is created when the `fit` and
+    `predict` are called. The `transform` method is evaluated lazily.
+
+    The scikit-learn estimators themselves are not modified at all, they are
+    taken from your local installation of scikit-learn.
+
+    Example:
+
+    >>> import vaex.ml
+    >>> from vaex.ml.sklearn import SKLearnPredictor
+    >>> from sklearn.linear_model import LinearRegression
+    >>> df = vaex.ml.dataset00.load_iris()
+    >>> features = ['sepal_width', 'petal_length', 'sepal_length']
+    >>> df_train, df_test = vaex.ml.train_test_split(df)
+    >>> model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
+    >>> model.fit(df_train, df_train.petal_width)
+    >>> df_train = model.transform(df_train)
+    >>> df_train.head(3)
+     #    sepal_length    sepal_width    petal_length    petal_width    class_      pred
+     0             5.4            3               4.5            1.5         1  1.64701
+     1             4.8            3.4             1.6            0.2         0  0.352236
+     2             6.9            3.1             4.9            1.5         1  1.59336
+    >>> df_test = model.transform(df_test)
+    >>> df_test.head(3)
+     #    sepal_length    sepal_width    petal_length    petal_width    class_     pred
+     0             5.9            3               4.2            1.5         1  1.39437
+     1             6.1            3               4.6            1.4         1  1.56469
+     2             6.6            2.9             4.6            1.3         1  1.44276
+    '''
+
+    warnings.warn(message='''This class is deprecated and it wil will be removed in vaex-ml 0.8.
+                  Please use vaex.ml.sklearn.Predictor instead.''',
+                  category=DeprecationWarning)
 
 
 @vaex.serialize.register

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -1,16 +1,15 @@
-import pickle
-import base64
-import tempfile
 import warnings
 
-import traitlets
 import numpy as np
+
+import traitlets
 
 import vaex
 import vaex.serialize
-from vaex.ml import state
 from vaex.ml import generate
+from vaex.ml import state
 from vaex.ml.state import serialize_pickle
+
 
 @vaex.serialize.register
 @generate.register
@@ -202,7 +201,7 @@ class IncrementalPredictor(state.HasState):
       4  -2.65534     -1.61991
     '''
 
-    model = traitlets.Any(default_value=None, allow_none=True, help='A scikit-learn estimator with `.fit_predict` method.').tag(**serialize_pickle)
+    model = traitlets.Any(default_value=None, allow_none=True, help='A scikit-learn estimator with a `.fit_predict` method.').tag(**serialize_pickle)
     features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
     batch_size = traitlets.Int(default_value=1_000_000, allow_none=False, help='Number of samples to be sent to the model in each batch.')
     num_epochs = traitlets.Int(default_value=1, allow_none=False, help='Number of times each batch is sent to the model.')

--- a/tests/ml/sklearn_test.py
+++ b/tests/ml/sklearn_test.py
@@ -1,7 +1,7 @@
 import pytest
 import vaex
 pytest.importorskip("sklearn")
-from vaex.ml.sklearn import SKLearnPredictor, IncrementalPredictor
+from vaex.ml.sklearn import Predictor, IncrementalPredictor
 
 import numpy as np
 
@@ -37,7 +37,7 @@ def test_sklearn_estimator():
 
     train, test = ds.ml.train_test_split(verbose=False)
 
-    model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
+    model = Predictor(model=LinearRegression(), features=features, prediction_name='pred')
     model.fit(train, train.petal_width)
     prediction = model.predict(test)
     test = model.transform(test)
@@ -58,7 +58,7 @@ def test_sklearn_estimator_virtual_columns():
     ds['z'] = ds.petal_width * 1
     train, test = ds.ml.train_test_split(test_size=0.2, verbose=False)
     features = ['x', 'y', 'z']
-    model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
+    model = Predictor(model=LinearRegression(), features=features, prediction_name='pred')
     model.fit(ds, ds.w)
     ds = model.transform(ds)
     assert ds.pred.values.shape == (150,)
@@ -68,14 +68,14 @@ def test_sklearn_estimator_serialize(tmpdir):
     ds = vaex.ml.datasets.load_iris()
     features = ['sepal_length', 'sepal_width', 'petal_length']
 
-    model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
+    model = Predictor(model=LinearRegression(), features=features, prediction_name='pred')
     model.fit(ds, ds.petal_width)
 
     pipeline = vaex.ml.Pipeline([model])
     pipeline.save(str(tmpdir.join('test.json')))
     pipeline.load(str(tmpdir.join('test.json')))
 
-    model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
+    model = Predictor(model=LinearRegression(), features=features, prediction_name='pred')
     model.fit(ds, ds.petal_width)
 
     model.state_set(model.state_get())
@@ -97,7 +97,7 @@ def test_sklearn_estimator_regression_validation():
     for model in models_regression:
 
         # vaex
-        vaex_model = SKLearnPredictor(model=model, features=features, prediction_name='pred')
+        vaex_model = Predictor(model=model, features=features, prediction_name='pred')
         vaex_model.fit(train, train.petal_width)
         test = vaex_model.transform(test)
 
@@ -122,7 +122,7 @@ def test_sklearn_estimator_pipeline():
     st = train.ml.state_transfer()
     # now apply the model
     features = ['sepal_virtual', 'petal_scaled']
-    model = SKLearnPredictor(model=LinearRegression(), features=features, prediction_name='pred')
+    model = Predictor(model=LinearRegression(), features=features, prediction_name='pred')
     model.fit(train, train.petal_width)
     # Create a pipeline
     pipeline = vaex.ml.Pipeline([st, model])
@@ -151,7 +151,7 @@ def test_sklearn_estimator_classification_validation():
     for model in models_classification:
 
         # vaex
-        vaex_model = SKLearnPredictor(model=model, features=features, prediction_name='pred')
+        vaex_model = Predictor(model=model, features=features, prediction_name='pred')
         vaex_model.fit(train, train.survived)
         test = vaex_model.transform(test)
 


### PR DESCRIPTION
This PR renames `vaex.ml.sklearn.SKLearnPredictor` to `vaex.ml.sklearn.Predictor`

- [x] "new" class `vaex.ml.sklearn.Predictor`. Implementation is identical, only the class name is changed.
- [x] Issue a deprecation warning in the `vaex.ml.sklearn.SKLearnPredictor` class and update the docstring to mention that the class is being deprecated.
- [x] Update the unit-tests to use `vaex.ml.sklearn.Predictor`
- [x] Update the CHANGELOG