### PR TITLE
Fix head/tail for concatenated DataFrames with missing values

### DIFF
--- a/tests/concat_test.py
+++ b/tests/concat_test.py
@@ -4,16 +4,16 @@ import numpy as np
 
 
 def test_concat():
-    x1, y1, z1 = np.arange(3), np.arange(3,0,-1), np.arange(10,13)
-    x2, y2, z2 = np.arange(3,6), np.arange(0,-3,-1), np.arange(13,16)
-    x3, y3, z3 = np.arange(6,9), np.arange(-3,-6,-1), np.arange(16,19)
+    x1, y1, z1 = np.arange(3), np.arange(3, 0, -1), np.arange(10, 13)
+    x2, y2, z2 = np.arange(3, 6), np.arange(0, -3, -1), np.arange(13, 16)
+    x3, y3, z3 = np.arange(6, 9), np.arange(-3, -6, -1), np.arange(16, 19)
     w1, w2, w3 = np.array(['cat']*3), np.array(['dog']*3), np.array(['fish']*3)
-    x = np.concatenate((x1,x2,x3))
-    y = np.concatenate((y1,y2,y3))
-    z = np.concatenate((z1,z2,z3))
-    w = np.concatenate((w1,w2,w3))
+    x = np.concatenate((x1, x2, x3))
+    y = np.concatenate((y1, y2, y3))
+    z = np.concatenate((z1, z2, z3))
+    w = np.concatenate((w1, w2, w3))
 
-    ds  = vaex.from_arrays(x=x, y=y, z=z, w=w)
+    ds = vaex.from_arrays(x=x, y=y, z=z, w=w)
     ds1 = vaex.from_arrays(x=x1, y=y1, z=z1, w=w1)
     ds2 = vaex.from_arrays(x=x2, y=y2, z=z2, w=w2)
     ds3 = vaex.from_arrays(x=x3, y=y3, z=z3, w=w3)

--- a/tests/concat_test.py
+++ b/tests/concat_test.py
@@ -104,3 +104,13 @@ def test_sliced_concat(i1, length, df_concat):
     x = df_concat.x.tolist()
     df = df_concat[i1:i2]
     assert df.x.tolist() == x[i1:i2]
+
+
+def test_concat_missing_values():
+    df1 = vaex.from_arrays(x=[1, 2, 3], y=[np.nan, 'b', 'c'])
+    df2 = vaex.from_arrays(x=[4, 5, np.nan], y=['d', 'e', 'f'])
+    df = vaex.concat([df1, df2])
+
+    repr(df.head(4))
+    repr(df.tail(4))
+    assert len(df) == 6


### PR DESCRIPTION
This addresses #529 

The issue happens when trying to display portion of a concat dataframe with `.head` or `.tail` methods of a dataframe that contains missing values. 

- [x] Reproduce issue and create test
- [ ] Fix