### PR TITLE
Bayesian Target Encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
       * IncrementalPredictor can be used with `sklearn.linear_model.SGDClassifier` [539](https://github.com/vaexio/vaex/pull/539)
    * Features
       * CycleTransformer [#532](https://github.com/vaexio/vaex/pull/532)
+      * BayesianTargetEncoder [#533](https://github.com/vaexio/vaex/pull/533)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -303,6 +303,7 @@ Transformers/encoders
     vaex.ml.transformations.RobustScaler
     vaex.ml.transformations.StandardScaler
     vaex.ml.transformations.CycleTransformer
+    vaex.ml.transformations.BayesianTargetEncoder
 
 
 .. autoclass:: vaex.ml.transformations.FrequencyEncoder
@@ -330,6 +331,7 @@ Transformers/encoders
      :members:
 
 .. autoclass:: vaex.ml.transformations.CycleTransformer
+.. autoclass:: vaex.ml.transformations.BayesianTargetEncoder
      :members:
 
 

--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -223,3 +223,4 @@ from .transformations import PCA
 from .transformations import StandardScaler, MinMaxScaler, MaxAbsScaler, RobustScaler
 from .transformations import LabelEncoder, OneHotEncoder, FrequencyEncoder
 from .transformations import CycleTransformer
+from .transformations import BayesianTargetEncoder


### PR DESCRIPTION
This PR implements a Bayesian Target Encoder. This is a variant of the mean target encoding scheme which fights over-fitting by smoothing the encoded values of each category towards the global mean of the target variable. The strength of the smoothing is adjusted by setting a prior (`weight`). If this is set to 0, no such smoothing is applied, and only a mean target encoding is applied. 

- [x] Implementation of `BayesianTargetEncoder`
- [x] Tests
- [ ] Review