### PR TITLE
Skip robust scaler test in windows for numpy <= 1.18.1

### DIFF
--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -243,7 +243,7 @@ import sys
 import platform
 version = tuple(map(int, numpy.__version__.split('.')))
 
-@pytest.mark.skipif(((1,17,0) <= version <= (1,17,5)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,17,3)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
 def test_robust_scaler():
     x = np.array([-2.65395789, -7.97116295, -4.76729177, -0.76885033, -6.45609635])


### PR DESCRIPTION
Yet another CI fix for windows, due to a numpy issues (RobustScaler in ml).

