### PR TITLE
Output features property for Transformers

### DIFF
--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -22,6 +22,7 @@ def test_pca():
     # Fit-transform
     pca = vaex.ml.PCA(features=['sepal_width', 'petal_length', 'sepal_length', 'petal_width'], n_components=2)
     ds = pca.fit_transform(ds)
+    assert pca.features_ == ['PCA_5', 'PCA_6']
 
 
 def test_valid_sklearn_pca():
@@ -67,6 +68,7 @@ def test_standard_scaler():
     # Fit-transform
     scaler = vaex.ml.StandardScaler(features=['petal_width', 'petal_length'])
     ds = scaler.fit_transform(ds)
+    assert scaler.features_ == ['standard_scaled_petal_width', 'standard_scaled_petal_length']
 
 
 def test_minmax_scaler():
@@ -100,6 +102,7 @@ def test_minmax_scaler():
     # Fit-transform
     scaler = vaex.ml.MinMaxScaler(features=['petal_width', 'petal_length'])
     ds = scaler.fit_transform(ds)
+    assert scaler.features_ == ['minmax_scaled_petal_width', 'minmax_scaled_petal_length']
 
 
 def test_train_test_split_values():
@@ -142,6 +145,7 @@ def test_frequency_encoder():
     np.testing.assert_almost_equal(test_b.frequency_encoded_numbers.values,
                                    [0.166, 0.5, 0.166, 0.166, 0.],
                                    decimal=3)
+    assert fe.features_ == ['frequency_encoded_animals', 'frequency_encoded_numbers']
 
 
 def test_label_encoder():
@@ -182,6 +186,7 @@ def test_label_encoder():
     df_unseen = label_encoder.transform(df_unseen)
     assert set(df_unseen[df_unseen.x == 'dragon'].mypref_x.tolist()) == {-1}
     assert set(df_unseen[df_unseen.y == 4].mypref_x.tolist()) == {-1}
+    assert label_encoder.features_ == ['mypref_x', 'mypref_y']
 
 
 def test_one_hot_encoding():
@@ -215,6 +220,9 @@ def test_one_hot_encoding():
     # Fit-transform
     ohe = vaex.ml.OneHotEncoder(features=['kids', 'animals', 'numbers'])
     ohe.fit_transform(ds)
+    assert ohe.features_ == ['kids_boy', 'kids_girl',
+                             'animals_cat', 'animals_dog', 'animals_mouse',
+                             'numbers_0', 'numbers_1']
 
 
 def test_maxabs_scaler():
@@ -236,6 +244,7 @@ def test_maxabs_scaler():
     assert result_vaex.absmax_scaled_x.values.tolist() == result_skl[:, 0].tolist(), "scikit-learn and vaex results do not match"
     assert result_vaex.absmax_scaled_y.values.tolist() == result_skl[:, 1].tolist(), "scikit-learn and vaex results do not match"
     assert result_vaex.absmax_scaled_w.values.tolist() == result_skl[:, 2].tolist(), "scikit-learn and vaex results do not match"
+    assert scaler_vaex.features_ == ['absmax_scaled_x', 'absmax_scaled_y', 'absmax_scaled_w']
 
 
 import numpy
@@ -261,6 +270,7 @@ def test_robust_scaler():
     result_vaex = scaler_vaex.fit_transform(ds)
 
     np.testing.assert_array_almost_equal(scaler_vaex.center_, scaler_skl.center_, decimal=0.2)
+    assert scaler_vaex.features_ == ['robust_scaled_x', 'robust_scaled_y']
 
     # check that an exception is rased for invalid percentile range
     scaler_vaex = vaex.ml.RobustScaler(features=features, percentile_range=(12, 175))
@@ -282,6 +292,7 @@ def test_cyclical_transformer(tmpdir):
     df_test.state_load(state_path)
     np.testing.assert_array_almost_equal(df_test.pref_hour_x.values, [-1, 1, 0.707107, -0.707107])
     np.testing.assert_array_almost_equal(df_test.pref_hour_y.values, [0, 0, -0.707107, -0.707107])
+    assert trans.features_ == ['pref_hour_x', 'pref_hour_y']
 
 
 def test_bayesian_target_encoder(tmpdir):
@@ -297,6 +308,7 @@ def test_bayesian_target_encoder(tmpdir):
     assert df_train.enc_x1.tolist() == [0.6, 0.6, 0.6, 0.6, 0.6, 0.4, 0.4, 0.4, 0.4, 0.4]
     assert df_train.enc_x2.tolist() == [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
     assert target_encoder.mappings_ == {'x1': {'a': 0.6, 'b': 0.4}, 'x2': {'p': 0.5, 'q': 0.5}}
+    assert target_encoder.features_ == ['enc_x1', 'enc_x2']
 
     state_path = str(tmpdir.join('state.json'))
     df_train.state_write(state_path)
@@ -319,6 +331,7 @@ def test_weight_of_evidence_encoder(tmpdir, as_bool):
     np.testing.assert_array_almost_equal(df_train.woe_encoded_x.values,
                                          [13.815510, 13.815510, 1.098612, 1.098612, 1.098612, 1.098612, 0., 0.])
     assert trans.mappings_ == {'x': {'a': 13.815510557964274, 'b': 1.0986122886681098, 'c': 0.0}}
+    assert trans.features_ == ['woe_encoded_x']
 
     state_path = str(tmpdir.join('state.json'))
     df_train.state_write(state_path)


### PR DESCRIPTION
Inspired by @maartenbreddels , this PR adds `.features_` property to the vaex Transformers, which is list of output feature names. The main idea is to simplify the feature combining process during ML pipeline prototyping. 

- [x] Implement a `.features_` property to the base Transformer class
- [x] Implement a general function and private function `_get_output_features()` for populating the `.features_` list
- [x] Implement custom `_get_output_features()` the `PCA` and `OneHotEncoder` Transformers since their functionality is different compared to the majority
- [x] Update tests so that they test the new element (check test for pca!)
- [ ] Update the Changelog
- [ ] Review: Discuss and agree on implementation details, issues and changes (see text below)

This change brings some level of "awkwardness" in the implementation of (some of) the transformers:

1. Currently, `._get_output_features()` method is called during the `.fit()` method of each transformer. One idea is to introduce a `.fit()` method in the base Transformer class where `_get_output_features` will be called prior to calling a `._fit()` method. Thus we should rename the `.fit()` method of each transformer to `._fit()`. 
This will help to reduce code duplication. I am not sure how such a change would impact readability and maintainability of the code. This is similar to what `scikit-learn` does, but is this the right path for us @maartenbreddels ? Also, if we do this, the docstrings of all `.fit()` methods will be identical (maybe we can get away with this?), unless we re-define `.fit` which is defeating the point of this strategy. I am fine leaving things as they are, but i thought to mention this just in case.

2. PCA: our implementation of `_get_output_features` is tricky here, since we are not overwriting output columns but just shifting the component identifier (see `.transform` method of PCA). So, do we want the PCA implementation to change in a way that, if columns of those names already exist, an exception should be raised?
How often is one expected to re-calculate the PCA on the same features without any other changes (@xdssio). Right now, the `.features_` lists the "naive" output, i.e. the features that should be there without overwriting during `.transform` time.

3. There is some duplication/redundancy when determining the feature names. During `.fit` right now we get the list of output features (`features_`). Then, during `.transform` we still determine the output feature names just before calculating the expressions, in more or less the same way. 
Do we need to spend time in reducing this redundancy, or somehow re-factoring (the way was not obvious to me). Maybe keeping things as they are is fine for now, it looked a bit weird to me, so I thought to bring it up (@maartenbreddels).
