### PR TITLE
Add dt.strftime and dt.quarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
       * Column names can have unicode, and we use str.isidentifier to test, also dont accidently hide columns. [#617](https://github.com/vaexio/vaex/pull/617)
       * Percentile approx can take a sequence of percentages [#527](https://github.com/vaexio/vaex/pull/527)
       * Polygon testing, useful in combinations with geo/geojson data [#685](https://github.com/vaexio/vaex/pull/685)
+      * Added dt.quarter property and dt.strftime method to expression (by Juho Lauri) [#682](https://github.com/vaexio/vaex/pull/682)
 
 # vaex-server 0.3.0-dev
    * Refactored server, can return multiple binary blobs, execute multiple tasks, cancel tasks, encoding/serialization is more flexible (like returning masked arrays). [#571](https://github.com/vaexio/vaex/pull/557)

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -455,7 +455,7 @@ def dt_quarter(x):
       1  2016-02-11 10:17:34
       2  2015-11-12 11:34:22
 
-    >>> df.date.dt.month_name
+    >>> df.date.dt.quarter
     Expression = dt_quarter(date)
     Length: 3 dtype: int64 (expression)
     -----------------------------------

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -437,6 +437,35 @@ def dt_month_name(x):
     import pandas as pd
     return pd.Series(_pandas_dt_fix(x)).dt.month_name().values.astype(str)
 
+@vaex.register_function(scope='dt', as_property=True)
+def dt_quarter(x):
+    """Extracts the quarter from a datetime sample.
+
+    :returns: an expression containing the number of the quarter extracted from a datetime column.
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> date = np.array(['2009-10-12T03:31:00', '2016-02-11T10:17:34', '2015-11-12T11:34:22'], dtype=np.datetime64)
+    >>> df = vaex.from_arrays(date=date)
+    >>> df
+      #  date
+      0  2009-10-12 03:31:00
+      1  2016-02-11 10:17:34
+      2  2015-11-12 11:34:22
+
+    >>> df.date.dt.month_name
+    Expression = dt_quarter(date)
+    Length: 3 dtype: int64 (expression)
+    -----------------------------------
+    0  4
+    1  1
+    2  4
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.quarter.values
+
 @register_function(scope='dt', as_property=True)
 def dt_day(x):
     """Extracts the day from a datetime sample.
@@ -610,6 +639,35 @@ def dt_second(x):
     """
     import pandas as pd
     return pd.Series(_pandas_dt_fix(x)).dt.second.values
+
+@vaex.register_function(scope='dt')
+def dt_strftime(x, date_format):
+    """Returns a formatted string from a datetime sample.
+
+    :returns: an expression containing a formatted string extracted from a datetime column.
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> date = np.array(['2009-10-12T03:31:00', '2016-02-11T10:17:34', '2015-11-12T11:34:22'], dtype=np.datetime64)
+    >>> df = vaex.from_arrays(date=date)
+    >>> df
+      #  date
+      0  2009-10-12 03:31:00
+      1  2016-02-11 10:17:34
+      2  2015-11-12 11:34:22
+
+    >>> df.date.dt.strftime("%Y-%m")
+    Expression = dt_strftime(date, '%Y-%m')
+    Length: 3 dtype: object (expression)
+    ------------------------------------
+    0  2009-10
+    1  2016-02
+    2  2015-11
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.strftime(date_format)
 
 ########## timedelta operations ##########
 

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -437,7 +437,7 @@ def dt_month_name(x):
     import pandas as pd
     return pd.Series(_pandas_dt_fix(x)).dt.month_name().values.astype(str)
 
-@vaex.register_function(scope='dt', as_property=True)
+@register_function(scope='dt', as_property=True)
 def dt_quarter(x):
     """Extracts the quarter from a datetime sample.
 
@@ -640,7 +640,7 @@ def dt_second(x):
     import pandas as pd
     return pd.Series(_pandas_dt_fix(x)).dt.second.values
 
-@vaex.register_function(scope='dt')
+@register_function(scope='dt')
 def dt_strftime(x, date_format):
     """Returns a formatted string from a datetime sample.
 

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -129,12 +129,14 @@ def test_create_datetime64_column_from_str():
     assert expr.values.astype('datetime64[ns]').tolist() == expr.astype('datetime64[ns]').tolist()
     
 def test_create_str_column_from_datetime64():
-    year = np.array(['2015', '2015', '2017'])
-    month = np.array(['01', '02', '10'])
-    day = np.array(['01', '03', '22'])
-    hour = np.array(['09', '10', '00'])
-    minute = np.array(['45', '15', '30'])
-    df = vaex.from_arrays(year=year, month=month, day=day, hour=hour, minute=minute)
+    date = np.array([np.datetime64('2009-10-12T03:31:00'),
+                np.datetime64('2016-02-11T10:17:34'),
+                np.datetime64('2015-11-12T11:34:22'),
+                np.datetime64('2003-03-03T00:33:15'),
+                np.datetime64('2014-07-23T15:08:05'),
+                np.datetime64('2011-01-01T07:02:01')], dtype='<M8[ns]')
+                
+    df = vaex.from_arrays(date=date)
     pandas_df = df.to_pandas_df()
     
     date_format = "%Y/%m/%d"

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -20,6 +20,7 @@ def test_datetime_operations():
     assert df.date.dt.day_name.values.tolist() == pandas_df.date.dt.day_name().values.tolist()
     assert df.date.dt.month.values.tolist() == pandas_df.date.dt.month.values.tolist()
     assert df.date.dt.month_name.values.tolist() == pandas_df.date.dt.month_name().values.tolist()
+    assert df.date.dt.quarter.values.tolist() == pandas_df.date.dt.quarter.values.tolist()
     assert df.date.dt.year.values.tolist() == pandas_df.date.dt.year.values.tolist()
     assert df.date.dt.is_leap_year.values.tolist() == pandas_df.date.dt.is_leap_year.values.tolist()
     assert any(df.date.dt.is_leap_year.values.tolist())
@@ -126,3 +127,16 @@ def test_create_datetime64_column_from_str():
     expr = df.year + '-' + df.month + '-' + df.day + 'T' + df.hour + ':' + df.minute
     assert expr.values.astype(np.datetime64).tolist() == expr.astype('datetime64').tolist()
     assert expr.values.astype('datetime64[ns]').tolist() == expr.astype('datetime64[ns]').tolist()
+    
+def test_create_str_column_from_datetime64():
+    year = np.array(['2015', '2015', '2017'])
+    month = np.array(['01', '02', '10'])
+    day = np.array(['01', '03', '22'])
+    hour = np.array(['09', '10', '00'])
+    minute = np.array(['45', '15', '30'])
+    df = vaex.from_arrays(year=year, month=month, day=day, hour=hour, minute=minute)
+    pandas_df = df.to_pandas_df()
+    
+    date_format = "%Y/%m/%d"
+
+    assert df.date.dt.strftime(date_format).values.tolist() == pandas_df.date.dt.strftime(date_format).values.tolist()


### PR DESCRIPTION
As per the title and in regards to [issue 679](https://github.com/vaexio/vaex/issues/679), this PR adds the `dt.strftime` (get formatted strings out of datetime) and `dt.quarter` (get the quarter a datetime belongs to) functionality.

I added a new function `test_create_str_column_from_datetime64()` since I wasn't sure where the test would be most appropriately placed. Might be overkill (plus is there some driver program somewhere that I should also touch if a new test function is added?), but let me know what you think.