### PR TITLE
Fix: join issue when data is memory-mapped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # vaex-core 1.5.0-dev
    * Features
       * df.evalute_iterator for efficient parallel chunked evaluation [#515](https://github.com/vaexio/vaex/pull/515)
+   * Fixes
+     * Slicing arrow string arrays with masked arrays is respected/working [#530](https://github.com/vaexio/vaex/pull/530)]
 
 # vaex-ml 0.7.1-dev
    * Performance

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -395,7 +395,14 @@ class ColumnStringArrow(ColumnString):
         if isinstance(slice, int):
             return self.string_sequence.get(slice)
         elif isinstance(slice, np.ndarray):
-            return type(self).from_string_sequence(self.string_sequence.index(slice))
+            if np.ma.isMaskedArray(slice):
+                if slice.dtype == np.bool_:
+                    ss = self.string_sequence.index(slice.data & ~slice.mask)
+                else:
+                    ss = self.string_sequence.index(slice.data, slice.mask)
+            else:
+                ss = self.string_sequence.index(slice)
+            return type(self).from_string_sequence(ss)
         else:
             start, stop, step = slice.start, slice.stop, slice.step
             start = start or 0

--- a/tests/column_test.py
+++ b/tests/column_test.py
@@ -27,6 +27,21 @@ def test_arrow_strings():
     assert len(df[1:3]) == 2
     assert df[1:3].x.tolist() == x[1:3]
 
+    indices = np.array([0, 2, 1, 3])
+    assert xc[indices].tolist() == ['a', 'ccc', 'bb', 'dddd']
+
+    indices_masked = np.ma.array(indices, mask=[False, True, False, False])
+    assert xc[indices_masked].tolist() == ['a', None, 'bb', 'dddd']
+
+    indices = np.array([0, 2, 1, 3])
+    assert xc[indices].tolist() == ['a', 'ccc', 'bb', 'dddd']
+
+    mask = np.array([True, True, False, True])
+    assert xc[mask].tolist() == ['a', 'bb', 'dddd']
+
+    mask_masked = np.ma.array(np.array([True, True, False, True]), mask=[False, True, True, False])
+    assert xc[mask_masked].tolist() == ['a', 'dddd']
+
 
 def test_arrow_strings_null():
     N = 4

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -63,6 +63,7 @@ def test_left_a_b():
     assert df.evaluate('y').tolist() == [0, None, 2]
     assert df.evaluate('y_r').tolist() == [None, 1, None]
 
+
 def test_join_indexed():
     df = df_a.join(other=df_b, left_on='a', right_on='b', rsuffix='_r')
     df_X = df_a.join(df, left_on='a', right_on='b', rsuffix='_r')
@@ -100,6 +101,7 @@ def test_left_a_b_filtered():
     assert df.evaluate('y').tolist() == [None, 2]
     assert df.evaluate('y_r').tolist() == [1, None]
 
+
 def test_inner_a_b_filtered():
     df_a_filtered = df_a[df_a.x > 0]
     df = df_a_filtered.join(other=df_b, left_on='a', right_on='b', rsuffix='_r', how='inner')
@@ -109,6 +111,7 @@ def test_inner_a_b_filtered():
     assert df.evaluate('x_r').tolist() == [1]
     assert df.evaluate('y').tolist() == [None]
     assert df.evaluate('y_r').tolist() == [1]
+
 
 def test_right_x_x():
     df = df_a.join(other=df_b, on='x', rsuffix='_r', how='right')


### PR DESCRIPTION
This PR is tackling #528.

This issue occurs when the data is memory-mapped. It has to do with the string columns of the resulting joined dataframe having missing values, since the two dataframes being joined to each other do not correspond 1:1. 

- [x] Reproduce and implement a test
- [x] Fix
