### PR TITLE
Fix IncrementalPredictor to work with classifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
       * IncrementalPredictor uses parallel chunked support (2x speedup possible) [#515](https://github.com/vaexio/vaex/pull/515)
    * Fix
       * IncrementalPredictor: epochs now iterate over the whole DataFrame instead on a batch level [#523](https://github.com/vaexio/vaex/pull/523)
-      * rename `vaex.ml.sklearn.SKLearnPredictor` to `vaex.ml.sklearn.Predictor` [#524](https://github.com/vaexio/vaex/pull/524)
+      * Rename `vaex.ml.sklearn.SKLearnPredictor` to `vaex.ml.sklearn.Predictor` [#524](https://github.com/vaexio/vaex/pull/524)
+      * IncrementalPredictor can be used with `sklearn.linear_model.SGDClassifier` [539](https://github.com/vaexio/vaex/pull/539)
 
 # vaex 2.5.0 (2019-12-16)
 

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -231,9 +231,4 @@ class IncrementalPredictor(state.HasState):
 
                 # train the model
                 self.model.partial_fit(X, y, **self.partial_fit_kwargs)
-
-            # update the slicing indices to be ready for the next batch
-            index_min += self.batch_size
-            index_max += self.batch_size
-            index_max = min(N_total, index_max)  # clip upper value
         progressbar(1.0)

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -228,6 +228,11 @@ class IncrementalPredictor(state.HasState):
                     X = X[shuffle_index]
                     y = y[shuffle_index]
 
-                # Train the model
-                self.model.partial_fit(X, y)
+                # train the model
+                self.model.partial_fit(X, y, **kwargs)
+
+            # update the slicing indices to be ready for the next batch
+            index_min += self.batch_size
+            index_max += self.batch_size
+            index_max = min(N_total, index_max)  # clip upper value
         progressbar(1.0)

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -170,6 +170,7 @@ class IncrementalPredictor(state.HasState):
     num_epochs = traitlets.Int(default_value=1, allow_none=False, help='Number of times each batch is sent to the model.')
     shuffle = traitlets.Bool(default_value=False, allow_none=False, help='If True, shuffle the samples before sending them to the model.')
     prediction_name = traitlets.Unicode(default_value='prediction', help='The name of the virtual column housing the predictions.')
+    partial_fit_kwargs = traitlets.Dict(default_value={}, help='A dictionary of key word arguments to be passed on to the `fit_predict` method of the `model`.')
 
     def __call__(self, *args):
         X = np.vstack([arg.astype(np.float64) for arg in args]).T.copy()
@@ -200,7 +201,7 @@ class IncrementalPredictor(state.HasState):
         copy.add_virtual_column(self.prediction_name, expression, unique=False)
         return copy
 
-    def fit(self, df, target, progress=None, **kwargs):
+    def fit(self, df, target, progress=None):
         '''Fit the IncrementalPredictor to the DataFrame.
 
         :param df: A vaex DataFrame containing the features on which to train the model.
@@ -229,7 +230,7 @@ class IncrementalPredictor(state.HasState):
                     y = y[shuffle_index]
 
                 # train the model
-                self.model.partial_fit(X, y, **kwargs)
+                self.model.partial_fit(X, y, **self.partial_fit_kwargs)
 
             # update the slicing indices to be ready for the next batch
             index_min += self.batch_size

--- a/tests/ml/sklearn_test.py
+++ b/tests/ml/sklearn_test.py
@@ -201,9 +201,10 @@ def test_sklearn_incremental_predictor_classification():
                                        batch_size=10_000,
                                        num_epochs=3,
                                        shuffle=False,
-                                       prediction_name='pred')
+                                       prediction_name='pred',
+                                       partial_fit_kwargs={'classes':[0, 1, 2]})
 
-    incremental.fit(df=df_train, target=target, classes=[0, 1, 2])
+    incremental.fit(df=df_train, target=target)
     df_train = incremental.transform(df_train)
 
     # State transfer

--- a/tests/ml/sklearn_test.py
+++ b/tests/ml/sklearn_test.py
@@ -161,7 +161,7 @@ def test_sklearn_estimator_classification_validation():
 
         assert np.all(skl_pred == test.pred.values)
 
-def test_sklearn_incremental_predictor():
+def test_sklearn_incremental_predictor_regression():
     df = vaex.example()
     df_train, df_test = df.ml.train_test_split(test_size=0.1, verbose=False)
 
@@ -186,6 +186,34 @@ def test_sklearn_incremental_predictor():
 
     pred_in_memory = incremental.predict(df_test)
     np.testing.assert_array_almost_equal(pred_in_memory, df_test.pred.values, decimal=1)
+
+
+def test_sklearn_incremental_predictor_classification():
+    df = vaex.ml.datasets.load_iris_1e5()
+    df_train, df_test = df.ml.train_test_split(test_size=0.1, verbose=False)
+
+    features = df_train.column_names[:4]
+    target = 'class_'
+
+    incremental = IncrementalPredictor(model=SGDClassifier(learning_rate='constant', eta0=0.01),
+                                       features=features,
+                                       batch_size=10_000,
+                                       num_epochs=3,
+                                       shuffle=False,
+                                       prediction_name='pred')
+
+    incremental.fit(df=df_train, target=target, classes=[0, 1, 2])
+    df_train = incremental.transform(df_train)
+
+    # State transfer
+    state = df_train.state_get()
+    df_test.state_set(state)
+
+    assert df_test.column_count() == 7
+    assert df_test.pred.values.shape == (10050,)
+
+    pred_in_memory = incremental.predict(df_test)
+    np.testing.assert_array_equal(pred_in_memory, df_test.pred.values)
 
 
 def test_sklearn_incremental_predictor_serialize(tmpdir):

--- a/tests/ml/sklearn_test.py
+++ b/tests/ml/sklearn_test.py
@@ -161,6 +161,7 @@ def test_sklearn_estimator_classification_validation():
 
         assert np.all(skl_pred == test.pred.values)
 
+
 def test_sklearn_incremental_predictor_regression():
     df = vaex.example()
     df_train, df_test = df.ml.train_test_split(test_size=0.1, verbose=False)
@@ -260,6 +261,7 @@ def test_sklearn_incremental_predictor_partial_fit_calls(batch_size, num_epochs)
         def __init__(self):
             self.n_samples_ = 0
             self.n_partial_fit_calls_ = 0
+
         def partial_fit(self, X, y):
             self.n_samples_ += X.shape[0]
             self.n_partial_fit_calls_ += 1

--- a/tests/ml/sklearn_test.py
+++ b/tests/ml/sklearn_test.py
@@ -210,7 +210,7 @@ def test_sklearn_incremental_predictor_classification():
     state = df_train.state_get()
     df_test.state_set(state)
 
-    assert df_test.column_count() == 7
+    assert df_test.column_count() == 6
     assert df_test.pred.values.shape == (10050,)
 
     pred_in_memory = incremental.predict(df_test)


### PR DESCRIPTION
A small fix in `vaex.ml.sklearn.IncrementalPredictor` so it can be used with `sklearn.linear_model.SGDClassifier`.  This requires that the classes are passed to the `.partial_fit` method of the scikit-learn model.

- [x] Add test
- [x] Apply fix (propagation of `**kwargs`)
- [ ] Review