### PR TITLE
WeightOfEvidenceEncoder implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
    * Features
       * CycleTransformer [#532](https://github.com/vaexio/vaex/pull/532)
       * BayesianTargetEncoder [#533](https://github.com/vaexio/vaex/pull/533)
+      * WeightOfEvidenceEncoder [#534](https://github.com/vaexio/vaex/pull/534)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -304,6 +304,7 @@ Transformers/encoders
     vaex.ml.transformations.StandardScaler
     vaex.ml.transformations.CycleTransformer
     vaex.ml.transformations.BayesianTargetEncoder
+    vaex.ml.transformations.WeightOfEvidenceEncoder
 
 
 .. autoclass:: vaex.ml.transformations.FrequencyEncoder
@@ -331,7 +332,12 @@ Transformers/encoders
      :members:
 
 .. autoclass:: vaex.ml.transformations.CycleTransformer
+     :members:
+
 .. autoclass:: vaex.ml.transformations.BayesianTargetEncoder
+     :members:
+
+.. autoclass:: vaex.ml.transformations.WeightOfEvidenceEncoder
      :members:
 
 

--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -224,3 +224,4 @@ from .transformations import StandardScaler, MinMaxScaler, MaxAbsScaler, RobustS
 from .transformations import LabelEncoder, OneHotEncoder, FrequencyEncoder
 from .transformations import CycleTransformer
 from .transformations import BayesianTargetEncoder
+from .transformations import WeightOfEvidenceEncoder


### PR DESCRIPTION
This PR implements a Weight of Evidence categorical encoder.

Weight of Evidence measures how well a particular feature supports the given hypothesis (i.e. the target variable). With this encoder, each category in a categorical feature is encoded by its "strength" i.e. Weight of Evidence value.

- [x] `WeightOfEvidenceEncoder` implementation in `vaex.ml.transformations`
- [x] Tests
- [x] Review