### PR TITLE
Fix several typos in the documentation

### DIFF
--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -126,7 +126,7 @@
     }
    ],
    "source": [
-    "df.x  # df.col.x or df['x'] are equivalent, but may be preferred because it is more tab completion friend or programmatics friendly respectively"
+    "df.x  # df.col.x or df['x'] are equivalent, but may be preferred because it is more tab completion friendly or programmatics friendly respectively"
    ]
   },
   {
@@ -278,7 +278,7 @@
    "metadata": {},
    "source": [
     "### Selections and filtering\n",
-    "Vaex can be efficient when exploring subsets of the data, for instance to remove outlier or to inspect only a part of the data. Instead of making copies, internally vaex keeps track which rows is selected."
+    "Vaex can be efficient when exploring subsets of the data, for instance to remove outlier or to inspect only a part of the data. Instead of making copies, internally vaex keeps track which rows are selected."
    ]
   },
   {
@@ -367,7 +367,7 @@
    "metadata": {},
    "source": [
     "## Statistics on N-d grids\n",
-    "A core feature of vaex, and used for visualization, is calculation of statistics on N dimensional gridf."
+    "A core feature of vaex, and used for visualization, is calculation of statistics on N dimensional grid."
    ]
   },
   {
@@ -649,7 +649,7 @@
     "  * [from_csv](api.rst#vaex.from_csv): Comma separated files\n",
     "  * [from_ascii](api.rst#vaex.from_ascii): Space/tab separated files\n",
     "  * [from_pandas](api.rst#vaex.from_pandas): Converts a pandas DataFrame\n",
-    "  * [from_astropy_table](api.rst#vaex.from_astropy_table): Converts a astropy table\n",
+    "  * [from_astropy_table](api.rst#vaex.from_astropy_table): Converts an astropy table\n",
     "\n",
     "Exporting, or converting a DataFrame to a different datastructure is also quite easy:\n",
     " \n",
@@ -695,7 +695,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The simpelest visualization is a 1d plot using [DataFrame.plot1d](api.rst#vaex.dataframe.DataFrame.plot1d). When only given one arguments, it will show a histogram showing 99.8% of the data."
+    "The simplest visualization is a 1d plot using [DataFrame.plot1d](api.rst#vaex.dataframe.DataFrame.plot1d). When only given one argument, it will show a histogram showing 99.8% of the data."
    ]
   },
   {
@@ -806,7 +806,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These objects are very similar to vaex' expression, in that they represent an underlying calculation, while normal arithmetic and numpy functions can be applied to it. However, these object represent a statistics computation, and not a column."
+    "These objects are very similar to vaex' expression, in that they represent an underlying calculation, while normal arithmetic and numpy functions can be applied to it. However, these objects represent a statistics computation, and not a column."
    ]
   },
   {
@@ -833,7 +833,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These statistical objects can be passed to the what argument. The advantage being that the data will only have to be passed over once."
+    "These statistical objects can be passed to the `what` argument. The advantage being that the data will only have to be passed over once."
    ]
   },
   {
@@ -950,7 +950,7 @@
    "source": [
     "### Selections for plotting\n",
     "While filtering is useful for narrowing down a selection (e.g. `df_negative = df[df.x < 0]`) there are a few downsides to this. First, a practical issue is that when you filter 4 different ways, you will need to have 4 different objects, polluting your namespace. However, more importantly, when vaex executes a bunch of statistical computations, it will do that per DataFrame, meaning for 4 different DataFrames (although pointing to the same underlying data) it will do a total of 4 passes over the data.\n",
-    "If instead, we have 4 (named) selections in our dataset, it can calculate statistics in one single pass over the data, which can speed up especially when you dataset is larger than your memory.\n",
+    "If instead, we have 4 (named) selections in our dataset, it can calculate statistics in one single pass over the data, which can speed up especially when your dataset is larger than your memory.\n",
     "\n",
     "In the plot below, we show three selection, which by default are blended together, requiring just one pass over the data."
    ]
@@ -1019,7 +1019,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, if you have multiple plots, they are shows as columns, multiple selections are overplotted, and multiple 'whats' (statistics) are shows as rows."
+    "By default, if you have multiple plots, they are shown as columns, multiple selections are overplotted, and multiple 'whats' (statistics) are shown as rows."
    ]
   },
   {
@@ -1112,7 +1112,7 @@
    "metadata": {},
    "source": [
     "### Smaller datasets / scatter plot\n",
-    "Although vaex focusses on large datasets, sometimes you end up with a fraction of the data (due to a selection) and you want to make a scatter plot. You could try the following approach:"
+    "Although vaex focuses on large datasets, sometimes you end up with a fraction of the data (due to a selection) and you want to make a scatter plot. You could try the following approach:"
    ]
   },
   {
@@ -1239,7 +1239,7 @@
    "metadata": {},
    "source": [
     "### Healpix (Plotting)\n",
-    "Using [healpix](https://en.wikipedia.org/wiki/HEALPix) is made available by the vaex-healpix package using the [healpy](https://healpy.readthedocs.io) package. Vaex does not need special support for healpix, only for plotting, but some helper functions are introduced to make working with healpix easier. By diving the source_id by 34359738368 you get a healpix index level 12, and diving it further will take you to lower levels.\n",
+    "[healpix](https://en.wikipedia.org/wiki/HEALPix) is made available by the vaex-healpix package using the [healpy](https://healpy.readthedocs.io) package. Vaex does not need special support for healpix, only for plotting, but some helper functions are introduced to make working with healpix easier. By diving the source_id by 34359738368 you get a healpix index level 12, and diving it further will take you to lower levels.\n",
     " \n",
     "To understand healpix better, we will start from the beginning. If we want to make a density sky plot, we would like to pass healpy a 1d numpy array where each value represents the density at a location of the sphere, where the location is determined by the array size (the healpix level) and the offset (the location). Since the Gaia data includes the healpix index encoded in the `source_id`. By diving the source_id by 34359738368 you get a healpix index level 12, and diving it further will take you to lower levels.\n",
     "\n"
@@ -1419,7 +1419,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Even though the TGAS dataset already contains galactic sky coordiantes (l and b), we add them again as virtual columns such that the transformation between RA. and Dec. and the galactic sky coordinates is know."
+    "Even though the TGAS dataset already contains galactic sky coordiantes (l and b), we add them again as virtual columns such that the transformation between RA. and Dec. and the galactic sky coordinates is known."
    ]
   },
   {
@@ -1448,7 +1448,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since RA. and Dec. are in degrees, while ra_error and dec_error is in miliarcseconds, so we put them on the same scale"
+    "Since RA. and Dec. are in degrees, while ra_error and dec_error are in miliarcseconds, we put them on the same scale"
    ]
   },
   {
@@ -1534,7 +1534,7 @@
    "metadata": {},
    "source": [
     "## Parallel computations\n",
-    "As mentioned in the sections on selections, vaex can do computations on a DataFrame in parallel. Often, this is taken care of, when for instance passing multiple selections, or multiple arguments to one of the statistical functions. However, sometimes it is difficult or impossible to express a computation in one expression, and we need to resort to doing so called 'delayed' computationed, similar as in [joblib](https://pythonhosted.org/joblib) and [dask](https://dask.pydata.org)."
+    "As mentioned in the sections on selections, vaex can do computations on a DataFrame in parallel. Often this is taken care of, when for instance passing multiple selections, or multiple arguments to one of the statistical functions. However, sometimes it is difficult or impossible to express a computation in one expression, and we need to resort to doing so called 'delayed' computation, similar as in [joblib](https://pythonhosted.org/joblib) and [dask](https://dask.pydata.org)."
    ]
   },
   {
@@ -1568,7 +1568,7 @@
    "source": [
     "Note that now the returned value is not a promise (TODO: a more Pythonic way would be to return a Future). This may be subject to change, and the best way to work with this is to use the [delayed](api.rst#vaex.delayed) decorator. And call [DataFrame.execute](api.rst#vaex.dataframe.DataFrame.execute) when the result is needed.\n",
     "\n",
-    "In addition to the above delayed computation, we schedule another computation, such that both the count and mean are execute in parallel such that we only do a single pass over the data. We schedule the execution of two extra functions using the `vaex.delayed` decorator, and run the whole pipeline using `df.execute()`."
+    "In addition to the above delayed computation, we schedule another computation, such that both the count and mean are executed in parallel such that we only do a single pass over the data. We schedule the execution of two extra functions using the `vaex.delayed` decorator, and run the whole pipeline using `df.execute()`."
    ]
   },
   {
@@ -1598,7 +1598,7 @@
     "    return sums/counts\n",
     "\n",
     "print('before calling mean')\n",
-    "# since calculate_mean is decorator with vaex.delayed\n",
+    "# since calculate_mean is decorated with vaex.delayed\n",
     "# this now also returns a 'delayed' object (a promise)\n",
     "delayed_mean = calculate_mean(delayed_sum, delayed_count)\n",
     "\n",
@@ -1627,7 +1627,7 @@
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**Note:** The interactive widgets require a running Python kernel, if you are viewing this documentation online you mean get a feeling for what the widgets can do, but computation will not be possible!\n",
+    "**Note:** The interactive widgets require a running Python kernel, if you are viewing this documentation online you can get a feeling for what the widgets can do, but computation will not be possible!\n",
     "\n",
     "</div>\n",
     "\n",
@@ -1652,7 +1652,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The simplest way to get a more interactive visualization (or even print out statistics) is to the the `vaex.jupyter.interactive_selection` decorator, which will execute the decorated function each time the selection is changed.\n"
+    "The simplest way to get a more interactive visualization (or even print out statistics) is to use the `vaex.jupyter.interactive_selection` decorator, which will execute the decorated function each time the selection is changed.\n"
    ]
   },
   {
@@ -1705,7 +1705,7 @@
    "metadata": {},
    "source": [
     "However, to get truly interactive visualization, we need to use widgets, such as the [bqplot](https://github.com/bloomberg/bqplot) library. Again, if we make a selection here, the above visualization will also update, so lets select a square region.\n",
-    "One issue is that if you have installed ipywidget, bqplot, ipyvolume etc, it may not be enabled if you installed them from pip (from conda-forge will enabled it automagically). To enable it, run the next cell, and refresh the notebook if there were not enabled already. *(Note that these commands will execute in the environment where the notebook is running, not where the kernel is running)*"
+    "One issue is that if you have installed ipywidget, bqplot, ipyvolume etc, it may not be enabled if you installed them from pip (installing from conda-forge will enable it automagically). To enable it, run the next cell, and refresh the notebook if they were not enabled already. *(Note that these commands will execute in the environment where the notebook is running, not where the kernel is running)*"
    ]
   },
   {
@@ -2166,7 +2166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Other joins (inner and outer) aren't supported, feel free [open an issue on github](https://github.com/maartenbreddels/vaex/issues) for this."
+    "Other joins (inner and outer) aren't supported, feel free to [open an issue on github](https://github.com/maartenbreddels/vaex/issues) for this."
    ]
   },
   {
@@ -2239,7 +2239,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When we calculate the mean angular distance of a taxi trip, we encounter some invalid data, that will give warnings, which we can savely ignore for this demonstration."
+    "When we calculate the mean angular distance of a taxi trip, we encounter some invalid data, that will give warnings, which we can safely ignore for this demonstration."
    ]
   },
   {
@@ -2275,7 +2275,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This computation uses quite some heavy mathematical operation, and since it's (internally) using numpy arrays, also uses quite some temporary arrays. We can optimize this calculation by doing a Just-In-Time compilation, based on [numba](https://numba.pydata.org/) or [pythran](https://pythonhosted.org/pythran/). Choose whichever gives the best performance or is easiest to install."
+    "This computation uses quite some heavy mathematical operations, and since it's (internally) using numpy arrays, also uses quite some temporary arrays. We can optimize this calculation by doing a Just-In-Time compilation, based on [numba](https://numba.pydata.org/) or [pythran](https://pythonhosted.org/pythran/). Choose whichever gives the best performance or is easiest to install."
    ]
   },
   {
@@ -2321,7 +2321,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can that we can get a significant speedup ($\\gt 4 x$) in this case."
+    "We can get a significant speedup ($\\gt 4 x$) in this case."
    ]
   },
   {
@@ -2490,7 +2490,7 @@
     "Vaex can be extended using several mechanisms.\n",
     "\n",
     "### Adding functions\n",
-    "Use the [vaex.register_function dectorator](api.rst#vaex.functions.register_function) API to add new functions. "
+    "Use the [vaex.register_function decorator](api.rst#vaex.functions.register_function) API to add new functions. "
    ]
   },
   {

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -1,7 +1,7 @@
 """
 Vaex is a library for dealing with larger than memory DataFrames (out of core).
 
-The most important class (datastructure) in vaex is the :class:`.DataFrame`. A DataFrame is obtained by either, opening
+The most important class (datastructure) in vaex is the :class:`.DataFrame`. A DataFrame is obtained by either opening
 the example dataset:
 
 >>> import vaex
@@ -21,12 +21,12 @@ Or connecting to a remove server:
 
 A few strong features of vaex are:
 
- * Performance: Works with huge tabular data, process over a billion (> 10:sup:`9`) rows/second.
+ * Performance: works with huge tabular data, process over a billion (> 10\\ :sup:`9`\\ ) rows/second.
  * Expression system / Virtual columns: compute on the fly, without wasting ram.
  * Memory efficient: no memory copies when doing filtering/selections/subsets.
  * Visualization: directly supported, a one-liner is often enough.
- * User friendly API: You will only need to deal with a DataFrame object, and tab completion + docstring will help you out: `ds.mean<tab>`, feels very similar to Pandas.
- * Very fast statiscs on N dimensional grids such as histograms, running mean, heatmaps.
+ * User friendly API: you will only need to deal with a DataFrame object, and tab completion + docstring will help you out: `ds.mean<tab>`, feels very similar to Pandas.
+ * Very fast statistics on N dimensional grids such as histograms, running mean, heatmaps.
 
 
 Follow the tutorial at https://docs.vaex.io/en/latest/tutorial.html to learn how to use vaex.
@@ -134,7 +134,7 @@ def open(path, convert=False, shuffle=False, copy_index=True, *args, **kwargs):
 
     Vaex supports streaming in hdf5 files from Amazon AWS object storage S3.
     Files are by default cached in $HOME/.vaex/file-cache/s3 such that successive access
-    it as fast as native disk access. The following url parameters control S3 options:
+    is as fast as native disk access. The following url parameters control S3 options:
 
      * anon: Use anonymous access or not (false by default). (Allowed values are: true,True,1,false,False,0)
      * use_cache: Use the disk cache or not, only set to false if the data should be accessed once. (Allowed values are: true,True,1,false,False,0)
@@ -242,7 +242,7 @@ def open(path, convert=False, shuffle=False, copy_index=True, *args, **kwargs):
 
 
 def open_many(filenames):
-    """Open a list of filenames, and return a DataFrame with all DataFrames cocatenated.
+    """Open a list of filenames, and return a DataFrame with all DataFrames concatenated.
 
     :param list[str] filenames: list of filenames/paths
     :rtype: DataFrame
@@ -284,7 +284,7 @@ def from_dict(data):
       1    2   'b'
       2    3   'c'
 
-    :param data: A dict of {columns:[value, value,...]}
+    :param data: A dict of {column:[value, value,...]}
     :rtype: DataFrame
 
     """

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -122,7 +122,7 @@ _doc_snippets["return_stat_scalar"] = """Numpy array with the given shape, or a 
 _doc_snippets["return_limits"] = """List in the form [[xmin, xmax], [ymin, ymax], .... ,[zmin, zmax]] or [xmin, xmax] when expression is not a list"""
 _doc_snippets["cov_matrix"] = """List all convariance values as a double list of expressions, or "full" to guess all entries (which gives an error when values are not found), or "auto" to guess, but allow for missing values"""
 _doc_snippets['propagate_uncertainties'] = """If true, will propagate errors for the new virtual columns, see :meth:`propagate_uncertainties` for details"""
-_doc_snippets['note_copy'] = '.. note:: Note that no copy of the underlying data is made, only a view/reference is make.'
+_doc_snippets['note_copy'] = '.. note:: Note that no copy of the underlying data is made, only a view/reference is made.'
 _doc_snippets['note_filter'] = '.. note:: Note that filtering will be ignored (since they may change), you may want to consider running :meth:`extract` first.'
 _doc_snippets['inplace'] = 'Make modifications to self or return a new DataFrame'
 _doc_snippets['return_shallow_copy'] = 'Returns a new DataFrame with a shallow copy/view of the underlying data'
@@ -327,7 +327,7 @@ class DataFrame(object):
 
 
         :param f: The function to be applied
-        :param arguments: List of arguments to be passed on the the function f.
+        :param arguments: List of arguments to be passed on to the function f.
         :return: A function that is lazily evaluated.
         """
         assert arguments is not None, 'for now, you need to supply arguments'
@@ -943,7 +943,7 @@ class DataFrame(object):
 
     @docsubst
     def covar(self, x, y, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None):
-        """Calculate the covariance cov[x,y] between and x and y, possibly on a grid defined by binby.
+        """Calculate the covariance cov[x,y] between x and y, possibly on a grid defined by binby.
 
         Example:
 
@@ -997,7 +997,7 @@ class DataFrame(object):
 
     @docsubst
     def correlation(self, x, y=None, binby=[], limits=None, shape=default_shape, sort=False, sort_key=np.abs, selection=False, delay=False, progress=None):
-        """Calculate the correlation coefficient cov[x,y]/(std[x]*std[y]) between and x and y, possibly on a grid defined by binby.
+        """Calculate the correlation coefficient cov[x,y]/(std[x]*std[y]) between x and y, possibly on a grid defined by binby.
 
         Example:
 
@@ -1068,11 +1068,11 @@ class DataFrame(object):
     def cov(self, x, y=None, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None):
         """Calculate the covariance matrix for x and y or more expressions, possibly on a grid defined by binby.
 
-        Either x and y are expressions, e.g:
+        Either x and y are expressions, e.g.:
 
         >>> df.cov("x", "y")
 
-        Or only the x argument is given with a list of expressions, e,g.:
+        Or only the x argument is given with a list of expressions, e.g.:
 
         >>> df.cov(["x, "y, "z"])
 
@@ -1271,7 +1271,7 @@ class DataFrame(object):
     @docsubst
     @stat_1d
     def median_approx(self, expression, percentage=50., binby=[], limits=None, shape=default_shape, percentile_shape=256, percentile_limits="minmax", selection=False, delay=False):
-        """Calculate the median , possibly on a grid defined by binby.
+        """Calculate the median, possibly on a grid defined by binby.
 
         NOTE: this value is approximated by calculating the cumulative distribution on a grid defined by
         percentile_shape and percentile_limits
@@ -1963,7 +1963,7 @@ class DataFrame(object):
 
         Convenient when working with ipython in combination with small DataFrames, since this gives tab-completion.
 
-        Columns can be accesed by there names, which are attributes. The attribues are currently expressions, so you can
+        Columns can be accessed by their names, which are attributes. The attributes are currently expressions, so you can
         do computations with them.
 
         Example
@@ -2393,7 +2393,7 @@ class DataFrame(object):
         vaex.utils.write_json_or_yaml(f, self.state_get())
 
     def state_load(self, f, use_active_range=False):
-        """Load a state previously stored by :meth:`DataFrame.state_store`, see also :meth:`DataFrame.state_set`."""
+        """Load a state previously stored by :meth:`DataFrame.state_write`, see also :meth:`DataFrame.state_set`."""
         state = vaex.utils.read_json_or_yaml(f)
         self.state_set(state, use_active_range=use_active_range)
 
@@ -2537,7 +2537,7 @@ class DataFrame(object):
         """Generate a Subspaces object, based on a custom list of expressions or all possible combinations based on
         dimension
 
-        :param expressions_list: list of list of expressions, where the inner list defines the subspace
+        :param expressions_list: list of lists of expressions, where the inner list defines the subspace
         :param dimensions: if given, generates a subspace with all possible combinations for that dimension
         :param exclude: list of
         """
@@ -3302,7 +3302,7 @@ class DataFrame(object):
         # self.write_virtual_meta()
 
     def add_variable(self, name, expression, overwrite=True, unique=True):
-        """Add a variable to to a DataFrame.
+        """Add a variable to a DataFrame.
 
         A variable may refer to other variables, and virtual columns and expression may refer to variables.
 
@@ -3632,7 +3632,7 @@ class DataFrame(object):
         return 0
 
     def has_current_row(self):
-        """Returns True/False is there currently is a picked row."""
+        """Returns True/False if there currently is a picked row."""
         return self._current_row is not None
 
     def get_current_row(self):
@@ -4194,7 +4194,7 @@ class DataFrame(object):
     def select_non_missing(self, drop_nan=True, drop_masked=True, column_names=None, mode="replace", name="default"):
         """Create a selection that selects rows having non missing values for all columns in column_names.
 
-        The name reflect Panda's, no rows are really dropped, but a mask is kept to keep track of the selection
+        The name reflects Pandas, no rows are really dropped, but a mask is kept to keep track of the selection
 
         :param drop_nan: drop rows when there is a NaN in any of the columns (will only affect float values)
         :param drop_masked: drop rows when there is a masked value in any of the columns
@@ -4249,7 +4249,7 @@ class DataFrame(object):
         self.signal_selection_changed.emit(self, name)
 
     def select_rectangle(self, x, y, limits, mode="replace", name="default"):
-        """Select a 2d rectangular box in the space given by x and y, bounds by limits.
+        """Select a 2d rectangular box in the space given by x and y, bounded by limits.
 
         Example:
 
@@ -4558,7 +4558,7 @@ class DataFrame(object):
     def __delitem__(self, item):
         '''Removes a (virtual) column from the DataFrame.
 
-        Note: this does not remove check if the column is used in a virtual expression or in the filter\
+        Note: this does not check if the column is used in a virtual expression or in the filter\
             and may lead to issues. It is safer to use :meth:`drop`.
         '''
         if isinstance(item, Expression):
@@ -4779,9 +4779,9 @@ class DataFrameLocal(DataFrame):
 
         Convenient when working with IPython in combination with small DataFrames, since this gives tab-completion.
         Only real columns (i.e. no virtual) columns can be accessed, for getting the data from virtual columns, use
-        DataFrame.evalulate(...).
+        DataFrame.evaluate(...).
 
-        Columns can be accesed by there names, which are attributes. The attribues are of type numpy.ndarray.
+        Columns can be accessed by their names, which are attributes. The attributes are of type numpy.ndarray.
 
         Example:
 
@@ -5034,7 +5034,7 @@ class DataFrameLocal(DataFrame):
             self.add_column(new_name, other.columns[name])
 
     def concat(self, other):
-        """Concatenates two DataFrames, adding the rows of one the other DataFrame to the current, returned in a new DataFrame.
+        """Concatenates two DataFrames, adding the rows of the other DataFrame to the current, returned in a new DataFrame.
 
         No copy of the data is made.
 
@@ -5113,7 +5113,7 @@ class DataFrameLocal(DataFrame):
                 yield i1, i2, i1, i2
 
     def evaluate(self, expression, i1=None, i2=None, out=None, selection=None, filtered=True, internal=None, parallel=True, chunk_size=None):
-        """"The local implementation of :func:`DataFrame.evaluate`, will forward call to :func:`DataFrame.evaluate_iterator` if chunk_size is given"""
+        """The local implementation of :func:`DataFrame.evaluate`, will forward call to :func:`DataFrame.evaluate_iterator` if chunk_size is given"""
         if chunk_size is not None:
             return self.evaluate_iterator(expression, s1=i1, s2=i2, out=out, selection=selection, filtered=filtered, internal=internal, parallel=parallel, chunk_size=chunk_size)
         else:
@@ -5716,7 +5716,7 @@ class DataFrameLocal(DataFrame):
     def binby(self, by=None, agg=None):
         """Return a :class:`BinBy` or :class:`DataArray` object when agg is not None
 
-        The binby operations does not return a 'flat' DataFrame, instead it returns an N-d grid
+        The binby operation does not return a 'flat' DataFrame, instead it returns an N-d grid
         in the form of an xarray.
 
 

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -813,7 +813,7 @@ def f({0}):
         return df._expr(self.expression)
 
     def map(self, mapper, nan_value=None, missing_value=None, default_value=None, allow_missing=False):
-        """Map values of an expression or in memory column accoring to an input
+        """Map values of an expression or in memory column according to an input
         dictionary or a custom callable function.
 
         Example:

--- a/packages/vaex-ml/vaex/ml/xgboost.py
+++ b/packages/vaex-ml/vaex/ml/xgboost.py
@@ -20,7 +20,7 @@ class XGBoostModel(state.HasState):
     XGBoost is an optimized distributed gradient boosting library designed to be
     highly efficient, flexible and portable. It implements machine learning
     algorithms under the Gradient Boosting framework. XGBoost provides a parallel
-    tree boosting (also known as GBDT, GBM) that solve many data science
+    tree boosting (also known as GBDT, GBM) that solves many data science
     problems in a fast and accurate way.
     (https://github.com/dmlc/xgboost)
 


### PR DESCRIPTION
Fix some typos or styling in the text of the [Vaex tutorial](https://docs.vaex.io/en/latest/tutorial.html) and [API](https://docs.vaex.io/en/latest/api.html).