### PR TITLE
feat: support xarray format for quick aggregators (e.g. df.count(..))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
       * df.to_arrow_table/to_pandas_df/to_items now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589)
       * Filtered datasets can be concatenated. [#590](https://github.com/vaexio/vaex/pull/590)
       * DataFrames/Executors are thread safe (meaning you can schedule/compute from any thread), which makes it work out of the box for Dash and Flask [#670](https://github.com/vaexio/vaex/pull/670)
-      * df.count/mean/std etc can output in xarray.DataArray format, makes plotting easier [#671](https://github.com/vaexio/vaex/pull/671)
+      * df.count/mean/std etc can output in xarray.DataArray array type, makes plotting easier [#671](https://github.com/vaexio/vaex/pull/671)
 
 # vaex-server 0.3.0-dev
    * Refactored server, can return multiple binary blobs, execute multiple tasks, cancel tasks, encoding/serialization is more flexible (like returning masked arrays). [#571](https://github.com/vaexio/vaex/pull/557)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
       * df.to_arrow_table/to_pandas_df/to_items now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589)
       * Filtered datasets can be concatenated. [#590](https://github.com/vaexio/vaex/pull/590)
       * DataFrames/Executors are thread safe (meaning you can schedule/compute from any thread), which makes it work out of the box for Dash and Flask [#670](https://github.com/vaexio/vaex/pull/670)
+      * df.count/mean/std etc can output in xarray.DataArray format, makes plotting easier [#671](https://github.com/vaexio/vaex/pull/671)
 
 # vaex-server 0.3.0-dev
    * Refactored server, can return multiple binary blobs, execute multiple tasks, cancel tasks, encoding/serialization is more flexible (like returning masked arrays). [#571](https://github.com/vaexio/vaex/pull/557)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -128,7 +128,7 @@ _doc_snippets['inplace'] = 'Make modifications to self or return a new DataFrame
 _doc_snippets['return_shallow_copy'] = 'Returns a new DataFrame with a shallow copy/view of the underlying data'
 _doc_snippets['chunk_size'] = 'Return an iterator with cuts of the object in lenght of this size'
 _doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel'
-_doc_snippets['array_type'] = 'Type o output array, possible values are None/"numpy" (ndarray) and "xarray" for a xarray.DataArray'
+_doc_snippets['array_type'] = 'Type of output array, possible values are None/"numpy" (ndarray) and "xarray" for a xarray.DataArray'
 
 
 def docsubst(f):

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -422,15 +422,15 @@ def test_mutual_information(df_local):
 
 def test_format_xarray(df_local):
     df = df_local
-    count = df.count(binby='x', limits=[-0.5, 9.5], shape=5, format='xarray')
+    count = df.count(binby='x', limits=[-0.5, 9.5], shape=5, array_type='xarray')
     assert count.coords['x'].data.tolist() == [0.5, 2.5, 4.5, 6.5, 8.5]
 
     df = df[:3]
     df['g'] = df.x
     df.categorize(df.g, ['aap', 'noot', 'mies'])
-    count = df.count(binby='g', format='xarray')
+    count = df.count(binby='g', array_type='xarray')
     assert count.coords['g'].data.tolist() == ['aap', 'noot', 'mies']
 
-    count = df.sum([df.x, df.g], binby='g', format='xarray')
+    count = df.sum([df.x, df.g], binby='g', array_type='xarray')
     assert count.coords['expression'].data.tolist() == ['x', 'g']
     assert count.coords['g'].data.tolist() == ['aap', 'noot', 'mies']

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -430,3 +430,7 @@ def test_format_xarray(df_local):
     df.categorize(df.g, ['aap', 'noot', 'mies'])
     count = df.count(binby='g', format='xarray')
     assert count.coords['g'].data.tolist() == ['aap', 'noot', 'mies']
+
+    count = df.sum([df.x, df.g], binby='g', format='xarray')
+    assert count.coords['expression'].data.tolist() == ['x', 'g']
+    assert count.coords['g'].data.tolist() == ['aap', 'noot', 'mies']

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -418,3 +418,15 @@ def test_mutual_information(df_local):
     mi1 = df.mutual_information("x", "y")
     mi2 = df.mutual_information("x", "z")
     assert mi_list.tolist() == list(sorted([mi1, mi2]))
+
+
+def test_format_xarray(df_local):
+    df = df_local
+    count = df.count(binby='x', limits=[-0.5, 9.5], shape=5, format='xarray')
+    assert count.coords['x'].data.tolist() == [0.5, 2.5, 4.5, 6.5, 8.5]
+
+    df = df[:3]
+    df['g'] = df.x
+    df.categorize(df.g, ['aap', 'noot', 'mies'])
+    count = df.count(binby='g', format='xarray')
+    assert count.coords['g'].data.tolist() == ['aap', 'noot', 'mies']


### PR DESCRIPTION
This is to be in line with #654 and the binby supporting xarray.
Example:
![image](https://user-images.githubusercontent.com/1765949/79265440-62712d80-7e96-11ea-9d0f-a063322df953.png)


Also, this integrates well with plotly express' latest xarray support (cc @nicolaskruchten):
![image](https://user-images.githubusercontent.com/1765949/79266371-c0eadb80-7e97-11ea-9ad8-46e878888478.png)
