### PR TITLE
Make df.column_count to not count hidden columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
       * Copying/printing sparse matrices [#615](https://github.com/vaexio/vaex/pull/615)
       * Fix the links to the example datasets. [#609](https://github.com/vaexio/vaex/pull/609)
       * Expression.isin supports dtype=object [#669](https://github.com/vaexio/vaex/pull/669)
+      * Fix `colum_count`, now only counts hidden columns if expicitly specified [#593](https://github.com/vaexio/vaex/pull/593)
    * Features
       * New lazy numpy wrappers: np.digitize and np.searchsorted [#573](https://github.com/vaexio/vaex/pull/573)
       * df.to_arrow_table/to_pandas_df/to_items now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3655,9 +3655,13 @@ class DataFrame(object):
         # currenly disabled
         return False
 
-    def column_count(self):
-        """Returns the number of columns (including virtual columns)."""
-        return len(self.get_column_names())
+    def column_count(self, hidden=False):
+        """Returns the number of columns (including virtual columns).
+
+        :param bool hidden: If True, include hidden columns in the tally
+        :returns: Number of columns in the DataFrame
+        """
+        return len(self.get_column_names(hidden=hidden))
 
     def get_names(self, hidden=False):
         """Return a list of column names and variable names."""

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3657,7 +3657,7 @@ class DataFrame(object):
 
     def column_count(self):
         """Returns the number of columns (including virtual columns)."""
-        return len(self.column_names)
+        return len(self.get_column_names())
 
     def get_names(self, hidden=False):
         """Return a list of column names and variable names."""

--- a/tests/column_test.py
+++ b/tests/column_test.py
@@ -73,3 +73,14 @@ def test_dtype_object_with_arrays():
     df = vaex.from_arrays(z=z)
     assert df.z.tolist()[0].tolist() == x.tolist()
     assert df.z.tolist()[1].tolist() == y.tolist()
+
+
+def test_column_count():
+    x = np.array([1, 2, np.nan])
+    df = vaex.from_arrays(x=x)
+
+    df['new_x'] = df.x + 1
+    df['new_x'] = df['new_x'].fillna(value=0)
+
+    assert df.column_count() == 2
+    assert df.new_x.tolist() == [2, 3, 0]

--- a/tests/column_test.py
+++ b/tests/column_test.py
@@ -80,7 +80,14 @@ def test_column_count():
     df = vaex.from_arrays(x=x)
 
     df['new_x'] = df.x + 1
-    df['new_x'] = df['new_x'].fillna(value=0)
 
     assert df.column_count() == 2
-    assert df.new_x.tolist() == [2, 3, 0]
+
+    # Overwriting a column will rename a column to a hidden column
+    df['new_x'] = df['new_x'].fillna(value=0)
+
+    # By default we do not count hidden columns
+    assert df.column_count() == 2
+
+    # We can count hidden columns if explicity specified
+    assert df.column_count(hidden=True) == 3


### PR DESCRIPTION
This PR makes `df.column_count()` to not count hidden columns in the DataFrame

- [x] Add test
- [x] Make changes
- [ ] Review