### PR TITLE
Fix: evaluation of a dataframe containing masked arrays

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5108,7 +5108,10 @@ class DataFrameLocal(DataFrame):
                 if self.dtype(name) != dtype:
                     raise ValueError("Cannot cast %r (of type %r) to %r" % (name, self.dtype(name), dtype))
         chunks = self.evaluate(column_names, parallel=parallel)
-        return np.array(chunks, dtype=dtype).T
+        if any(np.ma.isMaskedArray(chunk) for chunk in chunks):
+            return np.ma.array(chunks, dtype=dtype).T
+        else:
+            return np.array(chunks, dtype=dtype).T
 
     @vaex.utils.deprecated('use DataFrame.join(other)')
     def _hstack(self, other, prefix=None):

--- a/tests/values_test.py
+++ b/tests/values_test.py
@@ -28,9 +28,4 @@ def test_values_masked():
     y = [10, 20, 30]
     df = vaex.from_arrays(x=x, y=y)
 
-    values = df[['x', 'y']].values
-    comparison = np.array([[1., 10.],
-                           [2., 20.],
-                           [np.nan, 30.]])
-
-    np.testing.assert_array_equal(values, comparison)
+    assert df[['x', 'y']].values.tolist() ==  [[1., 10.], [2., 20.], [None, 30.]]

--- a/tests/values_test.py
+++ b/tests/values_test.py
@@ -1,5 +1,5 @@
-import pytest
 from common import *
+import pytest
 
 
 def test_values(ds_local):
@@ -11,15 +11,17 @@ def test_values(ds_local):
     assert ds[['x', 'y']].values.tolist() == np.array([ds.evaluate('x'), ds.evaluate('y')]).T.tolist()
     assert ds[['x', 'y']].values.shape == (len(ds), 2)
     assert ds[['m']].values[9][0] == 77777.0
-    assert ds[['m','x']].values[9][0] == 77777
+    assert ds[['m', 'x']].values[9][0] == 77777
     # The missing values are included. This may not be the correct behaviour
     assert ds[['x', 'y', 'nm']].values.tolist(), np.array([ds.evaluate('x'), ds.evaluate('y'), ds.evaluate('nm')]).T.tolist()
+
 
 @pytest.mark.skip(reason='TOFIX: obj is now recognized as str')
 def test_object_column_values(ds_local):
     ds = ds_local
     with pytest.raises(ValueError):
         ds[['x', 'name', 'nm', 'obj']].values
+
 
 def test_values_masked():
     x = np.ma.MaskedArray(data=[1, 2, 3], mask=[False, False, True])

--- a/tests/values_test.py
+++ b/tests/values_test.py
@@ -20,3 +20,15 @@ def test_object_column_values(ds_local):
     ds = ds_local
     with pytest.raises(ValueError):
         ds[['x', 'name', 'nm', 'obj']].values
+
+def test_values_masked():
+    x = np.ma.MaskedArray(data=[1, 2, 3], mask=[False, False, True])
+    y = [10, 20, 30]
+    df = vaex.from_arrays(x=x, y=y)
+
+    values = df[['x', 'y']].values
+    comparison = np.array([[1., 10.],
+                           [2., 20.],
+                           [np.nan, 30.]])
+
+    np.testing.assert_array_equal(values, comparison)

--- a/tests/values_test.py
+++ b/tests/values_test.py
@@ -10,8 +10,8 @@ def test_values(ds_local):
     assert ds['obj'].values.tolist() == ds.evaluate('obj').tolist()
     assert ds[['x', 'y']].values.tolist() == np.array([ds.evaluate('x'), ds.evaluate('y')]).T.tolist()
     assert ds[['x', 'y']].values.shape == (len(ds), 2)
-    assert ds[['m']].values[9][0] == 77777.0
-    assert ds[['m', 'x']].values[9][0] == 77777
+    assert ds[['m']].values[9].tolist()[0] == None
+    assert ds[['m', 'x']].values[9].tolist()[0] == None
     # The missing values are included. This may not be the correct behaviour
     assert ds[['x', 'y', 'nm']].values.tolist(), np.array([ds.evaluate('x'), ds.evaluate('y'), ds.evaluate('nm')]).T.tolist()
 


### PR DESCRIPTION
When a dataframe (the whole dataframe, not an expression) is evaluated with the `.values` method, if a column contains masked values, those values will be realized as some numeric values (i think the masked values is filled with some large number). In the case of `numpy.ma.MaskedArray`, i expect the masked values to be "translated" to `np.nan`. This is what the unit-test assumes. 

This may be related to #639 although I am not quite sure. 

Checklist:
- [x] Unit-test that catches the issue
- [x] Making the unit-test pass 
- [ ] Manual testing