### PR TITLE
Chore: version fix

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -64,17 +64,7 @@ except:
     print("version file not found, please run git/hooks/post-commit or git/hooks/post-checkout and/or install them as hooks (see git/README)", file=sys.stderr)
     raise
 
-__version__ = version.versionstring
-# __pre_release_name__ = version.pre_release
-__version_tuple__ = version.versiontuple
-__program_name__ = "vaex"
-# __version_name__ = version.versiontring
-# __release_name_ = version.versiontring[:]
-# __clean_release__ = "%d.%d.%d" % (__version_tuple__)
-__full_name__ = __program_name__ + "-" + __version__
-# __clean_name__ =  __program_name__ + "-" + __clean_release__
-
-__build_name__ = __full_name__ + "-" + version.osname
+__version__ = version.get_versions()
 
 
 def app(*args, **kwargs):

--- a/packages/vaex-core/vaex/version.py
+++ b/packages/vaex-core/vaex/version.py
@@ -1,26 +1,15 @@
-import platform
-from ._version import __version_tuple__, __version__
-versiontuple = __version_tuple__
-versionstring = __version__
-# if pre_release:
-# ersionstring += "-" + pre_release
+import pkg_resources
 
 
-# from vaex.utils import osname, setup.py doesn't want imports...
-osname = dict(darwin="osx", linux="linux", windows="windows")[platform.system().lower()]
+packages = ['vaex', 'vaex-core', 'vaex-viz', 'vaex-hdf5', 'vaex-server', 'vaex-astro',
+            'vaex-ui', 'vaex-jupyter', 'vaex-ml', 'vaex-distributed', 'vaex-arrow', 'vaex-graphql']
 
-if __name__ == "__main__":
-    import vaex
-    import sys
-    # print vaex.__version_tuple__
-    if sys.argv[1] == "version":
-        print("version:", vaex.__version__)
-    elif sys.argv[1] == "fullname":
-        print("full name:", vaex.__full_name__)
-    elif sys.argv[1] == "buildname":
-        print("build name:", vaex.__build_name__)
-    elif sys.argv[1] == "tagcmd":
-        print("git tag %s" % versionstring)
-        print("git push --tags")
-    else:
-        print("use version, fullname or buildname as argument")
+
+def get_versions():
+    def is_installed(p):
+        try:
+            pkg_resources.get_distribution(p)
+            return True
+        except pkg_resources.DistributionNotFound:
+            return False
+    return {p: pkg_resources.get_distribution(p).version for p in packages if is_installed(p)}


### PR DESCRIPTION
eg
```
$ python -c "import vaex; print(vaex.__version__)"                                                              
{'vaex': '3.0.0.dev0', 'vaex-core': '2.0.0.dev0', 'vaex-viz': '0.4.0.dev0', 'vaex-hdf5': '0.6.0.dev0', 
'vaex-server': '0.3.0.dev0', 'vaex-astro': '0.7.0.dev0', 'vaex-ui': '0.3.0', 'vaex-jupyter': '0.5.0',
'vaex-ml': '0.9.0.dev0', 'vaex-distributed': '0.3.0', 'vaex-arrow': '0.5.0.dev0', 'vaex-graphql': '0.1.0.dev0'}
```