### PR TITLE
feat(core): record all operations that led to dataframe

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -112,7 +112,9 @@ def _convert_name(filenames, shuffle=False):
     else:
         return base + ".hdf5"
 
+import vaex.operations as vop
 
+@vop.source("open")
 def open(path, convert=False, shuffle=False, copy_index=True, *args, **kwargs):
     """Open a DataFrame from file given by path.
 

--- a/packages/vaex-core/vaex/operations.py
+++ b/packages/vaex-core/vaex/operations.py
@@ -1,0 +1,85 @@
+import functools
+import inspect
+import vaex
+
+from inspect import Signature, Parameter, signature
+
+class Op:
+    pass
+
+register = {}
+
+def generate_source_op(name, callable):
+    class source_op(Op):
+        def __init__(self, args, kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.name = name
+
+        def execute(self):
+            df = callable(*self.args, **self.kwargs)
+            df.operation = self
+            return df
+
+        def to_json(self):
+            sig = inspect.signature(callable)
+            args = sig.bind(*self.args, **self.kwargs).arguments
+            return dict(type='source', name=name, parameters=args)
+
+    return source_op
+
+
+def source(name):
+    def f(callable):
+        register[name] = generate_source_op(name, callable)
+        def wrapper(*args, execute=True, **kwargs):
+            op = register[name](args, kwargs)
+            return op.execute() if execute else op
+        # return wrapper
+        return functools.wraps(callable)(wrapper)
+    return f
+
+
+
+def generate_transformation_op(name, callable):
+    class transformation_op(Op):
+        def __init__(self, child, args, kwargs):
+            self.child = child
+            self.args = args
+            self.kwargs = kwargs
+            self.name = name
+
+        def execute(self, df):
+            callable(df, *self.args, **self.kwargs)
+            df.operation = self
+            return df
+        
+        def to_json(self):
+            # return dict(type='transformation', name=name, args=self.args, kwargs=self.kwargs, child=self.child.to_json())
+            sig = inspect.signature(callable)
+            args = sig.bind(None, *self.args, **self.kwargs).arguments
+            args.pop('self')
+            return dict(type='transformation', name=name, parameters=args, child=self.child.to_json())
+
+        def __repr__(self):
+            import sys
+            import json
+            data = self.to_json()
+            json.dump(data, sys.stdout, indent=2)
+            return ''
+
+
+    return transformation_op
+
+
+def transformation(name):
+    def f(callable):
+        register[name] = generate_transformation_op(name, callable)
+        def wrapper(df, *args, execute=True, **kwargs):
+            op = register[name](df.operation, args, kwargs)
+            return op.execute(df) if execute else op
+        return wrapper
+        # return functools.wraps(callable, wrapper)
+    return f
+
+

--- a/tests/operations_test.py
+++ b/tests/operations_test.py
@@ -1,0 +1,24 @@
+import vaex.operations as vop
+import vaex
+
+def test_open():
+    path = vaex.example().path
+    op = vaex.open(path, execute=False)
+    df = op.execute()
+    assert df.path == path
+    assert df.operation.execute().path == path
+
+
+def test_add_virtual_column():
+    path = vaex.example().path
+    op = vaex.open(path, execute=False)
+    df = op.execute()
+    df['r'] = str(df.x + df.y)
+    assert df.operation.name == 'add_virtual_column'
+    assert df.operation.args[0] == 'r'
+    assert df.operation.child is op
+    
+    df['r'] = (df.r + df.y)
+    assert df.operation.name == 'add_virtual_column'
+    assert df.operation.child.name == 'rename_column'
+    repr(df.operation)


### PR DESCRIPTION
This POC solves several issues:
 * ALL operations can be recorded in the df.operation members: opening, joining, groupby etc
 * a dataframe can be serialized better, since it knows completely how it was constructed.

The state is still useful, but how they work together is something I need to think about. 

Example operations serialized to json:
```
{
  "type": "transformation",
  "name": "add_virtual_column",
  "parameters": {
    "name": "r",
    "expression": "(__r + y)",
    "column_position": 10
  },
  "child": {
    "type": "transformation",
    "name": "rename_column",
    "parameters": {
      "old": "r",
      "new": "__r"
    },
    "child": {
      "type": "transformation",
      "name": "add_virtual_column",
      "parameters": {
        "name": "r",
        "expression": "(x + y)",
        "column_position": 10
      },
      "child": {
        "type": "source",
        "name": "open",
        "parameters": {
          "path": "/Users/maartenbreddels/src/vaex/data/helmi-dezeeuw-2000-10p.hdf5"
        }
      }
    }
  }
}
```

Which reflects this code:
```python
df = vaex.open(path, execute=False)
df['r'] = df.x + df.y
df['r'] = df.r + df.y
```

