### PR TITLE
feat: let to_items/pandas_df/arrow_table return chunked iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
       * Give proper NameError when using non-existing column names [#299](https://github.com/vaexio/vaex/pull/299)
    * Features
       * New lazy numpy wrappers: np.digitize and np.searchsorted [#573](https://github.com/vaexio/vaex/pull/573)
+      * df.to_arrow_table/to_pandas_df/to_items now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589)
 
 # vaex-server 0.3.0-dev
    * Refactored server, can return multiple binary blobs, execute multiple tasks, cancel tasks, encoding/serialization is more flexible (like returning masked arrays). [#571](https://github.com/vaexio/vaex/pull/557)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -126,10 +126,15 @@ _doc_snippets['note_copy'] = '.. note:: Note that no copy of the underlying data
 _doc_snippets['note_filter'] = '.. note:: Note that filtering will be ignored (since they may change), you may want to consider running :meth:`extract` first.'
 _doc_snippets['inplace'] = 'Make modifications to self or return a new DataFrame'
 _doc_snippets['return_shallow_copy'] = 'Returns a new DataFrame with a shallow copy/view of the underlying data'
+_doc_snippets['chunk_size'] = 'Return an iterator with cuts of the object in lenght of this size'
+_doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel'
+
+
 def docsubst(f):
     if f.__doc__:
         f.__doc__ = f.__doc__.format(**_doc_snippets)
     return f
+
 
 _functions_statistics_1d = []
 
@@ -2671,18 +2676,25 @@ class DataFrame(object):
                 yield previous_l1, previous_l2, previous_chunk
 
     @docsubst
-    def to_items(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True):
+    def to_items(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None):
         """Return a list of [(column_name, ndarray), ...)] pairs where the ndarray corresponds to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
         :param selection: {selection}
         :param strings: argument passed to DataFrame.get_column_names when column_names is None
         :param virtual: argument passed to DataFrame.get_column_names when column_names is None
-        :return: list of (name, ndarray) pairs
+        :param parallel: {evaluate_parallel}
+        :param chunk_size: {chunk_size}
+        :return: list of (name, ndarray) pairs or iterator of
         """
-        items = []
-        column_names = self.get_column_names(strings=strings, virtual=virtual)
-        return list(zip(column_names, self.evaluate(column_names, selection=selection, parallel=parallel)))
+        column_names = column_names or self.get_column_names(strings=strings, virtual=virtual)
+        if chunk_size is not None:
+            def iterator():
+                for i1, i2, chunks in self.evaluate_iterator(column_names, selection=selection, parallel=parallel, chunk_size=chunk_size):
+                    yield i1, i2, list(zip(column_names, chunks))
+            return iterator()
+        else:
+            return list(zip(column_names, self.evaluate(column_names, selection=selection, parallel=parallel)))
 
     @docsubst
     def to_arrays(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True):
@@ -2749,7 +2761,7 @@ class DataFrame(object):
         self.description = other.description
 
     @docsubst
-    def to_pandas_df(self, column_names=None, selection=None, strings=True, virtual=False, index_name=None, parallel=True):
+    def to_pandas_df(self, column_names=None, selection=None, strings=True, virtual=False, index_name=None, parallel=True, chunk_size=None):
         """Return a pandas DataFrame containing the ndarray corresponding to the evaluated data
 
          If index is given, that column is used for the index of the dataframe.
@@ -2764,34 +2776,57 @@ class DataFrame(object):
         :param strings: argument passed to DataFrame.get_column_names when column_names is None
         :param virtual: argument passed to DataFrame.get_column_names when column_names is None
         :param index_column: if this column is given it is used for the index of the DataFrame
-        :return: pandas.DataFrame object
+        :param parallel: {evaluate_parallel}
+        :param chunk_size: {chunk_size}
+        :return: pandas.DataFrame object or iterator of
         """
         import pandas as pd
-        data = self.to_dict(column_names=column_names, selection=selection, strings=strings, virtual=virtual, parallel=True)
-        if index_name is not None:
-            if index_name in data:
+        column_names = column_names or self.get_column_names(strings=strings, virtual=virtual)
+        if index_name not in column_names and index_name is not None:
+            column_names = column_names + [index_name]
+
+        def create_pdf(data):
+            if index_name is not None:
                 index = data.pop(index_name)
             else:
-                index = self.evaluate(index_name, selection=selection)
+                index = None
+            df = pd.DataFrame(data=data, index=index)
+            if index is not None:
+                df.index.name = index_name
+            return df
+        if chunk_size is not None:
+            def iterator():
+                for i1, i2, chunks in self.evaluate_iterator(column_names, selection=selection, parallel=parallel, chunk_size=chunk_size):
+                    yield i1, i2, create_pdf(dict(zip(column_names, chunks)))
+            return iterator()
         else:
-            index = None
-        df = pd.DataFrame(data=data, index=index)
-        if index is not None:
-            df.index.name = index_name
-        return df
+            return create_pdf(self.to_dict(column_names=column_names, selection=selection, parallel=parallel))
 
     @docsubst
-    def to_arrow_table(self, column_names=None, selection=None, strings=True, virtual=False):
+    def to_arrow_table(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None):
         """Returns an arrow Table object containing the arrays corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
         :param selection: {selection}
         :param strings: argument passed to DataFrame.get_column_names when column_names is None
         :param virtual: argument passed to DataFrame.get_column_names when column_names is None
-        :return: pyarrow.Table object
+        :param parallel: {evaluate_parallel}
+        :param chunk_size: {chunk_size}
+        :return: pyarrow.Table object or iterator of
         """
-        from vaex_arrow.convert import arrow_table_from_vaex_df
-        return arrow_table_from_vaex_df(self, column_names, selection, strings, virtual)
+        from vaex_arrow.convert import arrow_table_from_vaex_df, arrow_array_from_numpy_array
+        import pyarrow as pa
+        column_names = column_names or self.get_column_names(strings=strings, virtual=virtual)
+        if chunk_size is not None:
+            def iterator():
+                for i1, i2, chunks in self.evaluate_iterator(column_names, selection=selection, parallel=parallel, chunk_size=chunk_size):
+                    chunks = list(map(arrow_array_from_numpy_array, chunks))
+                    yield i1, i2, pa.Table.from_arrays(chunks, column_names)
+            return iterator()
+        else:
+            chunks = self.evaluate(column_names, selection=selection, parallel=parallel)
+            chunks = list(map(arrow_array_from_numpy_array, chunks))
+            return pa.Table.from_arrays(chunks, column_names)
 
     @docsubst
     def to_astropy_table(self, column_names=None, selection=None, strings=True, virtual=False, index=None, parallel=True):

--- a/tests/from_json_test.py
+++ b/tests/from_json_test.py
@@ -6,7 +6,7 @@ def test_from_json(ds_local):
     df = ds_local
 
     # Create temporary json files
-    pandas_df = df.to_pandas_df(df, virtual=True)
+    pandas_df = df.to_pandas_df(virtual=True)
     tmp = tempfile.mktemp('.json')
     with open(tmp, 'w') as f:
         f.write(pandas_df.to_json())

--- a/tests/to_test.py
+++ b/tests/to_test.py
@@ -1,0 +1,42 @@
+def test_to_items(df_local):
+    df = df_local
+    items = df.to_items(['x', 'y'])
+    (xname, xvalues), (yname, yvalues) = items
+    assert xname == 'x'
+    assert yname == 'y'
+    assert xvalues.tolist() == df.x.tolist()
+    assert yvalues.tolist() == df.y.tolist()
+
+    for i1, i2, items in df.to_items(['x', 'y'], chunk_size=3):
+        (xcname, xcvalues), (ycname, ycvalues) = items
+        assert xcname == 'x'
+        assert ycname == 'y'
+        assert xcvalues.tolist() == xvalues[i1:i2].tolist()
+        assert ycvalues.tolist() == yvalues[i1:i2].tolist()
+
+
+def test_to_arrow_table(df_local):
+    df = df_local
+    t = df.to_arrow_table(['x', 'y'])
+    record_batches = t.to_batches(3)
+    index = 0
+    for i1, i2, tc in df.to_arrow_table(['x', 'y'], chunk_size=3):
+        record_batches[index].to_pydict() == tc.to_pydict()
+        index += 1
+
+
+def test_to_pandas_df(df_local):
+    df = df_local
+    pdf = df.to_pandas_df(['x', 'y'], index_name='x')
+    assert pdf.index.name == 'x'
+    assert pdf.columns == ['y']
+    assert pdf.index.values.tolist() == df.x.tolist()
+    assert pdf.y.values.tolist() == df.y.tolist()
+    x = df.x.values
+    y = df.y.values
+
+    for i1, i2, pdf in df.to_pandas_df(['y'], index_name='x', chunk_size=3):
+        assert pdf.index.name == 'x'
+        assert pdf.columns == ['y']
+        assert pdf.index.values.tolist() == x[i1:i2].tolist()
+        assert pdf.y.values.tolist() == y[i1:i2].tolist()


### PR DESCRIPTION
This is useful for outputting to csv or arrow very large dataframes
with virtual columns that cannot be kept into memory.

Example usage for csv:
```python
import vaex
df = vaex.open('s3://vaex/taxi/yellow_taxi_2009_2015_f32.hdf5?anon=true')[:1_000_000]
df = df[['passenger_count', 'fare_amount', 'pickup_datetime']]
for i1, i2, pdf in df.to_pandas_df(chunk_size=100_000):
    fn = f'taxi_{i1}-{i2}.csv'
    print(fn)
    pdf.to_csv(fn)
```

Or outputting to parquet
```python
schema = df[0:1].to_arrow_table().schema
with pq.ParquetWriter('example.parquet', schema) as writer:
    for i1, i2, table in df.to_arrow_table(chunk_size=100_000):
        print(i1, i2)
        writer.write_table(table)
```

Note that we probably want a nicer way to get the arrow schema. Also, we yield the row indices, should we also yield the chunk_index? e.g.:
```python
for chunk_index, row_begin, row_end, pdf in df.to_pandas_df(chunk_size=100_000):
```

We may want to put this into the docs @JovanVeljanoski , maybe open an item for this, basically we need a single page for IO.