### PR TITLE
Feat: Improve the data evaluators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
    * Breaking changes:
      * Python 2 is not supported anymore
      * Variables don't have access to pi and e anymore
-     * df.rename_column is now df.rename (and also renames variables)
+     * `df.rename_column` is now `df.rename` (and also renames variables)
      * DataFrame uses a normal dict instead of OrderedDict, requiring Python >= 3.6
      * Default limits (e.g. for plots) is minmax, so we don't miss outliers
-     * df.get_column_names() returns the aliased names (invalid identifiers), pass alias=False to get the internal column name
+     * `df.get_column_names()` returns the aliased names (invalid identifiers), pass `alias=False` to get the internal column name
+     * Default value of `virtual` is True in method `df.export`, `df.to_dict`, `df.to_items`, `df.to_arrays`.
 
 # vaex-core 2.0.0-dev
    * Performance
@@ -40,10 +41,10 @@
       * Using automatic names for aggregators led to many underscores in name [#687](https://github.com/vaexio/vaex/pull/687)
    * Features
       * New lazy numpy wrappers: np.digitize and np.searchsorted [#573](https://github.com/vaexio/vaex/pull/573)
-      * df.to_arrow_table/to_pandas_df/to_items now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589)
+      * `df.to_arrow_table`/`to_pandas_df`/`to_items`/`df.to_dict`/`df.to_arrays` now take a chunk_size argument for chunked iterators [#589](https://github.com/vaexio/vaex/pull/589) (https://github.com/vaexio/vaex/pull/699)
       * Filtered datasets can be concatenated. [#590](https://github.com/vaexio/vaex/pull/590)
       * DataFrames/Executors are thread safe (meaning you can schedule/compute from any thread), which makes it work out of the box for Dash and Flask [#670](https://github.com/vaexio/vaex/pull/670)
-      * df.count/mean/std etc can output in xarray.DataArray array type, makes plotting easier [#671](https://github.com/vaexio/vaex/pull/671)
+      * `df.count/mean/std` etc can output in xarray.DataArray array type, makes plotting easier [#671](https://github.com/vaexio/vaex/pull/671)
       * Column names can have unicode, and we use str.isidentifier to test, also dont accidently hide columns. [#617](https://github.com/vaexio/vaex/pull/617)
       * Percentile approx can take a sequence of percentages [#527](https://github.com/vaexio/vaex/pull/527)
       * Polygon testing, useful in combinations with geo/geojson data [#685](https://github.com/vaexio/vaex/pull/685)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2677,7 +2677,7 @@ class DataFrame(object):
                 yield previous_l1, previous_l2, previous_chunk
 
     @docsubst
-    def to_items(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None, array_type=None):
+    def to_items(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True, chunk_size=None, array_type=None):
         """Return a list of [(column_name, ndarray), ...)] pairs where the ndarray corresponds to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2720,7 +2720,7 @@ class DataFrame(object):
         return [to_array_type(chunk, array_type) for chunk in self.evaluate(column_names, selection=selection, parallel=parallel)]
 
     @docsubst
-    def to_dict(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None, array_type=None):
+    def to_dict(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True, chunk_size=None, array_type=None):
         """Return a dict containing the ndarray corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2741,7 +2741,7 @@ class DataFrame(object):
         return dict(list(zip(column_names, [to_array_type(chunk, array_type) for chunk in self.evaluate(column_names, selection=selection, parallel=parallel)])))
 
     @docsubst
-    def to_copy(self, column_names=None, selection=None, strings=True, virtual=False, selections=True):
+    def to_copy(self, column_names=None, selection=None, strings=True, virtual=True, selections=True):
         """Return a copy of the DataFrame, if selection is None, it does not copy the data, it just has a reference
 
         :param column_names: list of column names, to copy, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2781,7 +2781,7 @@ class DataFrame(object):
         self.description = other.description
 
     @docsubst
-    def to_pandas_df(self, column_names=None, selection=None, strings=True, virtual=False, index_name=None, parallel=True, chunk_size=None):
+    def to_pandas_df(self, column_names=None, selection=None, strings=True, virtual=True, index_name=None, parallel=True, chunk_size=None):
         """Return a pandas DataFrame containing the ndarray corresponding to the evaluated data
 
          If index is given, that column is used for the index of the dataframe.
@@ -2823,7 +2823,7 @@ class DataFrame(object):
             return create_pdf(self.to_dict(column_names=column_names, selection=selection, parallel=parallel))
 
     @docsubst
-    def to_arrow_table(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None):
+    def to_arrow_table(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True, chunk_size=None):
         """Returns an arrow Table object containing the arrays corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
@@ -2849,7 +2849,7 @@ class DataFrame(object):
             return pa.Table.from_arrays(chunks, column_names)
 
     @docsubst
-    def to_astropy_table(self, column_names=None, selection=None, strings=True, virtual=False, index=None, parallel=True):
+    def to_astropy_table(self, column_names=None, selection=None, strings=True, virtual=True, index=None, parallel=True):
         """Returns a astropy table object containing the ndarrays corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2699,29 +2699,46 @@ class DataFrame(object):
             return list(zip(column_names, [to_array_type(chunk, array_type) for chunk in self.evaluate(column_names, selection=selection, parallel=parallel)]))
 
     @docsubst
-    def to_arrays(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True):
+    def to_arrays(self, column_names=None, selection=None, strings=True, virtual=True, parallel=True, chunk_size=None, array_type=None):
         """Return a list of ndarrays
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
         :param selection: {selection}
         :param strings: argument passed to DataFrame.get_column_names when column_names is None
         :param virtual: argument passed to DataFrame.get_column_names when column_names is None
-        :return: list of (name, ndarray) pairs
+        :param parallel: {evaluate_parallel}
+        :param chunk_size: {chunk_size}
+        :param array_type: {array_type}
+        :return: list of arrays
         """
-        return self.evaluate(column_names or self.get_column_names(strings=strings, virtual=virtual), selection=selection, parallel=parallel)
+        column_names = column_names or self.get_column_names(strings=strings, virtual=virtual)
+        if chunk_size is not None:
+            def iterator():
+                for i1, i2, chunks in self.evaluate_iterator(column_names, selection=selection, parallel=parallel, chunk_size=chunk_size):
+                    yield i1, i2, [to_array_type(chunk, array_type) for chunk in chunks]
+            return iterator()
+        return [to_array_type(chunk, array_type) for chunk in self.evaluate(column_names, selection=selection, parallel=parallel)]
 
     @docsubst
-    def to_dict(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, array_type=None):
+    def to_dict(self, column_names=None, selection=None, strings=True, virtual=False, parallel=True, chunk_size=None, array_type=None):
         """Return a dict containing the ndarray corresponding to the evaluated data
 
         :param column_names: list of column names, to export, when None DataFrame.get_column_names(strings=strings, virtual=virtual) is used
         :param selection: {selection}
         :param strings: argument passed to DataFrame.get_column_names when column_names is None
         :param virtual: argument passed to DataFrame.get_column_names when column_names is None
+        :param parallel: {evaluate_parallel}
+        :param chunk_size: {chunk_size}
         :param array_type: {array_type}
         :return: dict
         """
-        return dict(self.to_items(column_names=column_names, selection=selection, strings=strings, virtual=virtual, parallel=parallel, array_type=array_type))
+        column_names = column_names or self.get_column_names(strings=strings, virtual=virtual)
+        if chunk_size is not None:
+            def iterator():
+                for i1, i2, chunks in self.evaluate_iterator(column_names, selection=selection, parallel=parallel, chunk_size=chunk_size):
+                    yield i1, i2, dict(list(zip(column_names, [to_array_type(chunk, array_type) for chunk in chunks])))
+            return iterator()
+        return dict(list(zip(column_names, [to_array_type(chunk, array_type) for chunk in self.evaluate(column_names, selection=selection, parallel=parallel)])))
 
     @docsubst
     def to_copy(self, column_names=None, selection=None, strings=True, virtual=False, selections=True):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5680,7 +5680,7 @@ class DataFrameLocal(DataFrame):
                 left.add_column(name, column)
         return left
 
-    def export(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
+    def export(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=True, sort=None, ascending=True):
         """Exports the DataFrame to a file written with arrow
 
         :param DataFrameLocal df: DataFrame to export
@@ -5709,7 +5709,7 @@ class DataFrameLocal(DataFrame):
         else:
             raise ValueError('''Unrecognized file extension. Please use .arrow, .hdf5, .parquet, .fits, or .csv to export to the particular file format.''')
 
-    def export_arrow(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
+    def export_arrow(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=True, sort=None, ascending=True):
         """Exports the DataFrame to a file written with arrow
 
         :param DataFrameLocal df: DataFrame to export
@@ -5728,7 +5728,7 @@ class DataFrameLocal(DataFrame):
         import vaex_arrow.export
         vaex_arrow.export.export(self, path, column_names, byteorder, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
-    def export_parquet(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
+    def export_parquet(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=True, sort=None, ascending=True):
         """Exports the DataFrame to a parquet file
 
         :param DataFrameLocal df: DataFrame to export
@@ -5747,7 +5747,7 @@ class DataFrameLocal(DataFrame):
         import vaex_arrow.export
         vaex_arrow.export.export_parquet(self, path, column_names, byteorder, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
-    def export_hdf5(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
+    def export_hdf5(self, path, column_names=None, byteorder="=", shuffle=False, selection=False, progress=None, virtual=True, sort=None, ascending=True):
         """Exports the DataFrame to a vaex hdf5 file
 
         :param DataFrameLocal df: DataFrame to export
@@ -5766,7 +5766,7 @@ class DataFrameLocal(DataFrame):
         import vaex.export
         vaex.export.export_hdf5(self, path, column_names, byteorder, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
-    def export_fits(self, path, column_names=None, shuffle=False, selection=False, progress=None, virtual=False, sort=None, ascending=True):
+    def export_fits(self, path, column_names=None, shuffle=False, selection=False, progress=None, virtual=True, sort=None, ascending=True):
         """Exports the DataFrame to a fits file that is compatible with TOPCAT colfits format
 
         :param DataFrameLocal df: DataFrame to export
@@ -5785,7 +5785,7 @@ class DataFrameLocal(DataFrame):
         vaex.export.export_fits(self, path, column_names, shuffle, selection, progress=progress, virtual=virtual, sort=sort, ascending=ascending)
 
     @docsubst
-    def export_csv(self, path, virtual=False, selection=False, progress=None, chunk_size=1_000_000, **kwargs):
+    def export_csv(self, path, virtual=True, selection=False, progress=None, chunk_size=1_000_000, **kwargs):
         """ Exports the DataFrame to a CSV file.
 
         :param str path: Path for file

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -1263,13 +1263,13 @@ class TestDataset(unittest.TestCase):
 										#print len(dataset)
 										if export == dataset.export_hdf5:
 											path = path_hdf5
-											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False)
+											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False, virtual=virtual)
 										elif export == dataset.export_arrow:
 											path = path_arrow
-											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False)
+											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False, virtual=virtual)
 										elif export == dataset.export_parquet:
 											path = path_parquet
-											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False)
+											export(path, column_names=column_names, byteorder=byteorder, shuffle=shuffle, selection=selection, progress=False, virtual=virtual)
 										else:
 											path = path_fits
 											export(path, column_names=column_names, shuffle=shuffle, selection=selection, progress=False, virtual=virtual)

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -14,6 +14,47 @@ def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
     assert total == x.sum()
 
 
+@pytest.mark.parametrize("chunk_size", [2, 5])
+@pytest.mark.parametrize("parallel", [True, False])
+@pytest.mark.parametrize("array_type", [None, 'list', 'xarray'])
+def test_to_items(df_local, chunk_size, parallel, array_type):
+    # chunk_size, parallel = 3, True
+    # chunk_size = 3
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df.to_items(['x'], chunk_size=chunk_size, parallel=parallel, array_type=array_type):
+        np.testing.assert_array_equal(x[i1:i2].tolist(), chunk[0][1])
+        total += sum(chunk[0][1])
+    assert total == x.sum()
+
+
+@pytest.mark.parametrize("chunk_size", [2, 5])
+@pytest.mark.parametrize("parallel", [True, False])
+@pytest.mark.parametrize("array_type", [None, 'list', 'xarray'])
+def test_to_dict(df_local, chunk_size, parallel, array_type):
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df.to_dict(['x'], chunk_size=chunk_size, parallel=parallel, array_type=array_type):
+        np.testing.assert_array_equal(x[i1:i2].tolist(), chunk['x'])
+        total += sum(chunk['x'])
+    assert total == x.sum()
+
+
+@pytest.mark.parametrize("chunk_size", [2, 5])
+@pytest.mark.parametrize("parallel", [True, False])
+@pytest.mark.parametrize("array_type", [None, 'list', 'xarray'])
+def test_to_arrays(df_local, chunk_size, parallel, array_type):
+    df = df_local
+    x = df.x.to_numpy()
+    total = 0
+    for i1, i2, chunk in df.to_arrays(['x'], chunk_size=chunk_size, parallel=parallel, array_type=array_type):
+        np.testing.assert_array_equal(x[i1:i2].tolist(), chunk[0])
+        total += sum(chunk[0])
+    assert total == x.sum()
+
+
 def test_evaluate_function_filtered_df():
     # Custom function to be applied to a filtered DataFrame
     def custom_func(x):

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -18,13 +18,11 @@ def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
 @pytest.mark.parametrize("parallel", [True, False])
 @pytest.mark.parametrize("array_type", [None, 'list', 'xarray'])
 def test_to_items(df_local, chunk_size, parallel, array_type):
-    # chunk_size, parallel = 3, True
-    # chunk_size = 3
     df = df_local
     x = df.x.to_numpy()
     total = 0
     for i1, i2, chunk in df.to_items(['x'], chunk_size=chunk_size, parallel=parallel, array_type=array_type):
-        np.testing.assert_array_equal(x[i1:i2].tolist(), chunk[0][1])
+        np.testing.assert_array_equal(x[i1:i2], chunk[0][1])
         total += sum(chunk[0][1])
     assert total == x.sum()
 
@@ -37,7 +35,7 @@ def test_to_dict(df_local, chunk_size, parallel, array_type):
     x = df.x.to_numpy()
     total = 0
     for i1, i2, chunk in df.to_dict(['x'], chunk_size=chunk_size, parallel=parallel, array_type=array_type):
-        np.testing.assert_array_equal(x[i1:i2].tolist(), chunk['x'])
+        np.testing.assert_array_equal(x[i1:i2], chunk['x'])
         total += sum(chunk['x'])
     assert total == x.sum()
 
@@ -50,7 +48,7 @@ def test_to_arrays(df_local, chunk_size, parallel, array_type):
     x = df.x.to_numpy()
     total = 0
     for i1, i2, chunk in df.to_arrays(['x'], chunk_size=chunk_size, parallel=parallel, array_type=array_type):
-        np.testing.assert_array_equal(x[i1:i2].tolist(), chunk[0])
+        np.testing.assert_array_equal(x[i1:i2], chunk[0])
         total += sum(chunk[0])
     assert total == x.sum()
 


### PR DESCRIPTION
This PR improves the data evaluators (i.e. the `to_dict`, `to_items` et.. method), by making them more consistent with each other. 

Work done:
- [x] Add chunking support for `to_arrays` and `to_dict`
- [x] Add `array_type` support for `to_arrays`
- [x] `virtual=True` is now the default for all `df.to_` methods
- [x] New tests for `df.to_dict`, `df.to_items`, `df.to_arrays`
