### PR TITLE
Feat: add chunking functionality to more data evaluators

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2675,7 +2675,7 @@ class DataFrame(object):
                 yield previous_l1, previous_l2, previous_chunk
 
     @docsubst
-    def to_items(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None):
+    def to_items(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True, chunk_size=None):
         """Return a list of [(column_name, ndarray), ...)] pairs where the ndarray corresponds to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2716,7 +2716,7 @@ class DataFrame(object):
         return self.evaluate(column_names, selection=selection, parallel=parallel)
 
     @docsubst
-    def to_dict(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None):
+    def to_dict(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True, chunk_size=None):
         """Return a dict containing the ndarray corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2736,7 +2736,7 @@ class DataFrame(object):
         return dict(self.to_items(column_names=column_names, selection=selection, strings=strings, virtual=virtual, parallel=parallel))
 
     @docsubst
-    def to_copy(self, column_names=None, selection=None, strings=True, virtual=False, selections=True):
+    def to_copy(self, column_names=None, selection=None, strings=True, virtual=True, selections=True):
         """Return a copy of the DataFrame, if selection is None, it does not copy the data, it just has a reference
 
         :param column_names: list of column names, to copy, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2776,7 +2776,7 @@ class DataFrame(object):
         self.description = other.description
 
     @docsubst
-    def to_pandas_df(self, column_names=None, selection=None, strings=True, virtual=False, index_name=None, parallel=True, chunk_size=None):
+    def to_pandas_df(self, column_names=None, selection=None, strings=True, virtual=True, index_name=None, parallel=True, chunk_size=None):
         """Return a pandas DataFrame containing the ndarray corresponding to the evaluated data
 
          If index is given, that column is used for the index of the dataframe.
@@ -2818,7 +2818,7 @@ class DataFrame(object):
             return create_pdf(self.to_dict(column_names=column_names, selection=selection, parallel=parallel))
 
     @docsubst
-    def to_arrow_table(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None):
+    def to_arrow_table(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True, chunk_size=None):
         """Returns an arrow Table object containing the arrays corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2844,7 +2844,7 @@ class DataFrame(object):
             return pa.Table.from_arrays(chunks, column_names)
 
     @docsubst
-    def to_astropy_table(self, column_names=None, selection=None, strings=True, virtual=False, index=None, parallel=True):
+    def to_astropy_table(self, column_names=None, selection=None, strings=True, virtual=True, index=None, parallel=True):
         """Returns a astropy table object containing the ndarrays corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -13,6 +13,51 @@ def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
         total += chunk.sum()
     assert total == x.sum()
 
+@pytest.mark.parametrize("chunk_size", [1, 3, 5])
+@pytest.mark.parametrize("parallel", [True, False])
+def test_to_items(df_local, chunk_size, parallel):
+    # chunk_size, parallel = 3, True
+    # chunk_size = 3
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df.to_items(['x'], chunk_size=chunk_size, parallel=parallel):
+        assert x[i1:i2].tolist() == chunk[0][1].tolist()
+        total += chunk[0][1].sum()
+    assert total == x.sum()
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 5])
+@pytest.mark.parametrize("parallel", [True, False])
+def test_to_dict(df_local, chunk_size, parallel):
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df.to_dict(['x'], chunk_size=chunk_size, parallel=parallel):
+        assert x[i1:i2].tolist() == chunk['x'].tolist()
+        total += chunk['x'].sum()
+    assert total == x.sum()
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 5])
+@pytest.mark.parametrize("parallel", [True, False])
+def test_to_dict(df_local, chunk_size, parallel):
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df.to_dict(['x'], chunk_size=chunk_size, parallel=parallel):
+        assert x[i1:i2].tolist() == chunk['x'].tolist()
+        total += chunk['x'].sum()
+    assert total == x.sum()
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 5])
+@pytest.mark.parametrize("parallel", [True, False])
+def test_to_arrays(df_local, chunk_size, parallel):
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df.to_arrays(['x'], chunk_size=chunk_size, parallel=parallel):
+        assert x[i1:i2].tolist() == chunk[0].tolist()
+        total += chunk[0].sum()
+    assert total == x.sum()
 
 def test_evaluate_function_filtered_df():
     # Custom function to be applied to a filtered DataFrame

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -13,6 +13,7 @@ def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
         total += chunk.sum()
     assert total == x.sum()
 
+
 @pytest.mark.parametrize("chunk_size", [1, 3, 5])
 @pytest.mark.parametrize("parallel", [True, False])
 def test_to_items(df_local, chunk_size, parallel):
@@ -26,16 +27,6 @@ def test_to_items(df_local, chunk_size, parallel):
         total += chunk[0][1].sum()
     assert total == x.sum()
 
-@pytest.mark.parametrize("chunk_size", [1, 3, 5])
-@pytest.mark.parametrize("parallel", [True, False])
-def test_to_dict(df_local, chunk_size, parallel):
-    df = df_local
-    x = df.x.to_numpy()
-    total = 0
-    for i1, i2, chunk in df.to_dict(['x'], chunk_size=chunk_size, parallel=parallel):
-        assert x[i1:i2].tolist() == chunk['x'].tolist()
-        total += chunk['x'].sum()
-    assert total == x.sum()
 
 @pytest.mark.parametrize("chunk_size", [1, 3, 5])
 @pytest.mark.parametrize("parallel", [True, False])
@@ -47,6 +38,7 @@ def test_to_dict(df_local, chunk_size, parallel):
         assert x[i1:i2].tolist() == chunk['x'].tolist()
         total += chunk['x'].sum()
     assert total == x.sum()
+
 
 @pytest.mark.parametrize("chunk_size", [1, 3, 5])
 @pytest.mark.parametrize("parallel", [True, False])
@@ -58,6 +50,7 @@ def test_to_arrays(df_local, chunk_size, parallel):
         assert x[i1:i2].tolist() == chunk[0].tolist()
         total += chunk[0].sum()
     assert total == x.sum()
+
 
 def test_evaluate_function_filtered_df():
     # Custom function to be applied to a filtered DataFrame


### PR DESCRIPTION
This PR adds chunking functionality to the `df.to_dict()` and to df.to_arrays()` array methods. 

Summary of work done:
 - [x] Add `chunk_size` kwarg to `df.to_dict()` and `df.to_dict()` 
 - [x] Change default behaviour `virtual=True` from now on for the data evaluators
 - [x] Tests
