### PR TITLE
Bug in .isin() for string columns that have None

### DIFF
--- a/tests/isin_test.py
+++ b/tests/isin_test.py
@@ -5,19 +5,22 @@ import vaex
 def test_isin():
     x = np.array([1.01, 2.02, 3.03])
     y = np.array([1, 3, 5])
-    z = np.array(['dog', 'cat', 'mouse'])
+    s = np.array(['dog', 'cat', 'mouse'])
+    sm = np.array(['dog', 'cat', None])
     w = np.array([2, '1.1', None])
     m = np.ma.MaskedArray(data=[np.nan, 1, 1], mask=[True, True, False])
     n = np.array([-5, np.nan, 1])
-    df = vaex.from_arrays(x=x, y=y, z=z, w=w, m=m, n=n)
+    df = vaex.from_arrays(x=x, y=y, s=s, sm=sm, w=w, m=m, n=n)
 
     assert df.x.isin([1, 2.02, 5, 6]).tolist() == [False, True, False]
     assert df.y.isin([5, -1, 0]).tolist() == [False, False, True]
-    assert df.z.isin(['elephant', 'dog']).tolist() == [True, False, False]
+    assert df.s.isin(['elephant', 'dog']).tolist() == [True, False, False]
+    assert df.sm.isin(['cat', 'dog']).tolist() == [True, True, False]
     assert df.w.isin([2, None]).tolist() == [True, False, True]
     assert df.m.isin([1, 2, 3]).tolist() == [False, False, True]
+    assert df.n.isin([2, np.nan]).tolist() == [False, True, False]
     # TODO: this fails, we should have a separate issue for it
-    #assert df.n.isin([2, np.nan]).tolist() == [False, True, False]
+    assert df.n.isin([2, np.nan]).tolist() == [False, True, False]
 
 
 def test_isin_object():


### PR DESCRIPTION
This test uncovers a bug in `.isin` method: if a column is string, and has `None` values inside, `.isin` will return `False` for all samples. 

- [x] Update test to cover the issue
- [ ] Make test pass

