### PR TITLE
Fix for CI (windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ bin/.idea
 *.npy
 /**/__pycache__/*
 catboost_info/*
+.vscode
 
 # symlinks generated in setup.py
 packages/vaex-core/vaex/arrow

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -243,6 +243,7 @@ import sys
 import platform
 version = tuple(map(int, numpy.__version__.split('.')))
 
+@pytest.mark.skipif(((1,17,0) <= version <= (1,17,5)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,17,3)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
 def test_robust_scaler():
     x = np.array([-2.65395789, -7.97116295, -4.76729177, -0.76885033, -6.45609635])


### PR DESCRIPTION
This is a small fix for the appveyor CI. There is some strange issue in numpy in some 1.17.x versions that is causing our RobustScaler tests to fail. 

- [x]  All tests pass
- [x] Review