### PR TITLE
fix(core): don't export symbols in cextensions, might avoid tensorflow and torch crash

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -71,6 +71,8 @@ if sys.platform == 'darwin':
 extra_link_args = []
 if sys.platform == 'linux':
     extra_link_args.append('-Wl,--version-script=src/ext.version')
+    extra_compile_args.append("-fvisibility=hidden")
+    extra_link_args.append("-fvisibility=hidden")
 
 # on windows (Conda-forge builds), the dirname is an absolute path
 extension_vaexfast = Extension("vaex.vaexfast", [os.path.relpath(os.path.join(dirname, "src/vaexfast.cpp"))],

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -68,11 +68,15 @@ else:
     extra_compile_args.append("-g")
 if sys.platform == 'darwin':
     extra_compile_args.append("-mmacosx-version-min=10.9")
+extra_link_args = []
+if sys.platform == 'linux':
+    extra_link_args.append('-Wl,--version-script=src/ext.version')
 
 # on windows (Conda-forge builds), the dirname is an absolute path
 extension_vaexfast = Extension("vaex.vaexfast", [os.path.relpath(os.path.join(dirname, "src/vaexfast.cpp"))],
                                include_dirs=[get_numpy_include()],
-                               extra_compile_args=extra_compile_args)
+                               extra_compile_args=extra_compile_args,
+                               extra_link_args=extra_link_args)
 extension_strings = Extension("vaex.superstrings", [os.path.relpath(os.path.join(dirname, "src/strings.cpp"))],
                                include_dirs=[
                                    get_numpy_include(),
@@ -88,7 +92,8 @@ extension_strings = Extension("vaex.superstrings", [os.path.relpath(os.path.join
                                    os.path.join(sys.prefix, 'Library', 'lib') # windows
                                ],
                                extra_compile_args=extra_compile_args,
-                               libraries=['pcre', 'pcrecpp']
+                               libraries=['pcre', 'pcrecpp'],
+                               extra_link_args=extra_link_args
                                )
 extension_superutils = Extension("vaex.superutils", [
         os.path.relpath(os.path.join(dirname, "src/hash_object.cpp")),
@@ -104,7 +109,8 @@ extension_superutils = Extension("vaex.superutils", [
         'vendor/hopscotch-map/include',
         'vendor/string-view-lite/include'
     ],
-    extra_compile_args=extra_compile_args)
+    extra_compile_args=extra_compile_args,
+    extra_link_args=extra_link_args)
 
 extension_superagg = Extension("vaex.superagg", [
         os.path.relpath(os.path.join(dirname, "src/superagg.cpp")),

--- a/packages/vaex-core/src/ext.version
+++ b/packages/vaex-core/src/ext.version
@@ -1,0 +1,4 @@
+vaex {
+  global: PyInit_vaexfast; PyInit_superstrings; PyInit_superutils; PyInit_superagg; # explicitly list symbols to be exported
+  local: *;         # hide everything else
+};

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2123,15 +2123,11 @@ static struct PyModuleDef moduledef = {
 #endif
 
 
+PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >= 3
 extern "C" PyObject *
-#  if defined(WIN32) || defined(_WIN32)
-#  else
-__attribute__ ((visibility("default")))
-#  endif
 PyInit_vaexfast(void)
 #else
-PyMODINIT_FUNC
 initvaexfast(void)
 #endif
 {

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2125,6 +2125,10 @@ static struct PyModuleDef moduledef = {
 
 #if PY_MAJOR_VERSION >= 3
 extern "C" PyObject *
+#  if defined(WIN32) || defined(_WIN32)
+#  else
+__attribute__ ((visibility("default")))
+#  endif
 PyInit_vaexfast(void)
 #else
 PyMODINIT_FUNC

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2122,10 +2122,9 @@ static struct PyModuleDef moduledef = {
 #define INITERROR return
 #endif
 
-
  #if (defined(__GNUC__) && (__GNUC__ >= 4)) ||\
      (defined(__clang__) && __has_attribute(visibility))
-__attribute__ ((visibility ("hidden")))
+__attribute__ ((visibility ("default")))
 #endif
 PyMODINIT_FUNC
 PyInit_vaexfast(void)

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2123,8 +2123,7 @@ static struct PyModuleDef moduledef = {
 #endif
 
 PyMODINIT_FUNC
- #if (defined(__GNUC__) && (__GNUC__ >= 4)) ||\
-     (defined(__clang__) && __has_attribute(visibility))
+ #if ((defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && __has_attribute(visibility)))
 __attribute__ ((visibility ("default")))
 #endif
 PyInit_vaexfast(void)

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2122,11 +2122,11 @@ static struct PyModuleDef moduledef = {
 #define INITERROR return
 #endif
 
+PyMODINIT_FUNC
  #if (defined(__GNUC__) && (__GNUC__ >= 4)) ||\
      (defined(__clang__) && __has_attribute(visibility))
 __attribute__ ((visibility ("default")))
 #endif
-PyMODINIT_FUNC
 PyInit_vaexfast(void)
 {
 	import_array();

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2123,19 +2123,15 @@ static struct PyModuleDef moduledef = {
 #endif
 
 
-PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
-PyInit_vaexfast(void)
-#else
-initvaexfast(void)
+ #if (defined(__GNUC__) && (__GNUC__ >= 4)) ||\
+     (defined(__clang__) && __has_attribute(visibility))
+__attribute__ ((visibility ("hidden")))
 #endif
+PyMODINIT_FUNC
+PyInit_vaexfast(void)
 {
 	import_array();
-#if PY_MAJOR_VERSION >= 3
     PyObject *module = PyModule_Create(&moduledef);
-#else
-	PyObject *module = Py_InitModule("vaex.vaexfast", pyvaex_functions);
-#endif
 
     if (module == NULL)
         INITERROR;
@@ -2147,7 +2143,5 @@ initvaexfast(void)
         INITERROR;
     }
 
-#if PY_MAJOR_VERSION >= 3
     return module;
-#endif
 }

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2123,8 +2123,10 @@ static struct PyModuleDef moduledef = {
 #endif
 
 PyMODINIT_FUNC
- #if ((defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && __has_attribute(visibility)))
-__attribute__ ((visibility ("default")))
+#if !defined(_WIN32)
+   #if ((defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && __has_attribute(visibility)))
+	__attribute__ ((visibility ("default")))
+  #endif
 #endif
 PyInit_vaexfast(void)
 {

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2124,7 +2124,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC
 #if !defined(_WIN32)
-   #if ((defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && __has_attribute(visibility)))
+   #if (defined(__GNUC__) && (__GNUC__ >= 4))
 	__attribute__ ((visibility ("default")))
   #endif
 #endif

--- a/packages/vaex-core/src/vaexfast.cpp
+++ b/packages/vaex-core/src/vaexfast.cpp
@@ -2125,7 +2125,6 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >= 3
-extern "C" PyObject *
 PyInit_vaexfast(void)
 #else
 initvaexfast(void)


### PR DESCRIPTION
Inspired by @xhochy 's article: https://uwekorn.com/2019/09/15/how-we-build-apache-arrows-manylinux-wheels.html

Might fix #606 and #514 
I, unfortunately, cannot reproduce it, but it does not hurt if it passes CI.