### PR TITLE
Improve error raised for arithmetic operations between a string and numeric columns

### DIFF
--- a/tests/column_operations_test.py
+++ b/tests/column_operations_test.py
@@ -1,0 +1,15 @@
+import vaex
+
+import numpy as np
+
+import pytest
+
+
+def test_add_str_and_numeric_types():
+    x = np.arange(10)
+    y = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+    df = vaex.from_arrays(x=x, y=y)
+    with pytest.raises(TypeError):
+        df['z1'] = df.x + df.y
+    with pytest.raises(TypeError):
+        df['z2'] = df.y + df.z


### PR DESCRIPTION
This handles the non-standard behaviour explained in #538: the behaviour of vaex when on attempts to do the non-permitted addition between a string and a numeric column.

- [x] Test for illegal addition between string and numeric type
- [ ] Fix
