### PR TITLE
Feature: Tensorflow Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ before_install:
   - which pip
   - pip install python-dateutil==2.8.0  # botocore caps dateutil leading to issues
   - pip install -r requirements.txt
+  - pip install tensorflow>=2.1.0      # At least temporary until we find a better place for it
+  - pip install tensorflow-io>=0.12.0  # At least temporary until we find a better place for it
   # - pip install -r requirements-ml.txt
 install:
   - source activate test-environment

--- a/packages/vaex-ml/setup.py
+++ b/packages/vaex-ml/setup.py
@@ -21,9 +21,11 @@ setup(name=name + '-ml',
       author=author,
       author_email=author_email,
       install_requires=install_requires_ml,
+      extras_require={'ml.tensorflow': ['tensorflow>=2.1.0', 'tensorflow-io>=0.12.0']},
       license=license,
       packages=['vaex.ml', 'vaex.ml.incubator', 'vaex.ml.datasets'],
       include_package_data=True,
       zip_safe=False,
-      entry_points={'vaex.dataframe.accessor': ['ml = vaex.ml:DataFrameAccessorML']}
+      entry_points={'vaex.dataframe.accessor': ['ml = vaex.ml:DataFrameAccessorML',
+                                                'ml.tensorflow = vaex.ml.tensorflow:DataFrameAccessorTensorflow']}
 )

--- a/packages/vaex-ml/vaex/ml/tensorflow.py
+++ b/packages/vaex-ml/vaex/ml/tensorflow.py
@@ -1,0 +1,70 @@
+from functools import partial
+
+
+import tensorflow as tf
+
+import tensorflow_io.arrow as arrow_io
+from tensorflow_io.arrow.python.ops.arrow_dataset_ops import arrow_schema_to_tensor_types
+
+
+class DataFrameAccessorTensorflow(object):
+    def __init__(self, ml):
+        self.ml = ml
+        self.df = self.ml.df
+
+    def _arrow_batch_generator(self, features, target=None, chunk_size=1024):
+        column_names = features + [target] if target is not None else features
+        for i1, i2, table in self.df.to_arrow_table(column_names=column_names, chunk_size=chunk_size):
+            yield table.to_batches(chunk_size)[0]
+
+    @staticmethod
+    def _get_batch_arrow_schema(arrow_batch):
+        output_types, output_shapes = arrow_schema_to_tensor_types(arrow_batch.schema)
+        return output_types, output_shapes
+
+    def to_dataset(self, features, target=None, chunk_size=1024, repeat=None, shuffle=False, keras=False):
+
+        # Set up the iterator factory
+        iterator_factory = partial(self._arrow_batch_generator, **{'features': features,
+                                                                   'target': target,
+                                                                   'chunk_size': chunk_size})
+        # get the arrow schema
+        output_types, output_shapes = self._get_batch_arrow_schema(next(iterator_factory()))
+
+        # Define the TF dataset
+        ds = arrow_io.ArrowStreamDataset.from_record_batches(record_batch_iter=iterator_factory(),
+                                                             output_types=output_types,
+                                                             output_shapes=output_shapes,
+                                                             batch_mode='auto',
+                                                             record_batch_iter_factory=iterator_factory)
+
+        # Reshape the data into the appropriate format
+        if keras:
+            if target is not None:
+                ds = ds.map(lambda *tensors: (tf.stack(tensors[:-1], axis=1), tensors[-1]))
+            else:
+                ds = ds.map(lambda *tensors: (tf.stack(tensors, axis=1)))
+        else:
+            if target is not None:
+                ds = ds.map(lambda *tensors: (dict(zip(features, tensors[:-1])), tensors[-1]))
+            else:
+                ds = ds.map(lambda *tensors: (dict(zip(features, tensors))))
+
+        # Repeating and shuffling the dataset if needed
+        if shuffle:
+            ds = ds.shuffle(chunk_size)
+        if repeat is not None:
+            ds = ds.repeat(repeat)
+
+        return ds
+
+    def make_input_function(self, features, target=None, chunk_size=1024, repeat=None, shuffle=False):
+        def tf_input_function():
+            return self.to_dataset(features=features,
+                                   target=target,
+                                   chunk_size=chunk_size,
+                                   repeat=repeat,
+                                   shuffle=shuffle)
+        return tf_input_function
+
+

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -2,3 +2,5 @@ catboost
 lightgbm
 scikit-learn
 annoy
+tensorflow>=2.1.0
+tensorflow-io>=0.12.0

--- a/tests/ml/tensorflow_test.py
+++ b/tests/ml/tensorflow_test.py
@@ -1,0 +1,112 @@
+import logging
+
+import pytest
+pytest.importorskip("tensorflow")
+pytest.importorskip("tensorflow_io")
+
+import tensorflow as tf
+
+import vaex
+import vaex.ml
+
+
+
+logger = tf.get_logger()
+logger.setLevel(logging.ERROR)
+
+
+# Set up the data to be used in this test file
+df = vaex.ml.datasets.load_iris()
+df_train, df_test = df.ml.train_test_split(test_size=0.2, verbose=False)
+features = df.column_names[:4]
+target = 'class_'
+
+
+def test_to_dataset_tensorflow():
+    ds = df_test.ml.tensorflow.to_dataset(features=features, target=target, chunk_size=10)
+    list_ds = list(ds)
+    assert len(list_ds) == 3  # The number of "batches" in the iterable, as defined by the chunk_size arg
+
+    idx_min = 0
+    idx_max = 10
+    for batch in list_ds:
+        assert len(batch) == 2  # check that each batch has feature matrix and target matrix (hence tuple of len 2)
+        # Assert the target
+        assert batch[1].numpy().tolist() == df_test[target][idx_min:idx_max].tolist()
+        # Assert each feature individually
+        for feat in batch[0]:
+            assert batch[0][feat].numpy().tolist() == df_test[feat][idx_min:idx_max].tolist()
+        # Shift index according to what the batch should be
+        idx_min += 10
+        idx_max += 10
+
+
+def test_to_dataset_keras():
+    ds = df_test.ml.tensorflow.to_dataset(features=features, target=target, chunk_size=10, keras=True)
+    list_ds = list(ds)
+    assert len(list_ds) == 3  # The number of "batches" in the iterable, as defined by the chunk_size arg
+
+    idx_min = 0
+    idx_max = 10
+    for batch in list_ds:
+        assert len(batch) == 2  # check that each batch has feature matrix and target matrix (hence tuple of len 2)
+        # Assert the target
+        assert batch[1].numpy().tolist() == df_test[target][idx_min:idx_max].tolist()
+        # Assert the feature tensor
+        assert batch[0].numpy().tolist() == df_test[features][idx_min:idx_max].values.tolist()
+        # Shift index according to what the batch should be
+        idx_min += 10
+        idx_max += 10
+
+
+@pytest.mark.parametrize("repeat", [1, 3, 10])
+@pytest.mark.parametrize("shuffle", [False, True])
+def test_to_dataset_tensorflow_options(repeat, shuffle):
+    num_batches = repeat * 3
+
+    ds = df_test.ml.tensorflow.to_dataset(features=features, target=target, chunk_size=10, repeat=repeat, shuffle=shuffle)
+    list_ds = list(ds)
+    assert len(list_ds) == num_batches  # The number of "batches" in the iterable, as defined by the chunk_size arg
+
+
+def test_make_input_function():
+    train_fn = df_train.ml.tensorflow.make_input_function(features=features, target=target, chunk_size=120, repeat=5)
+    eval_fn = df_test.ml.tensorflow.make_input_function(features=features, target=target, chunk_size=120)
+    test_fn = df_test.ml.tensorflow.make_input_function(features=features, chunk_size=120)
+
+    feature_columns = []
+    for feat in features:
+        feature_columns.append(tf.feature_column.numeric_column(key=feat))
+
+    est = tf.estimator.LinearClassifier(n_classes=3, feature_columns=feature_columns)
+    est.train(train_fn)
+    evaluation = est.evaluate(eval_fn)
+    assert len(evaluation) == 4  # the exact contents of the dict is not important, important is that it can be obrained
+
+    predictions = list(est.predict(test_fn, yield_single_examples=False))[0]
+    assert predictions['logits'].shape == (30, 3)
+    assert predictions['probabilities'].shape == (30, 3)
+    assert predictions['classes'].shape == (30, 1)
+    assert predictions['class_ids'].shape == (30, 1)
+    assert predictions['all_class_ids'].shape == (30, 3)
+    assert predictions['all_classes'].shape == (30, 3)
+    assert list(predictions.keys()) == ['logits', 'probabilities', 'class_ids', 'classes', 'all_class_ids', 'all_classes']
+
+
+def test_to_dataset_keras_model_train():
+
+    # Define the keras input functions
+    train_ds = df_train.ml.tensorflow.to_dataset(features=features, target=target, keras=True)
+    test_ds = df_test.ml.tensorflow.to_dataset(features=features, keras=True)
+
+    # Defne a simple keras model
+    model = tf.keras.Sequential()
+    model.add(tf.keras.layers.Dense(units=4, input_shape=(4,), activation='relu'))
+    model.add(tf.keras.layers.Dense(units=1, activation='sigmoid'))
+    model.compile(optimizer=tf.keras.optimizers.RMSprop(),
+                  loss='categorical_crossentropy',
+                  metrics=['accuracy'])
+
+    model.fit(train_ds)
+    predictions = model.predict(test_ds)
+    assert len(predictions) == len(df_test)


### PR DESCRIPTION
This PR realises #616 
The idea is enable vaex DataFrames to be used as input data sources for tensorflow (tf) data sources. 

This is made possible in large part thanks to [`tensorflow-io`](https://github.com/tensorflow/io) via arrow. 

- [x] A method to convert vaex DataFrames to tf datasets, to be used as input for tensorflow Estimators. This is now possible via `df.ml.tensorflow.to_dataset()`
- [x] A convenience function meant as a direct data source for tf Estimators. Note that tf Estimator consume an input function that returns a dataset object, rather than the dataset object itself.
- [x] Enabling the `to_dataset()` method do make the dataset compatible with Keras, so that one can use the dataset as an input for the Keras model `.fit()` method.
- [ ] A high level wrapper for the tf Estimators, which will make them easily consumable on the vaex side, while also turning them into vaex transformers, and also serialise them, and make them compatible with the state transfer system.
- [ ] A high level wrapper that will turn a pre-defined keras model into a vaex transformer.
- [ ] Unit tests (providing enough coverage & passing)
- [ ] Update the CHANGELOG when/if this PR is considered to be accepted
- [ ] Code review approval

Important notes:
- It is not readily obvious what the API of the high level wrapper for the tf Estimators should be. Typically, such wrappers need a `features` argument, used to select which features/columns of the vaex DataFrame should be used. To instantiate tf Estimators one need to provide one or more (in the case of `DNNLinearCombinedEstimator`) lists of `feature_columns` which give more detail to tf about the features, i.e. options on whether the features and numerical, categorical, providing various options of handing categorical variables, as well as options for engineering new features from the primary ones. In addition, some tf Estimators require various kwargs to be instantiated. Thus, over the next few days I will add some example code as comments here, from the user side, so we can decide on the type of API we should go with. 
- The test currently named `test_to_dataset_keras_model_train` that tests the successful passing of a vaex DataFrame to keras model via  a tf dataset fails with a segmentation fault.  At this point, I do not know whether this arises due to problems in vaex, tensorflow, tensorflow-io, or the code committed in this PR. However, my independent testing have also found other segmentation faults happening when making an input function or a dataset to be used for tf Estimators. Thus it is important that we investigate this issue.  
- At this point in time, we are using `tensorflow-io.arrow` to pass vaex data to keras, but this is not strictly necessary. It might be useful to investigate performance when using the tensorflow-io.arrow connection vs simply using vaex iterators  to pass numpy arrays to the keras models `.fit` method, since it can consume generators that return numpy arrays,