### PR TITLE
Perf(core): even more efficient check for types in a column when creating a DataFrame

### DIFF
--- a/benchmarks/from_pandas.py
+++ b/benchmarks/from_pandas.py
@@ -20,4 +20,4 @@ print('it took {} to convert {:,} rows ({:.1f} Gb), which is {:,} rows per secon
 
 # Last result when running on:
 # 2.8 GHz Quad-Core Intel Core i7; 16 GB 1600 MHz DDR3:
-# it took 0:00:07.244279 to convert 12,748,986 rows (1.8 Gb), which is 1,759,869 rows per second
+# it took 0:00:04.454153 to convert 12,748,986 rows (1.8 Gb), which is 2,862,269 rows per second


### PR DESCRIPTION
This change improves the performance of `vaex.from_pandas` further on top of the improvement made in #612: from 1.76 to 2.86 million rows per second on the NYC Taxi data of around 1.8 Gb.