### PR TITLE
Cyclical features transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
    * Fixes
      * Slicing arrow string arrays with masked arrays is respected/working [#530](https://github.com/vaexio/vaex/pull/530)]
 
-# vaex-ml 0.8.1-dev
+# vaex-ml 0.8.0-dev
    * Performance
       * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
    * Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@
    * Fixes
      * Slicing arrow string arrays with masked arrays is respected/working [#530](https://github.com/vaexio/vaex/pull/530)]
 
-# vaex-ml 0.7.1-dev
+# vaex-ml 0.8.1-dev
    * Performance
       * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
    * Fix
       * IncrementalPredictor: epochs now iterate over the whole DataFrame instead on a batch level [#523](https://github.com/vaexio/vaex/pull/523)
       * Rename `vaex.ml.sklearn.SKLearnPredictor` to `vaex.ml.sklearn.Predictor` [#524](https://github.com/vaexio/vaex/pull/524)
       * IncrementalPredictor can be used with `sklearn.linear_model.SGDClassifier` [539](https://github.com/vaexio/vaex/pull/539)
+   * Features
+      * CycleTransformer [#532](https://github.com/vaexio/vaex/pull/532)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -302,6 +302,7 @@ Transformers/encoders
     vaex.ml.transformations.PCA
     vaex.ml.transformations.RobustScaler
     vaex.ml.transformations.StandardScaler
+    vaex.ml.transformations.CycleTransformer
 
 
 .. autoclass:: vaex.ml.transformations.FrequencyEncoder
@@ -326,6 +327,9 @@ Transformers/encoders
      :members:
 
 .. autoclass:: vaex.ml.transformations.StandardScaler
+     :members:
+
+.. autoclass:: vaex.ml.transformations.CycleTransformer
      :members:
 
 

--- a/packages/vaex-meta/setup.py
+++ b/packages/vaex-meta/setup.py
@@ -23,7 +23,7 @@ install_requires = [
       'vaex-astro>=0.6.1,<0.7',
       'vaex-arrow>=0.4.2,<0.5',
       'vaex-jupyter>=0.4.1,<0.5',
-      'vaex-ml>=0.7.0,<0.8',
+      'vaex-ml>=0.8.0-dev,<0.8',
       # vaex-graphql it not on conda-forge yet
 ]
 

--- a/packages/vaex-meta/setup.py
+++ b/packages/vaex-meta/setup.py
@@ -23,7 +23,7 @@ install_requires = [
       'vaex-astro>=0.6.1,<0.7',
       'vaex-arrow>=0.4.2,<0.5',
       'vaex-jupyter>=0.4.1,<0.5',
-      'vaex-ml>=0.8.0-dev,<0.8',
+      'vaex-ml>=0.8.0-dev.0,<0.9',
       # vaex-graphql it not on conda-forge yet
 ]
 

--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -222,3 +222,4 @@ class DataFrameAccessorML(object):
 from .transformations import PCA
 from .transformations import StandardScaler, MinMaxScaler, MaxAbsScaler, RobustScaler
 from .transformations import LabelEncoder, OneHotEncoder, FrequencyEncoder
+from .transformations import CycleTransformer

--- a/packages/vaex-ml/vaex/ml/_version.py
+++ b/packages/vaex-ml/vaex/ml/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.7.1-dev'
-__version_tuple__ = (0, 7, 1, "dev")
+__version__ = '0.8.0-dev'
+__version_tuple__ = (0, 8, 0, "dev")

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -629,8 +629,8 @@ class CycleTransformer(Transformer):
         copy = df.copy()
         for feature in self.features:
             name_x = self.prefix_x + feature + self.suffix_x
-            copy[name_x] = (np.cos(2 * np.pi * copy[feature] / self.n))
+            copy[name_x] = np.cos(2 * np.pi * copy[feature] / self.n)
             name_y = self.prefix_y + feature + self.suffix_y
-            copy[name_y] = (np.sin(2 * np.pi * copy[feature] / self.n))
+            copy[name_y] = np.sin(2 * np.pi * copy[feature] / self.n)
 
         return copy

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -266,3 +266,18 @@ def test_robust_scaler():
     scaler_vaex = vaex.ml.RobustScaler(features=features, percentile_range=(12, 175))
     with pytest.raises(Exception):
         result_vaex = scaler_vaex.fit_transform(ds)
+
+
+def test_cyclical_transformer(tmpdir):
+    df_train = vaex.from_arrays(day=[0, 1, 2, 3, 4, 5, 6, 6, 5, 4, 3, 2, 1, 0])
+    df_test = vaex.from_arrays(day=[0, 6, 1, 5, 2, 4, 3])
+
+    trans = vaex.ml.CycleTransformer(n=7, features=['day'], prefix_x='pref_', prefix_y='pref_')
+    df_train = trans.transform(df_train)
+
+    state_path = str(tmpdir.join('state.json'))
+    df_train.state_write(state_path)
+    df_test.state_load(state_path)
+
+    assert set(df_test.pref_day_x.unique()) == set(df_train.pref_day_x.unique())
+    assert set(df_test.pref_day_y.unique()) == set(df_train.pref_day_y.unique())


### PR DESCRIPTION
Implementation of `CycleTransformer`. 

This is useful for encoding cyclical features (angles, time etc.) for machine learning tasks. The idea is to think of such circular features as the angle of a unit circle in polar coordinates, and then make projection on the x and y axes. This preserves the continuity (January is as close to December as it it is to February for example). For each encoded feature, two new ones are created. 

- [x] Implementation
- [x] Tests
- [x] Review
