### PR TITLE
Allow latest version of CatBoost in CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Create env
       # if: steps.cache-conda-env.outputs.cache-hit != 'true'
       run: |
-        conda create -q -n vaex -c conda-forge python=${{ matrix.python-version }} numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython runipy pandas pytest numba pyarrow graphviz python-graphviz pcre "catboost<0.20" plotly notebook
+        conda create -q -n vaex -c conda-forge python=${{ matrix.python-version }} numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython runipy pandas pytest numba pyarrow graphviz python-graphviz pcre catboost plotly notebook
     # - name: Restoring cached env
     #   if: steps.cache-conda-env.outputs.cache-hit == 'true'
     #   run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - conda update -q conda
   - conda info -a
   # future: kapteyn should only be needed for astro package testing
-  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION certifi=2019.6.16 pip numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython runipy pandas pytest numba pyarrow graphviz python-graphviz pcre "catboost<0.20" libcxx=9.0.0 notebook $OPTIONAL_PACKAGES
+  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION certifi=2019.6.16 pip numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython runipy pandas pytest numba pyarrow graphviz python-graphviz pcre catboost libcxx=9.0.0 notebook $OPTIONAL_PACKAGES
   - which pip
   - source activate test-environment
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 # vaex-ml 0.7.1-dev
    * Performance
       * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
+   * Fixes
+      * Improvements in CI [#525](https://github.com/vaexio/vaex/pull/525)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 # vaex-ml 0.7.1-dev
    * Performance
       * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
-   * Fixes
-      * Improvements in CI [#525](https://github.com/vaexio/vaex/pull/525)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment -c conda-forge python=%PYTHON_VERSION% numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython pandas runipy cython pytest numba pyarrow graphviz python-graphviz pcre lightgbm py-xgboost \"catboost<0.20\" scikit-learn ipydatawidgets ipyvolume bqplot ipympl geopandas"
+  - "conda create -q -n test-environment -c conda-forge python=%PYTHON_VERSION% numpy scipy pyqt matplotlib pyopengl h5py numexpr astropy tornado cython pandas runipy cython pytest numba pyarrow graphviz python-graphviz pcre lightgbm py-xgboost catboost scikit-learn ipydatawidgets ipyvolume bqplot ipympl geopandas"
   - activate test-environment
   - pip install "tabulate==0.8.3"  # issue with 0.8.4 on windows
   - pip install "numpy>=1.13" "pyarrow>=0.12"

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,4 +1,4 @@
-catboost<0.20
+catboost
 lightgbm
 scikit-learn
 annoy


### PR DESCRIPTION
The latest version of CatBoost remedies the issues described in #481 , and thus we are allowing the latest version of CatBoost to be installed as part of the CI testing.

- [x] Tests pass

