### PR TITLE
refactor!: df.dtype is a property, to get data types for expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
      * Default limits (e.g. for plots) is minmax, so we don't miss outliers
      * `df.get_column_names()` returns the aliased names (invalid identifiers), pass `alias=False` to get the internal column name
      * Default value of `virtual` is True in method `df.export`, `df.to_dict`, `df.to_items`, `df.to_arrays`.
+     * df.dtype is a property, to get data types for expressions, use df.data_type(), df.expr.dtype is still behaving the same
 
 # vaex-core 2.0.0-dev
    * Performance

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -72,7 +72,7 @@ class ColumnIndexed(Column):
         self.df = df
         self.indices = indices
         self.name = name
-        self.dtype = self.df.dtype(name)
+        self.dtype = self.df.data_type(name)
         self.shape = (len(indices),)
         self.masked = masked
         # this check is too expensive

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -285,7 +285,7 @@ class DataFrame(object):
         return self.is_category(column)
 
     def is_datetime(self, expression):
-        dtype = self.dtype(expression)
+        dtype = self.data_type(expression)
         return dtype != str_type and dtype.kind == 'M'
 
     def is_category(self, column):
@@ -375,13 +375,13 @@ class DataFrame(object):
         from vaex.column import _to_string_sequence
 
         transient = self[str(expression)].transient or self.filtered or self.is_masked(expression)
-        if self.dtype(expression) == str_type and not transient:
+        if self.data_type(expression) == str_type and not transient:
             # string is a special case, only ColumnString are not transient
             ar = self.columns[str(expression)]
             if not isinstance(ar, ColumnString):
                 transient = True
 
-        dtype = self.dtype(column)
+        dtype = self.data_type(column)
         ordered_set_type = ordered_set_type_from_dtype(dtype, transient)
         sets = [None] * self.executor.thread_pool.nthreads
         def map(thread_index, i1, i2, ar):
@@ -413,13 +413,13 @@ class DataFrame(object):
         from vaex.column import _to_string_sequence
 
         transient = self[str(expression)].transient or self.filtered or self.is_masked(expression)
-        if self.dtype(expression) == str_type and not transient:
+        if self.data_type(expression) == str_type and not transient:
             # string is a special case, only ColumnString are not transient
             ar = self.columns[str(expression)]
             if not isinstance(ar, ColumnString):
                 transient = True
 
-        dtype = self.dtype(column)
+        dtype = self.data_type(column)
         index_type = index_type_from_dtype(dtype, transient)
         index_list = [None] * self.executor.thread_pool.nthreads
         def map(thread_index, i1, i2, ar):
@@ -454,7 +454,7 @@ class DataFrame(object):
         if return_inverse:
             # inverse type can be smaller, depending on length of set
             inverse = np.zeros(self._length_unfiltered, dtype=np.int64)
-            dtype = self.dtype(expression)
+            dtype = self.data_type(expression)
             from vaex.column import _to_string_sequence
             def map(thread_index, i1, i2, ar):
                 if dtype == str_type:
@@ -1208,7 +1208,7 @@ class DataFrame(object):
         expression = _ensure_strings_from_expressions(expression)
         binby = _ensure_strings_from_expressions(binby)
         waslist, [expressions, ] = vaex.utils.listify(expression)
-        dtypes = [self.dtype(expr) for expr in expressions]
+        dtypes = [self.data_type(expr) for expr in expressions]
         dtype0 = dtypes[0]
         if not all([k.kind == dtype0.kind for k in dtypes]):
             raise ValueError("cannot mix datetime and non-datetime expressions")
@@ -1970,8 +1970,8 @@ class DataFrame(object):
         N = self.count(selection=selection)
         extra = 0
         for column in list(self.get_column_names(virtual=virtual)):
-            dtype = self.dtype(column)
-            dtype_internal = self.dtype(column, internal=True)
+            dtype = self.data_type(column)
+            dtype_internal = self.data_type(column, internal=True)
             #if dtype in [str_type, str] and dtype_internal.kind == 'O':
             if isinstance(self.columns[column], ColumnString):
                 # TODO: document or fix this
@@ -1993,7 +1993,7 @@ class DataFrame(object):
         rows = len(self) if filtered else self.length_unfiltered()
         return (rows,) + sample.shape[1:]
 
-    def dtype(self, expression, internal=False):
+    def data_type(self, expression, internal=False):
         """Return the numpy dtype for the given expression, if not a column, the first row will be evaluated to get the dtype."""
         expression = _ensure_string_from_expression(expression)
         if expression in self._dtypes_override:
@@ -2023,7 +2023,7 @@ class DataFrame(object):
     def dtypes(self):
         """Gives a Pandas series object containing all numpy dtypes of all columns (except hidden)."""
         from pandas import Series
-        return Series({column_name:self.dtype(column_name) for column_name in self.get_column_names()})
+        return Series({column_name:self.data_type(column_name) for column_name in self.get_column_names()})
 
     def is_masked(self, column):
         '''Return if a column is a masked (numpy.ma) column.'''
@@ -2866,7 +2866,7 @@ class DataFrame(object):
 
         table = Table(meta=meta)
         for name, data in self.to_items(column_names=column_names, selection=selection, strings=strings, virtual=virtual, parallel=parallel):
-            if self.dtype(name) == str_type:  # for astropy we convert it to unicode, it seems to ignore object type
+            if self.data_type(name) == str_type:  # for astropy we convert it to unicode, it seems to ignore object type
                 data = np.array(data).astype('U')
             meta = dict()
             if name in self.ucds:
@@ -3414,7 +3414,7 @@ class DataFrame(object):
             parts += ["<td>%s</td>" % name]
             virtual = name not in self.column_names
             if name in self.column_names:
-                dtype = str(self.dtype(name)) if self.dtype(name) != str else 'str'
+                dtype = str(self.data_type(name)) if self.data_type(name) != str else 'str'
             else:
                 dtype = "</i>virtual column</i>"
             parts += ["<td>%s</td>" % dtype]
@@ -3443,7 +3443,7 @@ class DataFrame(object):
             for name in variable_names:
                 parts += ["<tr>"]
                 parts += ["<td>%s</td>" % name]
-                type = self.dtype(name).name
+                type = self.data_type(name).name
                 parts += ["<td>%s</td>" % type]
                 units = self.unit(name)
                 units = units.to_string("latex_inline") if units else ""
@@ -3512,13 +3512,13 @@ class DataFrame(object):
         N = len(self)
         columns = {}
         for feature in self.get_column_names(strings=strings, virtual=virtual)[:]:
-            dtype = str(self.dtype(feature)) if self.dtype(feature) != str else 'str'
-            if self.dtype(feature) == str_type or self.dtype(feature).kind in ['S', 'U']:
+            dtype = str(self.data_type(feature)) if self.data_type(feature) != str else 'str'
+            if self.data_type(feature) == str_type or self.data_type(feature).kind in ['S', 'U']:
                 count = self.count(feature, selection=selection, delay=True)
                 self.execute()
                 count = count.get()
                 columns[feature] = ((dtype, count, N-count, '--', '--', '--', '--'))
-            elif self.dtype(feature).kind == 'O':
+            elif self.data_type(feature).kind == 'O':
                 # this will also properly count NaN-like objects like NaT
                 count_na = self[feature].isna().astype('int').sum(delay=True)
                 self.execute()
@@ -3772,7 +3772,7 @@ class DataFrame(object):
                 return False
             if not virtual and name in self.virtual_columns:
                 return False
-            if not strings and (self.dtype(name) == str_type or self.dtype(name).type == np.string_):
+            if not strings and (self.data_type(name) == str_type or self.data_type(name).type == np.string_):
                 return False
             if not hidden and name.startswith('__'):
                 return False
@@ -4809,12 +4809,12 @@ class DataFrame(object):
             return grid
 
     def _binner_scalar(self, expression, limits, shape):
-        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerScalar_", self.dtype(expression))
+        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerScalar_", self.data_type(expression))
         vmin, vmax = limits
         return type(expression, vmin, vmax, shape)
 
     def _binner_ordinal(self, expression, ordinal_count, min_value=0):
-        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerOrdinal_", self.dtype(expression))
+        type = vaex.utils.find_type_from_dtype(vaex.superagg, "BinnerOrdinal_", self.data_type(expression))
         return type(expression, ordinal_count, min_value)
 
     def _create_grid(self, binby, limits, shape, selection=None, delay=False):
@@ -5174,9 +5174,9 @@ class DataFrameLocal(DataFrame):
         chunks = []
         column_names = self.get_column_names(strings=False)
         for name in column_names:
-            if not np.can_cast(self.dtype(name), dtype):
-                if self.dtype(name) != dtype:
-                    raise ValueError("Cannot cast %r (of type %r) to %r" % (name, self.dtype(name), dtype))
+            if not np.can_cast(self.data_type(name), dtype):
+                if self.data_type(name) != dtype:
+                    raise ValueError("Cannot cast %r (of type %r) to %r" % (name, self.data_type(name), dtype))
         chunks = self.evaluate(column_names, parallel=parallel)
         if any(np.ma.isMaskedArray(chunk) for chunk in chunks):
             return np.ma.array(chunks, dtype=dtype).T
@@ -5319,7 +5319,7 @@ class DataFrameLocal(DataFrame):
             # TODO: For NEP branch: dtype -> dtype_evaluate
 
             for expression in set(expressions):
-                dtypes[expression] = df.dtype(expression, internal=False)
+                dtypes[expression] = df.data_type(expression, internal=False)
                 if expression not in df.columns:
                     virtual.add(expression)
                 # since we will use pre_filter=True, we'll get chunks of the data at unknown offset
@@ -5441,14 +5441,14 @@ class DataFrameLocal(DataFrame):
                 if unit1 != unit2:
                     print("unit mismatch : %r vs %r for %s" % (unit1, unit2, column_name))
                     meta_mismatch.append(column_name)
-                type1 = self.dtype(column_name)
+                type1 = self.data_type(column_name)
                 if type1 != str_type:
                     type1 = type1.type
-                type2 = other.dtype(column_name)
+                type2 = other.data_type(column_name)
                 if type2 != str_type:
                     type2 = type2.type
                 if type1 != type2:
-                    print("different dtypes: %s vs %s for %s" % (self.dtype(column_name), other.dtype(column_name), column_name))
+                    print("different dtypes: %s vs %s for %s" % (self.data_type(column_name), other.data_type(column_name), column_name))
                     type_mismatch.append(column_name)
                 else:
                     # a = self.columns[column_name]
@@ -5486,7 +5486,7 @@ class DataFrameLocal(DataFrame):
                         a = normalize(a)
                         b = normalize(b)
                         boolean_mask = (a == b)
-                        if self.dtype(column_name) != str_type and self.dtype(column_name).kind == 'f':  # floats with nan won't equal itself, i.e. NaN != NaN
+                        if self.data_type(column_name) != str_type and self.data_type(column_name).kind == 'f':  # floats with nan won't equal itself, i.e. NaN != NaN
                             boolean_mask |= (np.isnan(a) & np.isnan(b))
                         return boolean_mask
                     boolean_mask = equal_mask(a, b)
@@ -5581,7 +5581,7 @@ class DataFrameLocal(DataFrame):
             df = left
             # we index the right side, this assumes right is smaller in size
             index = right._index(right_on)
-            dtype = left.dtype(left_on)
+            dtype = left.data_type(left_on)
             duplicates_right = index.has_duplicates
 
             if duplicates_right and not allow_duplication:
@@ -5828,7 +5828,7 @@ class DataFrameLocal(DataFrame):
               self.columns[column_name].dtype.type == np.float64 and
               self.columns[column_name].strides[0] == 8 and
               column_name not in
-              self.virtual_columns) or self.dtype(column_name) == str_type or self.dtype(column_name).kind == 'S')
+              self.virtual_columns) or self.data_type(column_name) == str_type or self.data_type(column_name).kind == 'S')
         # and False:
 
     def selected_length(self, selection="default"):

--- a/packages/vaex-core/vaex/export.py
+++ b/packages/vaex-core/vaex/export.py
@@ -63,7 +63,7 @@ def _export(dataset_input, dataset_output, random_index_column, path, column_nam
     order_array_inverse = None
 
     # for strings we also need the inverse order_array, keep track of that
-    has_strings = any([dataset_input.dtype(k) == str_type for k in column_names])
+    has_strings = any([dataset_input.data_type(k) == str_type for k in column_names])
 
     if partial_shuffle:
         # if we only export a portion, we need to create the full length random_index array, and
@@ -162,7 +162,7 @@ def _export_column(dataset_input, dataset_output, column_name, shuffle, sort, se
         if 1:
             block_scope = dataset_input._block_scope(0, vaex.execution.buffer_size_default)
             to_array = dataset_output.columns[column_name]
-            dtype = dataset_input.dtype(column_name)
+            dtype = dataset_input.data_type(column_name)
             if shuffle or sort:  # we need to create a in memory copy, otherwise we will do random writes which is VERY inefficient
                 to_array_disk = to_array
                 if np.ma.isMaskedArray(to_array):
@@ -265,7 +265,7 @@ def export_fits(dataset, path, column_names=None, shuffle=False, selection=False
             column = dataset.columns[column_name]
             shape = (N,) + column.shape[1:]
             dtype = column.dtype
-            if dataset.dtype(column_name) == str_type:
+            if dataset.data_type(column_name) == str_type:
                 max_length = dataset[column_name].apply(lambda x: len(x)).max(selection=selection)
                 dtype = np.dtype('S'+str(int(max_length)))
         else:
@@ -286,7 +286,7 @@ def export_fits(dataset, path, column_names=None, shuffle=False, selection=False
         random_index_name = None
 
     # TODO: all expressions can have missing values.. how to support that?
-    null_values = {key: dataset.columns[key].fill_value for key in dataset.get_column_names() if dataset.is_masked(key) and dataset.dtype(key).kind != "f"}
+    null_values = {key: dataset.columns[key].fill_value for key in dataset.get_column_names() if dataset.is_masked(key) and dataset.data_type(key).kind != "f"}
     vaex.file.colfits.empty(path, N, column_names, data_types, data_shapes, ucds, units, null_values=null_values)
     if shuffle:
         del column_names[-1]

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -251,7 +251,11 @@ class Expression(with_metaclass(Meta)):
 
     @property
     def dtype(self):
-        return self.ds.dtype(self.expression)
+        return self.ds.data_type(self.expression)
+
+    def data_type(self):
+        """Alias to df.data_type(self.expression)"""
+        return self.ds.data_type(self.expression)
 
     @property
     def shape(self):
@@ -705,7 +709,7 @@ class Expression(with_metaclass(Meta)):
             all_vars = self.ds.get_column_names(virtual=True, strings=True, hidden=True) + list(self.ds.variables.keys())
             vaex.expresso.validate_expression(expression, all_vars, funcs, names)
             names = list(set(names))
-            types = ", ".join(str(self.ds.dtype(name)) + "[]" for name in names)
+            types = ", ".join(str(self.ds.data_type(name)) + "[]" for name in names)
             argstring = ", ".join(names)
             code = '''
 from numpy import *
@@ -1029,7 +1033,7 @@ class FunctionSerializableJit(FunctionSerializable):
         # TODO: can we do the above using the Expressio API?s
 
         arguments = list(set(names))
-        argument_dtypes = [df.dtype(argument) for argument in arguments]
+        argument_dtypes = [df.data_type(argument) for argument in arguments]
         return_dtype = df[expression].dtype
         return cls(str(expression), arguments, argument_dtypes, return_dtype, verbose, compile=compile)
 

--- a/packages/vaex-core/vaex/misc_cmdline.py
+++ b/packages/vaex-core/vaex/misc_cmdline.py
@@ -76,5 +76,5 @@ def stat_main(argv):
         unit = dataset.unit(name)
         if unit:
             print("   \tunit: %s" % unit)
-        dtype = dataset.dtype(name)
+        dtype = dataset.data_type(name)
         print("   \ttype: %s" % dtype.name)

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -344,7 +344,7 @@ class TaskAggregations(Task):
         # it is up the the executor to remove duplicate expressions
         self.expressions_all.extend(aggregator_descriptor.expressions)
         # TODO: optimize/remove?
-        self.dtypes = {expr: self.df.dtype(expr) for expr in self.expressions_all}
+        self.dtypes = {expr: self.df.data_type(expr) for expr in self.expressions_all}
         return task
 
     def check(self):

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -762,9 +762,9 @@ class TestDataset(unittest.TestCase):
 		assert self.dataset.unit("x+y") == None
 
 	def test_dtype(self):
-		self.assertEqual(self.dataset.dtype("x"), np.dtype(">f8"))
-		self.assertEqual(self.dataset.dtype("f"), np.float64)
-		self.assertEqual(self.dataset.dtype("x*f"), np.float64)
+		self.assertEqual(self.dataset.data_type("x"), np.dtype(">f8"))
+		self.assertEqual(self.dataset.data_type("f"), np.float64)
+		self.assertEqual(self.dataset.data_type("x*f"), np.float64)
 
 	def test_byte_size(self):
 		arrow_size = self.dataset.columns['name_arrow'].nbytes

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -57,7 +57,7 @@ def export_hdf5_v1(dataset, path, column_names=None, byteorder="=", shuffle=Fals
 
         logger.debug("exporting columns(hdf5): %r" % column_names)
         for column_name in column_names:
-            dtype = dataset.dtype(column_name)
+            dtype = dataset.data_type(column_name)
             if column_name in dataset.get_column_names(strings=True):
                 column = dataset.columns[column_name]
                 shape = (N,) + column.shape[1:]
@@ -147,8 +147,8 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
                 sparse_groups[id(sparse_matrix)].append(column_name)
                 sparse_matrices[id(sparse_matrix)] = sparse_matrix
                 continue
-            dtype = dataset.dtype(column_name)
-            if column_name in dataset.get_column_names(virtual=False, alias=False):
+            dtype = dataset.data_type(column_name)
+            if column_name in dataset.get_column_names(virtual=False):
                 column = dataset.columns[column_name]
                 shape = (N,) + column.shape[1:]
             else:

--- a/packages/vaex-jupyter/vaex/jupyter/traitlets.py
+++ b/packages/vaex-jupyter/vaex/jupyter/traitlets.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import traitlets
 
 def nice_type(df, name):
-    dtype = df.dtype(name)
+    dtype = df.data_type(name)
     type_map = {'i': 'integer', 'u': 'integer', 'f': 'float', 'b': 'boolean',
                'M': 'date/time'}
     if dtype == str:

--- a/packages/vaex-server/vaex/server/service.py
+++ b/packages/vaex-server/vaex/server/service.py
@@ -23,7 +23,7 @@ class Service:
         return {name: {
                        'length_original': df.length_original(),
                        'column_names': df.get_column_names(strings=True),
-                       'dtypes': {name: str("str" if df.dtype(name) == vaex.column.str_type else df.dtype(name)) for name in df.get_column_names(strings=True)},
+                       'dtypes': {name: str("str" if df.data_type(name) == vaex.column.str_type else df.data_type(name)) for name in df.get_column_names(strings=True)},
                        'state': df.state_get()
                     } for name, df in self.df_map.items()
                 }

--- a/packages/vaex-ui/vaex/ui/columns.py
+++ b/packages/vaex-ui/vaex/ui/columns.py
@@ -108,9 +108,9 @@ class ColumnsTableModel(QtCore.QAbstractTableModel):
                 return column_name
             elif property == "Type":
                 if column_name in self.dataset.get_column_names(strings=True):
-                    dtype = self.dataset.dtype(column_name)
+                    dtype = self.dataset.data_type(column_name)
                     return dtype.name
-                    # return str(self.dataset.dtype(column_name))
+                    # return str(self.dataset.data_type(column_name))
                 else:
                     return "virtual column"
             elif property == "Units":

--- a/packages/vaex-ui/vaex/ui/variables.py
+++ b/packages/vaex-ui/vaex/ui/variables.py
@@ -97,7 +97,7 @@ class VariablesTableModel(QtCore.QAbstractTableModel):
                 return variable_name
             elif property == "Type":
                 if column_name in self.dataset.get_column_names():
-                    return str(self.dataset.dtype(column_name))
+                    return str(self.dataset.data_type(column_name))
                 else:
                     return "virtual column"
             elif property == "Units":

--- a/tests/concat_test.py
+++ b/tests/concat_test.py
@@ -58,7 +58,7 @@ def test_concat_arrow_strings():
     df1 = vaex.from_arrays(x=vaex.string_column(['aap', 'noot', 'mies']))
     df2 = vaex.from_arrays(x=vaex.string_column(['a', 'b', 'c']))
     df = vaex.concat([df1, df2])
-    assert df.dtype('x') == df1.dtype('x')
+    assert df.data_type('x') == df1.data_type('x')
     assert df.x.tolist() == ['aap', 'noot', 'mies', 'a', 'b', 'c']
 
 

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -3,13 +3,13 @@ from vaex.column import str_type
 
 
 
-def test_dtype_basics(df):
-    df['new_virtual_column'] = df.x + 1
-    for name in df.column_names:
-        if df.dtype(name) == str_type:
-            assert df[name].values.dtype.kind in 'OSU'
-        else:
-            assert df[name].values.dtype == df.dtype(df[name])
+def test_dtype(ds_local):
+  ds = ds_local
+  for name in ds.column_names:
+    if ds.data_type(name) == str_type:
+      assert ds[name].values.dtype.kind in 'OSU'
+    else:
+      assert ds[name].values.dtype == ds.data_type(ds[name])
 
 
 def test_dtypes(ds_local):
@@ -19,10 +19,10 @@ def test_dtypes(ds_local):
 
 def test_dtype_str():
     df = vaex.from_arrays(x=["foo", "bars"], y=[1,2])
-    assert df.dtype(df.x) == str_type
+    assert df.data_type(df.x) == str_type
     df['s'] = df.y.apply(lambda x: str(x))
-    assert df.dtype(df.x) == str_type
-    assert df.dtype(df.s) == str_type
+    assert df.data_type(df.x) == str_type
+    assert df.data_type(df.s) == str_type
 
     n = np.array(['aap', 'noot'])
     assert vaex.from_arrays(n=n).n.dtype == str_type

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -63,9 +63,8 @@ def test_concat():
     ds2 = vaex.from_arrays(names=['hello', 'this', 'is', 'long'])
     ds = ds1.concat(ds2)
     assert len(ds) == len(ds1) + len(ds2)
-    assert ds.dtype('names') == vaex.column.str_type
-    assert ds.dtype('names') != np.object
-
+    assert ds.data_type('names') == vaex.column.str_type
+    assert ds.data_type('names') != np.object
 
 def test_string_count_stat():
     ds = vaex.from_arrays(names=['hello', 'this', 'is', 'long'])
@@ -101,12 +100,11 @@ def test_concat_mixed():
     # and the other string
     ds1 = vaex.from_arrays(names=['not', 'missing'])
     ds2 = vaex.from_arrays(names=[np.nan, np.nan])
-    assert ds1.dtype(ds1.names) == str
-    assert ds2.dtype(ds2.names) == np.float64
+    assert ds1.data_type(ds1.names) == str
+    assert ds2.data_type(ds2.names) == np.float64
     ds = ds1.concat(ds2)
     assert len(ds) == len(ds1) + len(ds2)
-    assert ds.dtype(ds.names) == ds1.names.dtype
-
+    assert ds.data_type(ds.names) == ds1.names.dtype
 
 def test_strip():
     ds = vaex.from_arrays(names=['this ', ' has', ' space'])


### PR DESCRIPTION
… use df.data_type(), df.expr.dtype is still behaving the same

This allows us to use .dtype for behaving as a numpy array (see NEP branch)
and to later add in support for other data_types, not just numpy (arrow, Python, ...)