### PR TITLE
chore: run benchmarks on dedicated hardware

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -24,3 +24,52 @@ Vaex benchmarks are run with `Airspeed Velocity <https://asv.readthedocs.io/en/s
     asv run --python=$(which python)
 
 On the dedicated hardware ASV will create a new Conda environment for each run.
+
+Benchmarks runner
+-----------------
+
+The benchmarks are executed on dedicated hardware at a predefined schedule. The HTML results are published to http://asv.vaex.io/ , while the raw performance numbers are saved in the `gh-pages` branch of the `vaexio/vaex` repo, for the history. The process works as follows.
+
+1. A cron job triggers the `bin/benchmark_new_commits.sh` script.
+2. The script checks out `vaexio/vaex/master`: the benchmark tests are taken from `master`.
+3. First the tests are run for the new commits on `master` branch.
+4. Then if there are any `vaexio/vaex/bench*` branches they are also tested: for any new commits on top of current `master`. Note that the benchmark tests are still taken from the `master` branch, so new benchmarks from e.g. a `bench_new_feature` branch would not run yet. So this process can be useful to improve existing benchmarks rather than developing new ones.
+5. The results are merged with those from `vaexio/vaex/gh-pages/benchmarks/results/**/*.json` and updated in that branch. This is done to keep the history of benchmark runs.
+6. Static HTML files are generated and copied to the www folder on the benchmarking machine, making them available at http://asv.vaex.io/ .
+
+Initial setup of the machine
+****************************
+
+To setup the benchmarks runner on a new machine you can do the following.
+
+1. Setup a unix user which will run the benchmarks: e.g. "`github`".
+2. Generate an SSH key and `add it as a Deploy key <https://github.com/vaexio/vaex/settings/keys>`__ in the repo, so that the user can push new commits in the `gh-pages` branch.
+3. Clone the repo:
+
+    git clone git@github.com:vaexio/vaex.git
+
+4. Configure git user name and email to be used in benchmark result commits:
+
+    git config --global user.name "Vaex GitHub Integration"
+    git config --global user.email github@vaex.io
+
+5. Install Miniconda and then install ASV:
+
+    conda install asv -c conda-forge
+
+6. Configure the machine parameters for ASV, they will be stored in `~/.asv-machine.json`:
+
+    asv machine
+
+7. Run ASV for the first time, to make sure that it works and to initialize the results history.
+
+    cd vaex
+    bin/benchmark_new_commits.sh --only-last
+
+8. Add a cron job to run the benchmarks, e.g. every 8 hours:
+
+    mkdir /home/github/log/
+    crontab -e
+    <add the following content in the editor>
+    PATH=/home/github/miniconda3/bin:/home/github/miniconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    0 */8 * * * /home/github/vaex/bin/benchmark_new_commits.sh >/home/github/log/benchmark-run-$(date "+\%Y-\%m-\%d_\%H-\%M-\%S").log 2>&1

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -28,13 +28,13 @@ On the dedicated hardware ASV will create a new Conda environment for each run.
 Benchmarks runner
 -----------------
 
-The benchmarks are executed on dedicated hardware at a predefined schedule. The HTML results are published to http://asv.vaex.io/ , while the raw performance numbers are saved in the `gh-pages` branch of the `vaexio/vaex` repo, for the history. The process works as follows.
+The benchmarks are executed on dedicated hardware at a predefined schedule. The HTML results are published to http://asv.vaex.io/ , while the raw performance numbers are saved in the the `vaexio/vaex-asv` repo, for the history. The process works as follows.
 
 1. A cron job triggers the `bin/benchmark_new_commits.sh` script.
 2. The script checks out `vaexio/vaex/master`: the benchmark tests are taken from `master`.
 3. First the tests are run for the new commits on `master` branch.
 4. Then if there are any `vaexio/vaex/bench*` branches they are also tested: for any new commits on top of current `master`. Note that the benchmark tests are still taken from the `master` branch, so new benchmarks from e.g. a `bench_new_feature` branch would not run yet. So this process can be useful to improve existing benchmarks rather than developing new ones.
-5. The results are merged with those from `vaexio/vaex/gh-pages/benchmarks/results/**/*.json` and updated in that branch. This is done to keep the history of benchmark runs.
+5. The results are merged with those from `vaexio/vaex-asv/.asv/results/**/*.json` and updated in that branch. This is done to keep the history of benchmark runs.
 6. Static HTML files are generated and copied to the www folder on the benchmarking machine, making them available at http://asv.vaex.io/ .
 
 Initial setup of the machine
@@ -43,10 +43,11 @@ Initial setup of the machine
 To setup the benchmarks runner on a new machine you can do the following.
 
 1. Setup a unix user which will run the benchmarks: e.g. "`github`".
-2. Generate an SSH key and `add it as a Deploy key <https://github.com/vaexio/vaex/settings/keys>`__ in the repo, so that the user can push new commits in the `gh-pages` branch.
-3. Clone the repo:
+2. Generate an SSH key and `add it as a Deploy key <https://github.com/vaexio/vaex-asv/settings/keys>`__ in the repo, so that the user can push new commits to this repo.
+3. Clone the repos:
 
     git clone git@github.com:vaexio/vaex.git
+    git clone git@github.com:vaexio/vaex-asv.git
 
 4. Configure git user name and email to be used in benchmark result commits:
 

--- a/bin/benchmark_new_commits.sh
+++ b/bin/benchmark_new_commits.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Run benchmarks for the new commits on "master" and "bench*" branches;
+# Save the results to the "gh-pages" branch, and copy produced
+# HTML results to the /var/www/asv.vaex.io/ folder on disk
+
+set -e
+
+VAEX_REPO_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../"
+cd "$VAEX_REPO_DIR"
+git pull origin master
+
+function restore_results_from_git () {
+  # copy results from gh-pages/benchmarks/results/**.json to master/.asv/results/**.json
+  (git checkout origin/gh-pages -- benchmarks/results/ && git reset -- benchmarks/results/) ||
+  (mkdir -p benchmarks/results/)
+  echo Restoring the following results from git branch:
+  find benchmarks/results/
+  cp -r benchmarks/results/ .asv/
+}
+
+function store_and_push_results_in_git () {
+  # copy results to gh-pages/benchmarks/results/**.json and HTML to gh-pages/benchmarks/index.html
+  echo Storing the following results into git branch:
+  find .asv/results
+  git checkout -f gh-pages
+  cp -rf .asv/results benchmarks/
+  cp -rf .asv/html/* benchmarks/
+  git add benchmarks
+  git commit -m 'Commit benchmark results'
+  git push
+  git checkout -
+}
+
+function copy_results_to_www () {
+  echo Copying HTML results to www
+  cp -rf .asv/html/* /var/www/asv.vaex.io/html/
+}
+
+function get_additional_branches_to_benchmark () {
+  # find branches which start with "bench*" in the "origin"
+  git branch -a | grep origin/bench | sed -e 's/.*origin\/\(.*\)/\1/'
+}
+
+
+restore_results_from_git
+
+if [[ "$1" == "--only-last" ]]
+then
+
+  echo Benchmarking last commit on master
+  asv run
+
+else
+
+  echo Benchmarking new commits on master
+  (asv run NEW) || (echo Maybe no new commits to benchmark?)
+
+  for branch in $(get_additional_branches_to_benchmark)
+  do
+    echo Benchmarking commits on "${branch}"
+    asv run origin/master..origin/${branch}
+  done
+
+fi
+
+# generate HTML
+asv publish
+
+store_and_push_results_in_git
+copy_results_to_www

--- a/bin/benchmark_new_commits.sh
+++ b/bin/benchmark_new_commits.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run benchmarks for the new commits on "master" and "bench*" branches;
-# Save the results to the "gh-pages" branch, and copy produced
+# Save the results to the vaex-asv repo, and copy produced
 # HTML results to the /var/www/asv.vaex.io/ folder on disk
 
 set -e
@@ -10,25 +10,22 @@ cd "$VAEX_REPO_DIR"
 git pull origin master
 
 function restore_results_from_git () {
-  # copy results from gh-pages/benchmarks/results/**.json to master/.asv/results/**.json
-  (git checkout origin/gh-pages -- benchmarks/results/ && git reset -- benchmarks/results/) ||
-  (mkdir -p benchmarks/results/)
-  echo Restoring the following results from git branch:
-  find benchmarks/results/
-  cp -r benchmarks/results/ .asv/
+  # copy results from vaex-asv/.asv/results/**.json to vaex/.asv/results/**.json
+  (cd ../vaex-asv && git pull -f)
+  (mkdir -p .asv)
+  echo Restoring the following results from vaex-asv repo:
+  find ../vaex-asv/.asv/results/
+  cp -r ../vaex-asv/.asv/results/ .asv/
 }
 
 function store_and_push_results_in_git () {
-  # copy results to gh-pages/benchmarks/results/**.json and HTML to gh-pages/benchmarks/index.html
-  echo Storing the following results into git branch:
+  # copy results to vaex-asv/.asv/results/**.json
+  echo Storing the following results into vaex-asv:
   find .asv/results
-  git checkout -f gh-pages
-  cp -rf .asv/results benchmarks/
-  cp -rf .asv/html/* benchmarks/
-  git add benchmarks
-  git commit -m 'Commit benchmark results'
-  git push
-  git checkout -
+  (mkdir -p ../vaex-asv/.asv)
+  cp -rf .asv/results ../vaex-asv/.asv/results
+  # cp -rf .asv/html ../vaex-asv/asv/ (should we also do the HTML?)
+  (cd ../vaex-asv && git add results && git commit -m 'Commit benchmark results' && git push)
 }
 
 function copy_results_to_www () {


### PR DESCRIPTION
Implement a script and instructions to run benchmarks as a cron job on dedicated hardware.
* Test all the new commits on `master`
* Test any commits on `bench*` branches in the base repo: to measure WIP performance improvements
* Publish results to the http://asv.vaex.io/
* Save results in the `gh-pages` repo for history

@maartenbreddels I have done some of the items from the [Initial setup of the machine](https://github.com/byaminov/vaex/blob/d0808e04415959df2659a467d894514264bc7064/benchmarks/README.rst#initial-setup-of-the-machine), but some you will have to do yourself, as you have permissions:
(2.) Add SSH key of `github` user as a [Deploy key](https://github.com/vaexio/vaex/settings/keys).
(3.) Clone the repo
(7.) Run ASV for the first time
(8.) Modify the cron job if you want a different cadence

TODO in this PR:
- [x] Have #672 merged to `master` and rebased this branch after that. Only last commit belongs to this change.