### PR TITLE
fix: Using automatic names for aggregators led to many underscores in name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
       * df.values respects masked arrays [#640](https://github.com/vaexio/vaex/pull/640)
       * Rewriting a virtual column and doing a state transfer does not lead to `ValueError: list.remove(x): x not in list` [#592](https://github.com/vaexio/vaex/pull/592)
       * `df.<stat>(limits=...)` will now respect the selection [#651](https://github.com/vaexio/vaex/pull/651)
+      * Using automatic names for aggregators led to many underscores in name [#687](https://github.com/vaexio/vaex/pull/687)
    * Features
       * New lazy numpy wrappers: np.digitize and np.searchsorted [#573](https://github.com/vaexio/vaex/pull/573)
       * df.to_arrow_table/to_pandas_df/to_items now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589)

--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -150,7 +150,7 @@ class AggregatorDescriptorMulti(AggregatorDescriptor):
         self.edges = edges
 
     def pretty_name(self, id=None):
-        id = id or "_".join(map(str, self.expression))
+        id = id or "_".join(map(str, self.expressions))
         return '{0}_{1}'.format(id, self.short_name)
 
 

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -64,6 +64,16 @@ def test_groupby_options():
     assert dfg.y_sum.tolist() == sum_answer
 
 
+def test_groupby_long_name(df_local):
+    df = df_local.extract()
+    g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2])
+    df.add_column('g', g)
+    df['long_name'] = df.x
+    dfg = df.groupby(by=df.g, agg=[vaex.agg.mean(df.long_name)]).sort('g')
+    # bugfix check for mixing up the name
+    assert 'long_name_mean' in dfg
+
+
 def test_groupby_1d(ds_local):
     ds = ds_local.extract()
     g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2])


### PR DESCRIPTION
`df.groupby(by=df.g, agg=[vaex.agg.mean(df.long_name)]).sort('g')` led to a column name `l_o_n_g__n_a_m_e_mean`.