### PR TITLE
Feature: export_csv

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5767,7 +5767,7 @@ class DataFrameLocal(DataFrame):
     def export_csv(self, path, virtual=False, selection=False, progress=None, chunk_size=1_000_000, **kwargs):
         """ Exports the DataFrame to a CSV file.
 
-        :param str path: Path for filename
+        :param str path: Path for file
         :param bool virtual: If True, export virtual columns as well
         :param bool selection: {selection1}
         :param progress: {progress}

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5767,8 +5767,7 @@ class DataFrameLocal(DataFrame):
         :param str path: Path for filename
         :param bool virtual: If True, export virtual columns as well
         :param bool selection: If True, export the selection
-        :param progress: Progress callback that gets a progress fraction as argument and should return True to continue,
-                or a default progress bar when progress=True
+        :param progress: {progress}
         :param int batch_size: Number of rows to be written to disk in a single iteration
         :param **kwargs: Extra keyword arguments to be passed on pandas.DataFrame.to_csv()
         :return:

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5764,14 +5764,14 @@ class DataFrameLocal(DataFrame):
         vaex.export.export_fits(self, path, column_names, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
     @docsubst
-    def export_csv(self, path, virtual=False, selection=False, progress=None, batch_size=1_000_000, **kwargs):
+    def export_csv(self, path, virtual=False, selection=False, progress=None, chunk_size=1_000_000, **kwargs):
         """ Exports the DataFrame to a CSV file.
 
         :param str path: Path for filename
         :param bool virtual: If True, export virtual columns as well
         :param bool selection: {selection1}
         :param progress: {progress}
-        :param int batch_size: {chunk_size_export}
+        :param int chunk_size: {chunk_size_export}
         :param **kwargs: Extra keyword arguments to be passed on pandas.DataFrame.to_csv()
         :return:
         """
@@ -5782,7 +5782,7 @@ class DataFrameLocal(DataFrame):
         dtypes = self[expressions].dtypes
         n_samples = len(self)
 
-        for i1, i2, chunks in self.evaluate_iterator(expressions, chunk_size=batch_size, selection=selection):
+        for i1, i2, chunks in self.evaluate_iterator(expressions, chunk_size=chunk_size, selection=selection):
             progressbar( i1 / n_samples)
             chunk_dict = {col: values for col, values in zip(expressions, chunks)}
             chunk_pdf = pd.DataFrame(chunk_dict)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5761,7 +5761,7 @@ class DataFrameLocal(DataFrame):
         import vaex.export
         vaex.export.export_fits(self, path, column_names, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
-    def export_csv(self, path, virtual=True, selection=False, progress=None, batch_size=1_000_000, **kwargs):
+    def export_csv(self, path, virtual=False, selection=False, progress=None, batch_size=1_000_000, **kwargs):
         """ Exports the DataFrame to a CSV file.
 
         :param str path: Path for filename
@@ -5782,7 +5782,8 @@ class DataFrameLocal(DataFrame):
 
         for i1, i2, chunks in self.evaluate_iterator(expressions, chunk_size=batch_size, selection=selection):
             progressbar( i1 / n_samples)
-            chunk_pdf = pd.DataFrame(np.stack(chunks).T, columns=expressions).astype(dtypes)
+            chunk_dict = {col: values for col, values in zip(expressions, chunks)}
+            chunk_pdf = pd.DataFrame(chunk_dict)
 
             if i1 == 0:  # Only the 1st chunk should have a header and the rest will be appended
                 mode = 'w'
@@ -5791,7 +5792,7 @@ class DataFrameLocal(DataFrame):
                 mode = 'a'
                 header = False
 
-            chunk_pdf.to_csv(path_or_buf=path, mode=mode, header=header, **kwargs)
+            chunk_pdf.to_csv(path_or_buf=path, mode=mode, header=header, index=False, **kwargs)
         progressbar(1.0)
         return
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -109,6 +109,7 @@ _doc_snippets["shape"] = """shape for the array where the statistic is calculate
 _doc_snippets["percentile_limits"] = """description for the min and max values to use for the cumulative histogram, should currently only be 'minmax'"""
 _doc_snippets["percentile_shape"] = """shape for the array where the cumulative histogram is calculated on, integer type"""
 _doc_snippets["selection"] = """Name of selection to use (or True for the 'default'), or all the data (when selection is None or False), or a list of selections"""
+_doc_snippets["selection1"] = """Name of selection to use (or True for the 'default'), or all the data (when selection is None or False)"""
 _doc_snippets["delay"] = """Do not return the result, but a proxy for delayhronous calculations (currently only for internal use)"""
 _doc_snippets["progress"] = """A callable that takes one argument (a floating point value between 0 and 1) indicating the progress, calculations are cancelled when this callable returns False"""
 _doc_snippets["expression_limits"] = _doc_snippets["expression"]
@@ -128,6 +129,7 @@ _doc_snippets['note_filter'] = '.. note:: Note that filtering will be ignored (s
 _doc_snippets['inplace'] = 'Make modifications to self or return a new DataFrame'
 _doc_snippets['return_shallow_copy'] = 'Returns a new DataFrame with a shallow copy/view of the underlying data'
 _doc_snippets['chunk_size'] = 'Return an iterator with cuts of the object in lenght of this size'
+_doc_snippets['chunk_size_export'] = 'Number of rows to be written to disk in a single iteration'
 _doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel'
 _doc_snippets['array_type'] = 'Type of output array, possible values are None/"numpy" (ndarray) and "xarray" for a xarray.DataArray'
 
@@ -5761,14 +5763,15 @@ class DataFrameLocal(DataFrame):
         import vaex.export
         vaex.export.export_fits(self, path, column_names, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
+    @docsubst
     def export_csv(self, path, virtual=False, selection=False, progress=None, batch_size=1_000_000, **kwargs):
         """ Exports the DataFrame to a CSV file.
 
         :param str path: Path for filename
         :param bool virtual: If True, export virtual columns as well
-        :param bool selection: If True, export the selection
+        :param bool selection: {selection1}
         :param progress: {progress}
-        :param int batch_size: Number of rows to be written to disk in a single iteration
+        :param int batch_size: {chunk_size_export}
         :param **kwargs: Extra keyword arguments to be passed on pandas.DataFrame.to_csv()
         :return:
         """

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -43,7 +43,7 @@ def test_export_open_hdf5(ds_local):
 def test_export_open_csv(ds_local, tmpdir):
     df = ds_local
     path = str(tmpdir.join('test.csv'))
-    df.export_csv(path, batch_size=3, virtual=True)
+    df.export_csv(path, chunk_size=3, virtual=True)
     df_opened = vaex.from_csv(path, copy_index=False)
     assert list(df) == list(df_opened)
     assert df.shape == df_opened.shape

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -40,12 +40,11 @@ def test_export_open_hdf5(ds_local):
     ds_opened = vaex.open(filename)
     assert list(ds) == list(ds_opened)
 
-def test_export_open_csv(ds_local):
+def test_export_open_csv(ds_local, tmpdir):
     df = ds_local
-    df = df.drop(df.obj)
-    filename = tempfile.mktemp(suffix='.csv')
-    df.export_csv(filename, batch_size=3, virtual=True)
-    df_opened = vaex.from_csv(filename, copy_index=False)
+    path = str(tmpdir.join('test.csv'))
+    df.export_csv(path, batch_size=3, virtual=True)
+    df_opened = vaex.from_csv(path, copy_index=False)
     assert list(df) == list(df_opened)
     assert df.shape == df_opened.shape
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -40,6 +40,14 @@ def test_export_open_hdf5(ds_local):
     ds_opened = vaex.open(filename)
     assert list(ds) == list(ds_opened)
 
+def test_export_open_csv(ds_local):
+    df = ds_local
+    df = df.drop(df.obj)
+    filename = tempfile.mktemp(suffix='.csv')
+    df.export_csv(filename, batch_size=3, virtual=True)
+    df_opened = vaex.from_csv(filename, copy_index=False)
+    assert list(df) == list(df_opened)
+    assert df.shape == df_opened.shape
 
 def test_export_open_hdf5(ds_local):
     ds = ds_local

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -6,7 +6,7 @@ import platform
 
 
 @pytest.mark.skipif(platform.system().lower() == 'windows', reason="access violation?")
-@pytest.mark.parametrize("filename", ["test.hdf5", "test.arrow", "test.parquet"])
+@pytest.mark.parametrize("filename", ["test.hdf5", "test.arrow", "test.parquet", "test.csv"])
 def test_export_empty_string(tmpdir, filename):
     path = str(tmpdir.join(filename))
     s = np.array(["", ""])
@@ -14,7 +14,6 @@ def test_export_empty_string(tmpdir, filename):
     df.export(path)
     df = vaex.open(path)
     repr(df)
-
 
 def test_export(ds_local, tmpdir):
     ds = ds_local


### PR DESCRIPTION
This PR adds `.export_csv` method to the dataframe.
For DataFrames that are too large to fit in memory, the export is done in chunks, so one only needs to have enough disk space to house the output file.

- [x] Implementation
- [x] Testing 
- [x] Review