### PR TITLE
feat: df.to_items df.to_dict support array_type, and added array_type=list

### DIFF
--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -2,6 +2,20 @@
 import numpy as np
 
 
+def to_array_type(x, array_type):
+    if array_type is None:
+        return x
+    elif array_type == "list":
+        return to_array_type(x, 'numpy').tolist()
+    elif array_type == "numpy":
+        return to_numpy(x)
+    elif array_type == "xarray":
+        import xarray
+        return xarray.DataArray(x)
+    else:
+        raise ValueError(f'Unknown/unsupported array_type {array_type}')
+
+
 def to_numpy(x):
     if isinstance(x, np.ndarray):
         return x

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -420,10 +420,13 @@ def test_mutual_information(df_local):
     assert mi_list.tolist() == list(sorted([mi1, mi2]))
 
 
-def test_format_xarray(df_local):
+def test_format_xarray_and_list(df_local):
     df = df_local
     count = df.count(binby='x', limits=[-0.5, 9.5], shape=5, array_type='xarray')
     assert count.coords['x'].data.tolist() == [0.5, 2.5, 4.5, 6.5, 8.5]
+    count = df.count(binby='x', limits=[-0.5, 9.5], shape=5, array_type='list')
+    assert count == [2] * 5
+    assert isinstance(count, list)
 
     df = df[:3]
     df['g'] = df.x

--- a/tests/to_test.py
+++ b/tests/to_test.py
@@ -1,3 +1,5 @@
+import xarray
+
 def test_to_items(df_local):
     df = df_local
     items = df.to_items(['x', 'y'])
@@ -13,6 +15,21 @@ def test_to_items(df_local):
         assert ycname == 'y'
         assert xcvalues.tolist() == xvalues[i1:i2].tolist()
         assert ycvalues.tolist() == yvalues[i1:i2].tolist()
+
+
+def test_to_array_type_list(df_local):
+    df = df_local
+    data = df[:3]['x', 'y'].to_dict(array_type='list')
+    assert data == {'x': [0, 1, 2], 'y': [0, 1, 4]}
+    assert isinstance(data['x'], list)
+
+
+def test_to_array_type_xarray(df_local):
+    df = df_local
+    data = df[:3]['x', 'y'].to_dict(array_type='xarray')
+    assert isinstance(data['x'], xarray.DataArray)
+    assert data['x'].data.tolist() == [0, 1, 2]
+    assert data['y'].data.tolist() == [0, 1, 4]
 
 
 def test_to_arrow_table(df_local):


### PR DESCRIPTION
Next to df.count(..., array_type='xarray'), we also can do df.count(..., array_type='list').

We also have support for array_type in df.to_dict(..), so it's easier to JSON serialize.