### PR TITLE
feat(core): progress update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # vaex-core 1.5.0-dev
    * Features
       * df.evalute_iterator for efficient parallel chunked evaluation [#515](https://github.com/vaexio/vaex/pull/515)
+      * Widget progress bar has time estimation [#545](https://github.com/vaexio/vaex/pull/545)
    * Fixes
      * Slicing arrow string arrays with masked arrays is respected/working [#530](https://github.com/vaexio/vaex/pull/530)]
 

--- a/packages/vaex-core/vaex/misc/progressbar.py
+++ b/packages/vaex-core/vaex/misc/progressbar.py
@@ -1,130 +1,130 @@
 from __future__ import print_function
+import os
 import sys
 import time
 
-## @defgroup python Python
-#@{
-class ProgressBar(object):
-	"""
-		Implementation of progress bar on a console
-		
-		Usage::
-		
-			progressbar = ProgressBar(0, 100)
-			progressbar.update(0)
-			....
-			progressbar.update(100)
-		
-		By default, the progress bar writes to stderr, so it doesn't clutter up log files when piping stdout 
-	"""
-	def __init__(self, min_value, max_value, format="%(bar)s: %(percentage) 6.2f%% %(timeinfo)s", width=40, barchar="#", emptychar="-", output=sys.stdout):
-		"""		
-			:param min_value: minimum value for update(..)
-			:param format: format specifier for the output
-			:param width: width of the progress bar's (excluding extra text)
-			:param barchar: character used to print the bar
-			:param output: where to write the output to
-		"""
-		self.min_value = min_value
-		self.max_value = max_value
-		self.format = format
-		self.width = width
-		self.barchar = barchar
-		self.emptychar = emptychar
-		self.output = output
-		
-		self.firsttime = True
-		self.prevtime = time.time()
-		self.starttime = self.prevtime
-		self.prevfraction = 0
-		self.firsttimedone = False
-		self.value = self.min_value
-		
-	## Updates the progress bar, writing a \\t char to stdout, and the progress bar
-	# @param value the current progress of the bar, should be in the range min_value and max_value 
-	def update(self, value):
-		self.value = value
-		print(repr(self), file=self.output, end=' ')
-		self.output.flush()
 
-	def finish(self):
-		self.value = 1
-		print(repr(self), file=self.output, end=' ')
-		self.output.flush()
+class ProgressBarBase(object):
+    def __init__(self, min_value, max_value, format="%(percentage) 6.2f%% %(timeinfo)s cpu: %(cpu_usage)d%%"):
+        self.min_value = min_value
+        self.max_value = max_value
+        self.format = format
+        self.value = self.min_value
+        self.fraction = 0
+        self.prevfraction = 0
+
+    def info(self):
+        value = self.value
+        if value == 0:
+            self.prevtime = time.time()
+            self.starttime = self.prevtime
+            self.utime0, self.stime0 = os.times()[:2]
+            self.walltime0 = time.time()
+        currenttime = time.time()
+        if (self.max_value-self.min_value) == 0:
+            self.fraction = 1.
+        else:
+            self.fraction = (float(value)-self.min_value)/(self.max_value-self.min_value)
+        percentage = self.fraction * 100
+        self.utime, self.stime = os.times()[:2]
+        self.walltime  = time.time()
+        cpu_time_delta = self.stime - self.stime0 + self.utime - self.utime0
+        wall_time_delta = self.walltime - self.walltime0
+        if wall_time_delta == 0:
+            cpu_usage = 0  # it's formally infinity
+        else:
+            cpu_usage = cpu_time_delta / wall_time_delta * 100
+
+        if (self.fraction > 0) and ((self.fraction-self.prevfraction) > 0):
+            if self.fraction == 1:
+                elapsedtime = (currenttime-self.starttime)
+                seconds = elapsedtime
+                minutes = seconds/60.
+                hours = minutes/60.
+                timeinfo = "elapsed time  : % 8.2fs = % 4.1fm = % 2.1fh" % (seconds, minutes, hours)
+            else:
+                #estimatedtime = (currenttime-self.starttime)/(self.fraction) * (1-self.fraction)
+                #estimatedtime = (currenttime-self.prevtime)/(self.fraction-self.prevself.fraction) * (1-self.fraction)
+                estimatedtime = (currenttime-self.prevtime) / (self.fraction) * (1-self.fraction)
+                seconds = estimatedtime
+                minutes = seconds/60.
+                hours = minutes/60.
+                timeinfo = "estimated time: % 8.2fs = % 4.1fm = % 2.1fh" % (seconds, minutes, hours)
+        else:
+            timeinfo = "estimated time: unknown                "
+        return {"percentage":percentage, "timeinfo":timeinfo, "cpu_usage": cpu_usage}
+
+    def __repr__(self):
+        output = ''
+        return self.format % self.info()
+
+class ProgressBar(ProgressBarBase):
+    """
+        Implementation of progress bar on a console
+
+        Usage::
+
+            progressbar = ProgressBar(0, 100)
+            progressbar.update(0)
+            ....
+            progressbar.update(100)
+
+        By default, the progress bar writes to stderr, so it doesn't clutter up log files when piping stdout
+    """
+    def __init__(self, min_value, max_value, format="%(percentage) 6.2f%% %(timeinfo)s", width=40, barchar="#", emptychar="-", output=sys.stdout):
+        """		
+            :param min_value: minimum value for update(..)
+            :param format: format specifier for the output
+            :param width: width of the progress bar's (excluding extra text)
+            :param barchar: character used to print the bar
+            :param output: where to write the output to
+        """
+        super(ProgressBar, self).__init__(min_value, max_value, format=format)
+        self.width = width
+        self.barchar = barchar
+        self.emptychar = emptychar
+        self.output = output
+
+    def update(self, value):
+        self.value = value
+        print(repr(self), file=self.output, end=' ')
+        self.output.flush()
+
+    def finish(self):
+        self.value = self.max_value
+        print(repr(self), file=self.output, end=' ')
+        self.output.flush()
 
 
-	def __repr__(self):
-		output = ''
-		value = self.value
-		currenttime = time.time()
-		if (self.max_value-self.min_value) == 0:
-			fraction = 1.
-		else:
-			fraction = (float(value)-self.min_value)/(self.max_value-self.min_value)
-		count = int(fraction * self.width + 0.5)
-		space = self.width - count
-		percentage = fraction * 100
-		bar = "[" + (self.barchar * count) + (self.emptychar * space) + "]"
-		if (fraction > 0) and ((fraction-self.prevfraction) > 0):
-			if fraction == 1:
-				elapsedtime = (currenttime-self.starttime)
-				seconds = elapsedtime 
-				minutes = seconds/60. 
-				hours = minutes/60.
-				timeinfo = "elapsed time  : % 8ds = % 4.1fm = % 2.1fh" % (seconds, minutes, hours)
-			else:
-				#estimatedtime = (currenttime-self.starttime)/(fraction) * (1-fraction)
-				#estimatedtime = (currenttime-self.prevtime)/(fraction-self.prevfraction) * (1-fraction)
-				estimatedtime = (currenttime-self.prevtime) / (fraction) * (1-fraction)
-				seconds = estimatedtime 
-				minutes = seconds/60.
-				hours = minutes/60.
-				timeinfo = "estimated time: % 8ds = % 4.1fm = % 2.1fh" % (seconds, minutes, hours)
-		else:
-			timeinfo = "estimated time: unknown                "
-		s = self.format % {"bar":bar, "percentage":percentage, "timeinfo":timeinfo}
-		if (fraction != 1) or (not self.firsttimedone): # last time print a newline char
-			if not self.firsttime:
-				self.firsttime = True
-				output += '\r'+ s#, end=' ', file=self.output)
-			else:
-				output += '\r' + s
-		if (fraction == 1) and (not self.firsttimedone): # last time print a newline char
-			self.firsttimedone = True
-			output += '\n'
+    def __repr__(self):
+        output = ''
+        count = int(self.fraction * self.width + 0.5)
+        space = self.width - count
+        bar = "[" + (self.barchar * count) + (self.emptychar * space) + "]"
+        output = "\r" + bar + super(ProgressBar, self).__repr__()
+        if self.fraction == 1:
+            output += "\n" # last time print a newline char
+        return output
 
-		return output
-			
-		#self.output.flush()
-		#if fraction > 0:
-		#	self.prevtime = currenttime
-		#	self.prevfraction = fraction
-			
-			
-def main():
-	import time
-	bar = ProgressBar(0, 100, width=20, barchar="*", emptychar=" ")
-	for i in range(100+1):
-		bar.update(i)
-		time.sleep(0.05)
-		
-	bar = ProgressBar(0, 100, format="%(percentage) 6.2f%% %(timeinfo)s")
-	for i in range(100+1):
-		bar.update(i)
-		time.sleep(0.05)
-		
-	
-	bar = ProgressBar(0, 100)
-	for i in range(100+1):
-		bar.update(i)
-		time.sleep(0.05)
-		
-	bar = ProgressBar(0, 100, format="%(bar)s: %(percentage) 6.2f%%")
-	for i in range(100+1):
-		bar.update(i)
-		time.sleep(0.05)
-		
-if __name__ == "__main__":
-	main()
-		
-#@}
+
+class ProgressBarWidget(ProgressBarBase):
+    def __init__(self, min_value, max_value, name=None):
+        super(ProgressBarWidget, self).__init__(min_value, max_value)
+        import ipywidgets as widgets
+        from IPython.display import display
+        self.bar = widgets.FloatProgress(min=self.min_value, max=self.max_value)
+        self.text = widgets.Label(value='In progress...')
+        self.widget = widgets.HBox([self.bar, self.text])
+        # self.widget.description = repr(self)
+        display(self.widget)
+
+    def __call__(self, value):
+        self.value = value
+        self.bar.value = value
+        self.text.value = repr(self)
+
+    def update(self, value):
+        self(value)
+
+    def finish(self):
+        self(self.max_value)

--- a/packages/vaex-core/vaex/multithreading.py
+++ b/packages/vaex-core/vaex/multithreading.py
@@ -49,7 +49,7 @@ class ThreadPoolIndex(concurrent.futures.ThreadPoolExecutor):
         values = list(iterator)
         N = len(values)
         time_last = time.time() - 100
-        min_delta_t = 1. / 100  # max 100 per second
+        min_delta_t = 1. / 10  # max 10 per second
         if self.nthreads == 1:  # when using 1 thread, it makes debugging easier (better stacktrace)
             iterator = self._map(wrapped, values)
         else:

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -298,37 +298,15 @@ def _progressbar_vaex(type=None, name="processing", max_value=1):
     import vaex.misc.progressbar as pb
     return pb.ProgressBar(0, 1)
 
-
-class _ProgressBarWidget(object):
-    def __init__(self, name=None):
-        import ipywidgets as widgets
-        from IPython.display import display
-        self.value = 0
-        self.widget = widgets.FloatProgress(min=0, max=1)
-        self.widget.description = name or 'Progress:'
-        display(self.widget)
-
-    def __call__(self, value):
-        self.value = value
-        self.widget.value = value
-
-    def update(self, value):
-        self(value)
-
-    def finish(self):
-        self.widget.description = 'Finished:'
-        self(1)
-
-    # def add_child(self, progress, task, name):
-    # 	#print('add', name)
-    # 	pb = _ProgressBarWidget(name=name)
-    # 	task.signal_progress.connect(pb)
+def _progressbar_widget(type=None, name="processing", max_value=1):
+    import vaex.misc.progressbar as pb
+    return pb.ProgressBarWidget(0, 1, name=name)
 
 
 _progressbar_typemap = {}
 _progressbar_typemap['progressbar2'] = _progressbar_progressbar2
 _progressbar_typemap['vaex'] = _progressbar_vaex
-_progressbar_typemap['widget'] = _ProgressBarWidget
+_progressbar_typemap['widget'] = _progressbar_widget
 
 
 def progressbar(type_name=None, title="processing", max_value=1):

--- a/tests/progress_test.py
+++ b/tests/progress_test.py
@@ -1,0 +1,24 @@
+import vaex.misc.progressbar
+import pytest
+
+def test_progress_bar():
+    pb = vaex.misc.progressbar.ProgressBar(0, 100)
+    pb.update(0)
+    pb.update(50)
+    assert "50.00%" in repr(pb)
+    pb.finish()
+    assert "elapsed time" in repr(pb)
+
+def test_progress_bar_widget():
+    pb = vaex.misc.progressbar.ProgressBarWidget(0, 100)
+    pb.update(0)
+    pb.update(50)
+    assert "50.00%" in repr(pb)
+    assert pb.bar.value == 50
+    pb.finish()
+    assert "elapsed time" in repr(pb)
+
+@pytest.mark.parametrize("progress", ['vaex', 'widget'])
+def test_progress(progress):
+    df = vaex.from_arrays(x=vaex.vrange(0, 10000))
+    df.sum('x', progress=progress)


### PR DESCRIPTION
Refactored our own (old) progress bar a bit so the widget version can use much of the same logic.
The widget version also has cpu usage, which is the cpu usage between start end end:
![progress-bar](https://user-images.githubusercontent.com/1765949/71920112-62221180-3186-11ea-8d81-b5396e9955e6.gif)
