### PR TITLE
feat: support jitting using OSX Metal

### DIFF
--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -6,7 +6,8 @@ import vaex.utils
 supported_arrow_array_types = (pa.Array, pa.ChunkedArray)
 supported_array_types = (np.ndarray, ) + supported_arrow_array_types
 string_types = [pa.string(), pa.large_string()]
-_type_names = ["float64", "float32", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]
+_type_names_int = ["int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]
+_type_names = ["float64", "float32"] + _type_names_int
 map_arrow_to_numpy = {getattr(pa, name)(): np.dtype(name) for name in _type_names}
 map_arrow_to_numpy[pa.bool_()] = np.dtype("?")
 for unit in 's ms us ns'.split():

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -1128,9 +1128,9 @@ class Expression(with_metaclass(Meta)):
     def clip(self, lower=None, upper=None):
         return self.ds.func.clip(self, lower, upper)
 
-    def jit_metal(self, verbose=False, dtype_out='float32'):
+    def jit_metal(self, verbose=False):
         from .metal import FunctionSerializableMetal
-        f = FunctionSerializableMetal.build(self.expression, df=self.ds, verbose=verbose, compile=self.ds.is_local(), dtype_out=dtype_out)
+        f = FunctionSerializableMetal.build(self.expression, df=self.ds, verbose=verbose, compile=self.ds.is_local())
         function = self.ds.add_function('_jit', f, unique=True)
         return function(*f.arguments)
 
@@ -1498,13 +1498,12 @@ class FunctionSerializablePickle(FunctionSerializable):
 
 
 class FunctionSerializableJit(FunctionSerializable):
-    def __init__(self, expression, arguments, argument_dtypes, return_dtype, verbose=False, compile=True, dtype_out=None):
+    def __init__(self, expression, arguments, argument_dtypes, return_dtype, verbose=False, compile=True):
         self.expression = expression
         self.arguments = arguments
         self.argument_dtypes = argument_dtypes
         self.return_dtype = return_dtype
         self.verbose = verbose
-        self.dtype_out = dtype_out
         if compile:
             self.f = self.compile()
         else:
@@ -1517,8 +1516,7 @@ class FunctionSerializableJit(FunctionSerializable):
                     arguments=self.arguments,
                     argument_dtypes=list(map(lambda dtype: str(dtype.numpy), self.argument_dtypes)),
                     return_dtype=str(self.return_dtype),
-                    verbose=self.verbose,
-                    dtype_out=self.dtype_out)
+                    verbose=self.verbose)
 
     @classmethod
     def state_from(cls, state, trusted=True):
@@ -1526,11 +1524,10 @@ class FunctionSerializableJit(FunctionSerializable):
                    arguments=state['arguments'],
                    argument_dtypes=list(map(lambda s: DataType(np.dtype(s)), state['argument_dtypes'])),
                    return_dtype=DataType(np.dtype(state['return_dtype'])),
-                   verbose=state['verbose'],
-                   dtype_out=state['dtype_out'])
+                   verbose=state['verbose'])
 
     @classmethod
-    def build(cls, expression, df=None, verbose=False, compile=True, dtype_out=None):
+    def build(cls, expression, df=None, verbose=False, compile=True):
         df = df or expression.df
         # if it's a virtual column, we probably want to optimize that
         # TODO: fully extract the virtual columns, i.e. depending ones?
@@ -1549,7 +1546,7 @@ class FunctionSerializableJit(FunctionSerializable):
         arguments = list(set(names))
         argument_dtypes = [df.data_type(argument, array_type='numpy') for argument in arguments]
         return_dtype = df[expression].dtype
-        return cls(str(expression), arguments, argument_dtypes, return_dtype, verbose, compile=compile, dtype_out=dtype_out)
+        return cls(str(expression), arguments, argument_dtypes, return_dtype, verbose, compile=compile)
 
     def __call__(self, *args, **kwargs):
         '''Forward the call to the numba function'''

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -1128,6 +1128,12 @@ class Expression(with_metaclass(Meta)):
     def clip(self, lower=None, upper=None):
         return self.ds.func.clip(self, lower, upper)
 
+    def jit_metal(self, verbose=False):
+        from .metal import FunctionSerializableMetal
+        f = FunctionSerializableMetal.build(self.expression, df=self.ds, verbose=verbose, compile=self.ds.is_local())
+        function = self.ds.add_function('_jit', f, unique=True)
+        return function(*f.arguments)
+
     def jit_numba(self, verbose=False):
         f = FunctionSerializableNumba.build(self.expression, df=self.ds, verbose=verbose, compile=self.ds.is_local())
         function = self.ds.add_function('_jit', f, unique=True)

--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -381,6 +381,9 @@ class ExpressionString(ast.NodeVisitor):
     def visit_List(self, node):
         return "[{}]".format(", ".join([self.visit(k) for k in node.elts]))
 
+    def pow(self, left, right):
+        return "({left} ** {right})".format(left=left, right=right)
+
     def visit_BinOp(self, node):
         newline = indent = ""
         if self.pretty:
@@ -405,7 +408,7 @@ class ExpressionString(ast.NodeVisitor):
             elif isinstance(node.op, ast.Sub):
                 return "({left} - {right})".format(left=left, right=right)
             elif isinstance(node.op, ast.Pow):
-                return "({left} ** {right})".format(left=left, right=right)
+                return self.pow(left, right)
             elif isinstance(node.op, ast.BitAnd):
                 return "({left} & {right})".format(left=left, right=right)
             elif isinstance(node.op, ast.BitOr):

--- a/packages/vaex-core/vaex/metal.py
+++ b/packages/vaex-core/vaex/metal.py
@@ -1,0 +1,100 @@
+import numpy as np
+import threading
+
+import vaex.serialize
+from .expression import FunctionSerializableJit
+from . import expresso
+
+
+class ExpressionStringMetal(expresso.ExpressionString):
+    def pow(self, left, right):
+        return "pow({left}, {right})".format(left=left, right=right)
+
+
+def node_to_cpp(node, pretty=False):
+    return ExpressionStringMetal(pretty=pretty).visit(node)
+
+
+@vaex.serialize.register
+class FunctionSerializableMetal(FunctionSerializableJit):
+    def compile(self):
+        import runmetal
+        ast_node = expresso.parse_expression(self.expression)
+        cppcode = node_to_cpp(ast_node)
+        typemap = {'float32': 'float',
+                   'float64': 'float'}  # we downcast!
+        typenames = [typemap[dtype.name] for dtype in self.argument_dtypes]
+        metal_args = [f'const device {typename} *{name}_array [[buffer({i})]]' for i, (typename, name) in
+                      enumerate(zip(typenames, self.arguments))]
+        code_get_scalar = [f'    {typename} {name} = {name}_array[id];\n' for typename, name, in zip(typenames, self.arguments)]
+        sourcecode = '''
+#include <metal_stdlib>
+using namespace metal;
+
+float arctan2(float y, float x) {
+    return atan2(y, x);
+}
+kernel void vaex_kernel(%s,
+                        device float *vaex_output [[buffer(%i)]],
+                        uint id [[thread_position_in_grid]]) {
+%s
+    vaex_output[id] = %s;
+}
+''' % (', '.join(metal_args), len(metal_args), ''.join(code_get_scalar), cppcode)
+        if self.verbose:
+            print('Generated code:\n' + sourcecode)
+        with open('test.metal', 'w') as f:
+            print(f'Write to {f.name}')
+            f.write(sourcecode)
+
+        pm = runmetal.PyMetal()
+        pm.opendevice()
+        pm.openlibrary(sourcecode)
+        vaex_kernel = pm.getfn("vaex_kernel")
+
+        storage = threading.local()
+        lock = threading.Lock()
+
+        def wrapper(*args):
+            chunks = args = [arg * 1.0 for arg in args]
+
+            def getbuf(name, value=None, dtype=np.float32(), N=None):
+                buf = getattr(storage, name, None)
+                if value is not None:
+                    N = len(value)
+                    dtype = value.dtype
+                if buf is not None and buf.length() != dtype.itemsize * N:
+                    buf = None
+                # buf = None  # if we don't reused buffers, we can move the lock
+                if buf is None:
+                    if value is not None:
+                        value = value.astype(np.float32)
+                    else:
+                        value = np.zeros(N, dtype=dtype)
+                        print("length", N)
+                    buf = pm.numpybuffer(value)
+                    setattr(storage, name + "_array", value)
+                    # buf = pm.emptybuffer(N*dtype.itemsize)
+                    setattr(storage, name, buf)
+                else:
+                    from runmetal import mem
+                    if value is not None:
+                        mem.put(value.astype(np.float32), buf.contents())
+                return buf
+            # if 1:
+            with lock:
+                # we need to lock this part due to multithreading, it does not crash
+                # but gives invalid results (concorrent compute kernels not supported?)
+                input_buffers = [getbuf(name, chunk) for name, chunk in zip(self.arguments, chunks)]
+                output_buffer = getbuf('vaex_output', N=len(args[0]))
+                cqueue, cbuffer = pm.getqueue()
+                pm.enqueue_compute(cbuffer, vaex_kernel, input_buffers + [output_buffer])
+                pm.enqueue_blit(cbuffer, output_buffer)
+            # with lock:
+                # we can also move the lock just here, if we devide not to reuse the buffers
+                # (uncomment buf = None above)
+                pm.start_process(cbuffer)
+                pm.wait_process(cbuffer)
+                result = pm.buf2numpy(output_buffer, dtype=np.float32)
+            return result
+        return wrapper

--- a/packages/vaex-core/vaex/metal.py
+++ b/packages/vaex-core/vaex/metal.py
@@ -1,9 +1,14 @@
 import numpy as np
 import threading
+import logging
 
 import vaex.serialize
 from .expression import FunctionSerializableJit
 from . import expresso
+
+
+
+logger = logging.getLogger("vaex.webserver.tornado")
 
 
 class ExpressionStringMetal(expresso.ExpressionString):
@@ -15,12 +20,22 @@ def node_to_cpp(node, pretty=False):
     return ExpressionStringMetal(pretty=pretty).visit(node)
 
 
+import faulthandler
+faulthandler.enable()
+
 @vaex.serialize.register
 class FunctionSerializableMetal(FunctionSerializableJit):
+    device = None
     def compile(self):
-        import runmetal
+        try:
+            import Metal
+        except ImportError:
+            logging.error("Failure to import Metal, please install pyobjc-framework-Metal")
+            raise
+        import objc
         ast_node = expresso.parse_expression(self.expression)
         cppcode = node_to_cpp(ast_node)
+        dtype_out = np.dtype(self.dtype_out)
         typemap = {'float32': 'float',
                    'float64': 'float'}  # we downcast!
         typenames = [typemap[dtype.name] for dtype in self.argument_dtypes]
@@ -40,61 +55,75 @@ kernel void vaex_kernel(%s,
 %s
     vaex_output[id] = %s;
 }
-''' % (', '.join(metal_args), len(metal_args), ''.join(code_get_scalar), cppcode)
+''' % (', '.join(metal_args), len(metal_args), ''.join(code_get_scalar), cppcode) # typemap[self.dtype_out],
         if self.verbose:
             print('Generated code:\n' + sourcecode)
         with open('test.metal', 'w') as f:
             print(f'Write to {f.name}')
             f.write(sourcecode)
 
-        pm = runmetal.PyMetal()
-        pm.opendevice()
-        pm.openlibrary(sourcecode)
-        vaex_kernel = pm.getfn("vaex_kernel")
 
         storage = threading.local()
         lock = threading.Lock()
 
-        def wrapper(*args):
-            chunks = args = [arg * 1.0 for arg in args]
+        # following https://developer.apple.com/documentation/metal/basic_tasks_and_concepts/performing_calculations_on_a_gpu?language=objc
+        self.device = Metal.MTLCreateSystemDefaultDevice()
+        opts = Metal.MTLCompileOptions.new()
+        self.library = self.device.newLibraryWithSource_options_error_(sourcecode, opts, objc.NULL)
+        if self.library is None:
+            logger.error("Error compiling: %s", sourcecode)
+        kernel_name = "vaex_kernel"
+        self.vaex_kernel = self.library[0].newFunctionWithName_(kernel_name)
+        desc = Metal.MTLComputePipelineDescriptor.new()
+        desc.setComputeFunction_(self.vaex_kernel)
+        state = self.device.newComputePipelineStateWithDescriptor_error_(desc, objc.NULL)
+        command_queue = self.device.newCommandQueue()
 
-            def getbuf(name, value=None, dtype=np.float32(), N=None):
+        def wrapper(*args):
+            args = [ vaex.array_types.to_numpy(ar) for ar in args]
+            def getbuf(name, value=None, dtype=np.dtype("float32"), N=None):
                 buf = getattr(storage, name, None)
                 if value is not None:
                     N = len(value)
                     dtype = value.dtype
-                if buf is not None and buf.length() != dtype.itemsize * N:
+                if dtype.name == "float64":
+                    dtype = np.dtype("float32")
+                nbytes = N * dtype.itemsize
+                if buf is not None and buf.length() != nbytes:
+                    # doesn't match size, create a new one
                     buf = None
-                # buf = None  # if we don't reused buffers, we can move the lock
+                # create a buffer
                 if buf is None:
-                    if value is not None:
-                        value = value.astype(np.float32)
-                    else:
-                        value = np.zeros(N, dtype=dtype)
-                        print("length", N)
-                    buf = pm.numpybuffer(value)
-                    setattr(storage, name + "_array", value)
-                    # buf = pm.emptybuffer(N*dtype.itemsize)
+                    buf = self.device.newBufferWithLength_options_(nbytes, 0)
                     setattr(storage, name, buf)
-                else:
-                    from runmetal import mem
-                    if value is not None:
-                        mem.put(value.astype(np.float32), buf.contents())
+                # copy data to buffer
+                if value is not None:
+                    mv = buf.contents().as_buffer(buf.length())
+                    buf_as_numpy = np.frombuffer(mv, dtype=np.float32)
+                    buf_as_numpy[:] = value.astype(np.float32, copy=False)
                 return buf
-            # if 1:
-            with lock:
-                # we need to lock this part due to multithreading, it does not crash
-                # but gives invalid results (concorrent compute kernels not supported?)
-                input_buffers = [getbuf(name, chunk) for name, chunk in zip(self.arguments, chunks)]
-                output_buffer = getbuf('vaex_output', N=len(args[0]))
-                cqueue, cbuffer = pm.getqueue()
-                pm.enqueue_compute(cbuffer, vaex_kernel, input_buffers + [output_buffer])
-                pm.enqueue_blit(cbuffer, output_buffer)
-            # with lock:
-                # we can also move the lock just here, if we devide not to reuse the buffers
-                # (uncomment buf = None above)
-                pm.start_process(cbuffer)
-                pm.wait_process(cbuffer)
-                result = pm.buf2numpy(output_buffer, dtype=np.float32)
+            input_buffers = [getbuf(name, chunk) for name, chunk in zip(self.arguments, args)]
+            output_buffer = getbuf('vaex_output', N=len(args[0]))
+            buffers = input_buffers + [output_buffer]
+            command_buffer = command_queue.commandBuffer()
+            encoder = command_buffer.computeCommandEncoder()
+            encoder.setComputePipelineState_(state)
+            for i, buf in enumerate(buffers):
+                encoder.setBuffer_offset_atIndex_(buf, 0, i)
+            nitems = len(args[0])
+            tpgrid = Metal.MTLSize(width=nitems, height=1, depth=1)
+            # state.threadExecutionWidth() == 32 on M1 max
+            # state.maxTotalThreadsPerThreadgroup() == 1024 on M1 max
+            tptgroup = Metal.MTLSize(width=state.threadExecutionWidth(), height=state.maxTotalThreadsPerThreadgroup()//state.threadExecutionWidth(), depth=1)
+            # this is simpler, and gives the same performance
+            # tptgroup = Metal.MTLSize(width=1, height=1, depth=1)
+            encoder.dispatchThreads_threadsPerThreadgroup_(tpgrid, tptgroup)
+            encoder.endEncoding()
+            command_buffer.commit()
+            command_buffer.waitUntilCompleted()
+
+            output_buffer_py = output_buffer.contents().as_buffer(output_buffer.length())
+             # do we needs .copy() ?
+            result = np.frombuffer(output_buffer_py, dtype=dtype_out)
             return result
         return wrapper

--- a/packages/vaex-core/vaex/metal.py
+++ b/packages/vaex-core/vaex/metal.py
@@ -1,6 +1,7 @@
 import numpy as np
 import threading
 import logging
+import warnings
 
 import vaex.serialize
 from .expression import FunctionSerializableJit
@@ -33,11 +34,16 @@ class FunctionSerializableMetal(FunctionSerializableJit):
             logging.error("Failure to import Metal, please install pyobjc-framework-Metal")
             raise
         import objc
+        dtype_out = vaex.dtype(self.return_dtype).numpy
+        if dtype_out.name == "float64":
+            dtype_out = np.dtype("float32")
+            warnings.warn("Casting output from float64 to float32 since Metal does not support float64")
         ast_node = expresso.parse_expression(self.expression)
         cppcode = node_to_cpp(ast_node)
-        dtype_out = np.dtype(self.dtype_out)
         typemap = {'float32': 'float',
                    'float64': 'float'}  # we downcast!
+        for name in vaex.array_types._type_names_int:
+            typemap[name] = f'{name}_t'
         typenames = [typemap[dtype.name] for dtype in self.argument_dtypes]
         metal_args = [f'const device {typename} *{name}_array [[buffer({i})]]' for i, (typename, name) in
                       enumerate(zip(typenames, self.arguments))]
@@ -49,13 +55,18 @@ using namespace metal;
 float arctan2(float y, float x) {
     return atan2(y, x);
 }
+
+template<typename T>
+T where(bool condition, T y, T x) {
+    return condition ? x : y;
+}
 kernel void vaex_kernel(%s,
-                        device float *vaex_output [[buffer(%i)]],
+                        device %s *vaex_output [[buffer(%i)]],
                         uint id [[thread_position_in_grid]]) {
 %s
     vaex_output[id] = %s;
 }
-''' % (', '.join(metal_args), len(metal_args), ''.join(code_get_scalar), cppcode) # typemap[self.dtype_out],
+''' % (', '.join(metal_args), typemap[dtype_out.name], len(metal_args), ''.join(code_get_scalar), cppcode) # typemap[self.dtype_out],
         if self.verbose:
             print('Generated code:\n' + sourcecode)
         with open('test.metal', 'w') as f:
@@ -70,8 +81,10 @@ kernel void vaex_kernel(%s,
         self.device = Metal.MTLCreateSystemDefaultDevice()
         opts = Metal.MTLCompileOptions.new()
         self.library = self.device.newLibraryWithSource_options_error_(sourcecode, opts, objc.NULL)
-        if self.library is None:
-            logger.error("Error compiling: %s", sourcecode)
+        if self.library[0] is None:
+            msg = f"Error compiling: {sourcecode}, sourcecode"
+            logger.error(msg)
+            raise RuntimeError(msg)
         kernel_name = "vaex_kernel"
         self.vaex_kernel = self.library[0].newFunctionWithName_(kernel_name)
         desc = Metal.MTLComputePipelineDescriptor.new()
@@ -80,13 +93,14 @@ kernel void vaex_kernel(%s,
         command_queue = self.device.newCommandQueue()
 
         def wrapper(*args):
-            args = [ vaex.array_types.to_numpy(ar) for ar in args]
+            args = [vaex.array_types.to_numpy(ar) for ar in args]
             def getbuf(name, value=None, dtype=np.dtype("float32"), N=None):
                 buf = getattr(storage, name, None)
                 if value is not None:
                     N = len(value)
                     dtype = value.dtype
                 if dtype.name == "float64":
+                    warnings.warn("Casting input argument from float64 to float32 since Metal does not support float64")
                     dtype = np.dtype("float32")
                 nbytes = N * dtype.itemsize
                 if buf is not None and buf.length() != nbytes:
@@ -99,11 +113,11 @@ kernel void vaex_kernel(%s,
                 # copy data to buffer
                 if value is not None:
                     mv = buf.contents().as_buffer(buf.length())
-                    buf_as_numpy = np.frombuffer(mv, dtype=np.float32)
-                    buf_as_numpy[:] = value.astype(np.float32, copy=False)
+                    buf_as_numpy = np.frombuffer(mv, dtype=dtype)
+                    buf_as_numpy[:] = value.astype(dtype, copy=False)
                 return buf
             input_buffers = [getbuf(name, chunk) for name, chunk in zip(self.arguments, args)]
-            output_buffer = getbuf('vaex_output', N=len(args[0]))
+            output_buffer = getbuf('vaex_output', N=len(args[0]), dtype=dtype_out)
             buffers = input_buffers + [output_buffer]
             command_buffer = command_queue.commandBuffer()
             encoder = command_buffer.computeCommandEncoder()

--- a/tests/jit_test.py
+++ b/tests/jit_test.py
@@ -32,25 +32,6 @@ def test_numba(ds):
     np.testing.assert_array_almost_equal(ds.arc_distance.tolist(), ds.arc_distance_jit.tolist())
 
 
-# @pytest.mark.skipif(sys.version_info < (3,6) and sys.version_info[0] != 2,
-#                     reason="no support for python3.5 (numba segfaults)")
-def test_metal(df_local):
-    df = df_local
-    df_original = df.copy()
-    #df.columns['x'] = (df.columns['x']*1).copy()  # convert non non-big endian for now
-    expr = arc_distance(df.y*1, df.y*1, df.y**2*df.y, df.x+df.y)
-    # expr = df.x + df.y
-    df['arc_distance'] = expr
-    #assert df.arc_distance.expression == expr.expression
-    df['arc_distance_jit'] = df['arc_distance'].jit_metal()
-    # assert df.arc_distance.tolist() == df.arc_distance_jit.tolist()
-    np.testing.assert_almost_equal(df.arc_distance.values, df.arc_distance_jit.values, decimal=1)
-    # TODO: make it such that they can be pickled
-    df_original.state_set(df.state_get())
-    df = df_original
-    np.testing.assert_almost_equal(df.arc_distance.values, df.arc_distance_jit.values, decimal=1)
-
-
 @pytest.mark.skipif(sys.version_info < (3,6) and sys.version_info[0] != 2,
                     reason="no support for python3.5 (numba segfaults)")
 def test_jit_overwrite(ds_local):
@@ -79,3 +60,31 @@ def test_cuda(ds_local):
     ds_original.state_set(ds.state_get())
     ds = ds_original
     np.testing.assert_almost_equal(ds.arc_distance.values, ds.arc_distance_jit.values)
+
+
+def test_metal(df_local):
+    pytest.importorskip("Metal")
+    df = df_local
+    df_original = df.copy()
+    #df.columns['x'] = (df.columns['x']*1).copy()  # convert non non-big endian for now
+    expr = arc_distance(df.y*1, df.y*1, df.y**2*df.y, df.x+df.y)
+    # expr = df.x + df.y
+    df['arc_distance'] = expr
+    #assert df.arc_distance.expression == expr.expression
+    df['arc_distance_jit'] = df['arc_distance'].jit_metal()
+    # assert df.arc_distance.tolist() == df.arc_distance_jit.tolist()
+    np.testing.assert_almost_equal(df.arc_distance.values, df.arc_distance_jit.values, decimal=1)
+    # TODO: make it such that they can be pickled
+    df_original.state_set(df.state_get())
+    df = df_original
+    np.testing.assert_almost_equal(df.arc_distance.values, df.arc_distance_jit.values, decimal=1)
+
+
+@pytest.mark.parametrize("type_name", vaex.array_types._type_names)
+def test_types_metal(type_name, df_factory_numpy):
+    pytest.importorskip("Metal")
+    df = df_factory_numpy(x=np.array([0, 1, 2], dtype=type_name), y=[2, 3, 4])
+    # df = df_factory_numpy(x=np.array([0, 1, 2], dtype=type_name), y=np.array([2, 3, 4], dtype=type_name))
+    # df['x'] = df['x'].astype(type_name)
+    df['z'] = (df['x'] + df['y']).jit_metal()
+    assert df['z'].tolist() == [2, 4, 6]

--- a/tests/jit_test.py
+++ b/tests/jit_test.py
@@ -34,7 +34,8 @@ def test_numba(ds):
 
 # @pytest.mark.skipif(sys.version_info < (3,6) and sys.version_info[0] != 2,
 #                     reason="no support for python3.5 (numba segfaults)")
-def test_metal(df):
+def test_metal(df_local):
+    df = df_local
     df_original = df.copy()
     #df.columns['x'] = (df.columns['x']*1).copy()  # convert non non-big endian for now
     expr = arc_distance(df.y*1, df.y*1, df.y**2*df.y, df.x+df.y)


### PR DESCRIPTION
Proof of concept for jitting using Metal. Unfortunately, this does not work that great. We can't schedule multiple compute kernels multithreaded, it seems to share some memory/state, because the results are garbled up without the lock in `metal.py`. Disabling ths lock gives speedups of `>2x`, on a 2018 MacBook 15" with Radeon Pro 560 4GB. With the lock the performance is the same as on my CPU.

Requires https://github.com/wtnb75/runmetal/
`pip install git+https://github.com/wtnb75/runmetal/` should do it.

A way out could be to do an MetalExecutor, meaning we take control of the whole execution part, single threaded, and execute all the code on the GPU, but that requires a lot more work.

Putting this out there in case someone finds this interesting, or has ideas how to avoid that lock.

Example usage:
```python
import vaex
import numpy as np
# From http://pythonhosted.org/pythran/MANUAL.html
def arc_distance(theta_1, phi_1, theta_2, phi_2):
    """
    Calculates the pairwise arc distance
    between all points in vector a and b.
    """
    temp = (np.sin((theta_2-theta_1)/2)**2
           + np.cos(theta_1)*np.cos(theta_2) * np.sin((phi_2-phi_1)/2)**2)
    distance_matrix = 2 * np.arctan2(np.sqrt(temp), np.sqrt(1-temp))
    return distance_matrix

df = vaex.open('s3://vaex/taxi/yellow_taxi_2009_2015_f32.hdf5?anon=true')[:200_000_000]
expr = arc_distance(df.pickup_longitude, df.pickup_latitude, df.dropoff_longitude, df.dropoff_latitude)
df['arc_distance'] = expr
#assert df.arc_distance.expression == expr.expression
df['arc_distance_jit'] = df['arc_distance'].jit_metal()

# cell2
%%time
df.arc_distance.sum()

# cell 3
%%time
df.arc_distance_jit.sum()
```