### PR TITLE
fix: cancelled calculations were not stopped

### DIFF
--- a/packages/vaex-core/vaex/multithreading.py
+++ b/packages/vaex-core/vaex/multithreading.py
@@ -62,6 +62,7 @@ class ThreadPoolIndex(concurrent.futures.ThreadPoolExecutor):
                 time_last = time_now
                 if progress(progress_value) == False:
                     cancelled = True
+                    cancel()
             yield value
 
     def _map(self, callable, iterator):

--- a/packages/vaex-server/vaex/server/executor.py
+++ b/packages/vaex-server/vaex/server/executor.py
@@ -29,10 +29,15 @@ class Executor:
                 tasks_df[0].signal_progress.connect(self.signal_progress.emit)
                 for task in tasks_df:
                     task.signal_progress.emit(0)
-                results = self.client.execute(df, tasks_df)
+                try:
+                    results = self.client.execute(df, tasks_df)
+                except vaex.execution.UserAbort:
+                    self.signal_cancel.emit()
+                    raise
                 self.remote_calls += 1
                 for task, result in zip(tasks_df, results):
                     if task.cancelled:
+                        self.signal_cancel.emit()
                         task.reject(vaex.execution.UserAbort("cancelled"))
                     else:
                         task._result = result

--- a/tests/progress_test.py
+++ b/tests/progress_test.py
@@ -1,5 +1,6 @@
 import vaex.misc.progressbar
 import pytest
+from unittest.mock import MagicMock
 from common import *
 
 def test_progress_bar():
@@ -38,10 +39,13 @@ def test_progress_calls(df):
 
 
 def test_cancel(df):
+    magic = MagicMock()
+    df.executor.signal_cancel.connect(magic)
     def progress(f):
         return False
     with pytest.raises(vaex.execution.UserAbort):
         assert df.x.min(progress=progress) is None
+    magic.assert_called_once()
 
 
 # @pytest.mark.timeout(1)

--- a/tests/server/basics_test.py
+++ b/tests/server/basics_test.py
@@ -1,0 +1,5 @@
+def test_count_huge(client):
+    # this catched a bug introduced in https://github.com/vaexio/vaex/pull/557
+    # where remote dataframe calculations were cancelled
+    df = client['huge']
+    assert df.count() == len(df)


### PR DESCRIPTION
Also, they did not propagate to the client, and remote dataframe calculations were accidentally cancelled. 