### PR TITLE
Fix: `count` issue with `limits='minmax'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
       * Fix `colum_count`, now only counts hidden columns if expicitly specified [#593](https://github.com/vaexio/vaex/pull/593)
       * df.values respects masked arrays [#640](https://github.com/vaexio/vaex/pull/640)
       * Rewriting a virtual column and doing a state transfer does not lead to `ValueError: list.remove(x): x not in list` [#592](https://github.com/vaexio/vaex/pull/592)
+      * `df.<stat>(limits=...)` will now respect the selection [#651](https://github.com/vaexio/vaex/pull/651)
    * Features
       * New lazy numpy wrappers: np.digitize and np.searchsorted [#573](https://github.com/vaexio/vaex/pull/573)
       * df.to_arrow_table/to_pandas_df/to_items now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4784,7 +4784,7 @@ class DataFrame(object):
         type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerOrdinal_", self.dtype(expression))
         return type(expression, ordinal_count, min_value)
 
-    def _create_grid(self, binby, limits, shape, selection, delay=False):
+    def _create_grid(self, binby, limits, shape, selection=None, delay=False):
         if isinstance(binby, (list, tuple)):
             binbys = binby
         else:

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -622,7 +622,7 @@ class DataFrame(object):
             # TODO: GET RID OF THIS
             len(self) # fill caches and masks
             # pass
-        grid = self._create_grid(binby, limits, shape, delay=True)
+        grid = self._create_grid(binby, limits, shape, selection=selection, delay=True)
         @delayed
         def compute(expression, grid, selection, edges, progressbar):
             self.local._aggregator_nest_count += 1
@@ -4749,7 +4749,7 @@ class DataFrame(object):
             self.executor.schedule(task_agg)
         return self._delay(delay, sub_task)
 
-    def _binner(self, expression, limits=None, shape=None, delay=False):
+    def _binner(self, expression, limits=None, shape=None, selection=None, delay=False):
         expression = str(expression)
         if limits is not None and not isinstance(limits, (tuple, str)):
             limits = tuple(limits)
@@ -4764,7 +4764,7 @@ class DataFrame(object):
                 @delayed
                 def create_binner(limits):
                     return self._binner_scalar(expression, limits, shape)
-                self._binners[key] = create_binner(self.limits(expression, limits, delay=True))
+                self._binners[key] = create_binner(self.limits(expression, limits, selection=selection, delay=True))
         return self._delay(delay, self._binners[key])
 
     def _grid(self, binners):
@@ -4784,7 +4784,7 @@ class DataFrame(object):
         type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerOrdinal_", self.dtype(expression))
         return type(expression, ordinal_count, min_value)
 
-    def _create_grid(self, binby, limits, shape, delay=False):
+    def _create_grid(self, binby, limits, shape, selection, delay=False):
         if isinstance(binby, (list, tuple)):
             binbys = binby
         else:
@@ -4800,7 +4800,7 @@ class DataFrame(object):
             limits = []
         shapes = _expand_shape(shape, len(binbys))
         for binby, limits1, shape in zip(binbys, limits, shapes):
-            binners.append(self._binner(binby, limits1, shape, delay=True))
+            binners.append(self._binner(binby, limits1, shape, selection, delay=True))
         @delayed
         def finish(*binners):
             return self._grid(binners)

--- a/tests/count_test.py
+++ b/tests/count_test.py
@@ -1,3 +1,4 @@
+import pytest
 from common import *
 
 
@@ -18,6 +19,25 @@ def test_count_2d():
     assert list(binned_values.shape) == [32, 32]
     binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=[[-50, 50],[-50, 50]])
     assert list(binned_values.shape) == [32, 32]
+
+@pytest.mark.parametrize('limits', ['minmax', '68.2%', '99.7%', '100%'])
+def test_count_1d_verify_against_numpy(ds_local, limits):
+    df = ds_local
+
+    expression = 'x'
+    selection = df.y > 10
+    shape = 4
+
+    # bin with vaex
+    xmin, xmax = df.limits(expression=expression, value=limits, selection=selection)
+    vaex_counts = df.count(binby=[expression], selection=selection, shape=shape, limits=limits)
+
+    # bin with numpy
+    x_values = df[selection][expression].values
+    numpy_counts, numpy_edges =  np.histogram(x_values, bins=shape, range=(xmin, xmax))
+
+    assert vaex_counts.tolist() == numpy_counts.tolist()
+
 
 
 # def test_count_edges():

--- a/tests/count_test.py
+++ b/tests/count_test.py
@@ -32,14 +32,14 @@ def test_count_1d_verify_against_numpy(ds_local, limits):
     shape = 4
 
     # bin with vaex
-    xmin, xmax = df.limits(expression=expression, value=limits, selection=selection)
     vaex_counts = df.count(binby=[expression], selection=selection, shape=shape, limits=limits)
 
     # bin with numpy
+    xmin, xmax = df.limits(expression=expression, value=limits, selection=selection)  # to have the same range as df.count
     x_values = df[selection][expression].values
     numpy_counts, numpy_edges = np.histogram(x_values, bins=shape, range=(xmin, xmax))
 
-    assert vaex_counts.tolist() == numpy_counts.tolist()
+    assert vaex_counts[:-1].tolist() == numpy_counts[:-1].tolist()
 
 # def test_count_edges():
 #     ds = vaex.from_arrays(x=[-2, -1, 0, 1, 2, 3, np.nan])

--- a/tests/count_test.py
+++ b/tests/count_test.py
@@ -1,5 +1,6 @@
-import pytest
 from common import *
+
+import pytest
 
 
 def test_count_1d():
@@ -11,14 +12,16 @@ def test_count_1d():
     binned_values = ds.count(binby=ds.x, limits='95%', shape=16)
     assert len(binned_values) == 16
 
+
 def test_count_2d():
     ds = vaex.example()
     binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=['minmax', '95%'])
     assert list(binned_values.shape) == [32, 32]
     binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=None)
     assert list(binned_values.shape) == [32, 32]
-    binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=[[-50, 50],[-50, 50]])
+    binned_values = ds.count(binby=[ds.x, ds.y], shape=32, limits=[[-50, 50], [-50, 50]])
     assert list(binned_values.shape) == [32, 32]
+
 
 @pytest.mark.parametrize('limits', ['minmax', '68.2%', '99.7%', '100%'])
 def test_count_1d_verify_against_numpy(ds_local, limits):
@@ -34,11 +37,9 @@ def test_count_1d_verify_against_numpy(ds_local, limits):
 
     # bin with numpy
     x_values = df[selection][expression].values
-    numpy_counts, numpy_edges =  np.histogram(x_values, bins=shape, range=(xmin, xmax))
+    numpy_counts, numpy_edges = np.histogram(x_values, bins=shape, range=(xmin, xmax))
 
     assert vaex_counts.tolist() == numpy_counts.tolist()
-
-
 
 # def test_count_edges():
 #     ds = vaex.from_arrays(x=[-2, -1, 0, 1, 2, 3, np.nan])


### PR DESCRIPTION
This PR fixes a potential issue with `df.count(expression=some_expression, limit='minmax')`
This issue is especially apparent when there is a selection applied to the dataframe.

- [x] Unit-tests exposing the problem
- [ ] Unit-tests passes

