### PR TITLE
Fix: inconsistent evaluation in to_arrow_table

### DIFF
--- a/packages/vaex-arrow/vaex_arrow/convert.py
+++ b/packages/vaex-arrow/vaex_arrow/convert.py
@@ -8,6 +8,7 @@ def arrow_array_from_numpy_array(array):
     mask = None
     if np.ma.isMaskedArray(array):
         mask = array.mask
+        # arrow 0.16 behaves weird in this case https://github.com/vaexio/vaex/pull/639
         if mask is np.False_:
             mask = None
         elif mask is np.True_:

--- a/packages/vaex-arrow/vaex_arrow/convert.py
+++ b/packages/vaex-arrow/vaex_arrow/convert.py
@@ -8,6 +8,10 @@ def arrow_array_from_numpy_array(array):
     mask = None
     if np.ma.isMaskedArray(array):
         mask = array.mask
+        if mask is np.False_:
+            mask = None
+        elif mask is np.True_:
+            raise ValueError('not sure what pyarrow does with mask=True')
         array = array.data
     if dtype.kind == 'S':
         type = pyarrow.binary(dtype.itemsize)

--- a/tests/arrow/to_arrow_table_test.py
+++ b/tests/arrow/to_arrow_table_test.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+import pytest
+
+import vaex
+
+
+@pytest.mark.parametrize("sample", [100, 1_000, 10_000])
+@pytest.mark.parametrize("chunk_size", [5, 10, 30, 100, 500])
+def test_to_arrow_table_batches(sample, chunk_size):
+    x = np.ma.MaskedArray(data=np.random.randint(low=-5, high=55, size=sample),
+                          mask=np.random.choice([True, False], size=sample, p=[0.1, 0.9]),
+                          dtype=np.int16)
+    df = vaex.from_arrays(x=x)
+    df['y'] = (df.x > 15).astype('int')
+
+    def gen():
+        features = ['x', 'y']
+        for i1, i2, table in df.to_arrow_table(features, chunk_size=chunk_size):
+            yield table.to_batches(chunk_size)[0]
+
+    for batch in gen():
+        pdf_batch = batch.to_pandas()
+        pdf_batch['comp'] = (pdf_batch.x > 15).astype(int)
+        y_values = pdf_batch.y.values.copy()
+        comp_values = pdf_batch.comp.values.copy().astype(float)
+        comp_values[pdf_batch.x.isna()] = np.nan
+        np.testing.assert_array_equal(y_values, comp_values)

--- a/tests/arrow/to_arrow_table_test.py
+++ b/tests/arrow/to_arrow_table_test.py
@@ -1,28 +1,10 @@
 import numpy as np
-
-import pytest
-
 import vaex
 
 
-@pytest.mark.parametrize("sample", [100, 1_000, 10_000])
-@pytest.mark.parametrize("chunk_size", [5, 10, 30, 100, 500])
-def test_to_arrow_table_batches(sample, chunk_size):
-    x = np.ma.MaskedArray(data=np.random.randint(low=-5, high=55, size=sample),
-                          mask=np.random.choice([True, False], size=sample, p=[0.1, 0.9]),
-                          dtype=np.int16)
+def test_to_arrow_mixed_masked():
+    # tests https://github.com/vaexio/vaex/pull/639
+    x = np.ma.MaskedArray(data=np.arange(10))
     df = vaex.from_arrays(x=x)
-    df['y'] = (df.x > 15).astype('int')
-
-    def gen():
-        features = ['x', 'y']
-        for i1, i2, table in df.to_arrow_table(features, chunk_size=chunk_size):
-            yield table.to_batches(chunk_size)[0]
-
-    for batch in gen():
-        pdf_batch = batch.to_pandas()
-        pdf_batch['comp'] = (pdf_batch.x > 15).astype(int)
-        y_values = pdf_batch.y.values.copy()
-        comp_values = pdf_batch.comp.values.copy().astype(float)
-        comp_values[pdf_batch.x.isna()] = np.nan
-        np.testing.assert_array_equal(y_values, comp_values)
+    df['y'] = df.x**2
+    assert df.to_arrow_table(['x', 'y'])['y'].to_pylist() == df.y.tolist()


### PR DESCRIPTION
This is to fix a flaky/inconsistent evaluation of expressions using the `to_arrow_table` method. 
The better summarize the issue:
- It happens only (to the best of my knowledge) when an expression is make of masked arrays, or is a virtual column calculated on the basis of masked arrays
- Not sure if it happens if the evaluation is *not* in chunks
- Does not happen if the `chunk_size` is very small (like less than 5 or so)
- Happens more rarely if the `chunk_size` is large compared to the size of the dataset (like 50% of the df size or more), although I can not guarantee this in all cases. 
- This does not seem to be the case with other types of missing values like `None` and `np.nan`.

I made a unit-test exposing this. Not the most concise of test, but this is the most I could narrow the issue down. Suggestions welcome. 

Checklist:
- [x] Unit-test reproducing the issue
- [ ] Making the unit-test pass
- [ ] Manual testing

