### PR TITLE
Improve API to correlation and mutual_information DataFrame methods

### DIFF
--- a/tests/correlation_test.py
+++ b/tests/correlation_test.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+import vaex
+
+
+def correlation_test():
+    df = vaex.example()
+
+    # A single column pair
+    desired = df.correlation('x', 'y')
+    expected = np.array(-0.066913)
+    np.testing.assert_array_almost_equal(desired, expected)
+
+    # A list of columns
+    desired = df.correlation(x=['x', 'y', 'z'])
+    expected = np.array([[ 1.00000000, -0.06691309, -0.02656313],
+                         [-0.06691309,  1.00000000,  0.03083857],
+                         [-0.02656313,  0.03083857,  1.00000000]])
+    np.testing.assert_array_almost_equal(desired, expected)
+
+    # A list of columns and a single target
+    desired = df.correlation(x=['x', 'y', 'z'], y='vx')
+    expected = np.array([-0.00779179,  0.01804911, -0.02175331])
+    np.testing.assert_array_almost_equal(desired, expected)
+
+    # A list of columns and a list of targets
+    desired = df.correlation(x=['x', 'y', 'z'], y=['vx', 'vy'])
+    expected = np.array(([-0.00779179,  0.01804911, -0.02175331],
+                         [0.00014019, -0.00411498, 0.02988355]))
+
+    # No arguments (entire DataFrame)
+    desired = df[['x', 'y', 'z']].correlation(x=None, y=None)
+    expected = np.array([[ 1.00000000, -0.06691309, -0.02656313],
+                         [-0.06691309,  1.00000000,  0.03083857],
+                         [-0.02656313,  0.03083857,  1.00000000]])

--- a/tests/mutual_information_test.py
+++ b/tests/mutual_information_test.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+import vaex
+
+
+def mutual_information_test():
+    df = vaex.example()
+
+    # A single pair
+    desired = df.mutual_information('x', 'y')
+    expected = np.array(0.15118145)
+    np.testing.assert_array_almost_equal(desired, expected)
+
+    # A list of columns
+    desired = df.mutual_information(x=['x', 'y', 'z'])
+    expected = np.array(([4.80278827, 0.15118145, 0.18439181],
+                         [0.15118145, 4.87766263, 0.21418761],
+                         [0.18439181, 0.21418761, 4.61453743]))
+    np.testing.assert_array_almost_equal(desired, expected)
+
+    # A list of columns and a single target
+    desired = df.mutual_information(x=['vx', 'vy', 'vz'], y='vx')
+    expected = np.array([0.21501621, 0.2370898, 0.24951082])
+    np.testing.assert_array_almost_equal(desired, expected)
+
+    # A list of columns and targets
+    desired = df.mutual_information(x=['vx', 'vy', 'vz'], y=['Lz', 'FeH'])
+    expected = np.array(([0.21501621, 0.23708980, 0.24951082],
+                         [0.12492044, 0.13276138, 0.14383603]))
+    np.testing.assert_array_almost_equal(desired, expected)
+
+    # No arguments (entire DataFrame)
+    desired = df[['x', 'y', 'z']].mutual_information(x=None, y=None)
+    expected = np.array(([4.80278827, 0.15118145, 0.18439181],
+                         [0.15118145, 4.87766263, 0.21418761],
+                         [0.18439181, 0.21418761, 4.61453743]))


### PR DESCRIPTION
In this PR i propose certain changes to the API of `dataframe.correlation` and `dataframe.mutual_information`. The changes are related to how the data (columns) are passed on to the method. In summary:
- A single column or expression given for `x` and `y`: returns and array with a single number/item;
- A list of columns or expressions for `x`, `y=None`: returns a correlation matrix between the columns listed, which is an array of shape `(len(x), len(x))`;
- A list of columns or expressions given for `x`, and a single column or expression for `y`: returns an array of the correlation results between the elements of x and y, an array of shape `len(x)`;
- A list of columns or expressions for `x` and a list of columns or expressions for `y`: returns a 2d array of shape `(len(y), len(x)`, that contains the results of the correlation, each element of `x` to each element of `y`;
- No arguments are passed, i. e. `x=None`, `y=None`: returns a correlation matrix (2d array) of all numerical features in the DataFrame.

- [x] Implement tests to guide the API re-design
- [ ] Implementation of changes
- [ ] Review and test
