### PR TITLE
Fix: limits calculation with selection

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1456,7 +1456,7 @@ class DataFrame(object):
             return task.get()
 
     @docsubst
-    def limits_percentage(self, expression, percentage=99.73, square=False, delay=False):
+    def limits_percentage(self, expression, percentage=99.73, square=False, selection=False, delay=False):
         """Calculate the [min, max] range for expression, containing approximately a percentage of the data as defined
         by percentage.
 
@@ -1482,10 +1482,10 @@ class DataFrame(object):
         waslist, [expressions, ] = vaex.utils.listify(expression)
         limits = []
         for expr in expressions:
-            limits_minmax = self.minmax(expr)
+            limits_minmax = self.minmax(expr, selection=selection)
             vmin, vmax = limits_minmax
             size = 1024 * 16
-            counts = self.count(binby=expr, shape=size, limits=limits_minmax)
+            counts = self.count(binby=expr, shape=size, limits=limits_minmax, selection=selection)
             cumcounts = np.concatenate([[0], np.cumsum(counts)])
             cumcounts = cumcounts / cumcounts.max()
             # TODO: this is crude.. see the details!
@@ -1591,11 +1591,11 @@ class DataFrame(object):
                             elif type in ["ss", "sigmasquare"]:
                                 limits = self.limits_sigma(number, square=True)
                             elif type in ["%", "percent"]:
-                                limits = self.limits_percentage(expression, number, delay=False)
+                                limits = self.limits_percentage(expression, number, selection=selection, delay=False)
                             elif type in ["%s", "%square", "percentsquare"]:
-                                limits = self.limits_percentage(expression, number, square=True, delay=True)
+                                limits = self.limits_percentage(expression, number, selection=selection, square=True, delay=True)
                 elif value is None:
-                    limits = self.minmax(expression, delay=True)
+                    limits = self.minmax(expression, selection=selection, delay=True)
                 else:
                     limits = value
             limits_list.append(limits)

--- a/tests/limits_test.py
+++ b/tests/limits_test.py
@@ -27,3 +27,12 @@ def test_limits(df):
 
     assert df.limits(['x', 'y'], 'minmax', shape=10)[1] == [10, 10]
     assert df.limits(['x', 'y'], 'minmax', shape=(10, 12))[1] == [10, 12]
+
+
+def test_limits_with_selection(df):
+    limits_selection_perc = df.limits('x', value='90%', selection='x > 5')
+
+    df_sliced = df[df.x > 5]
+    limits_sliced = df_sliced.limits('x', value='90%')
+
+    assert limits_sliced.tolist() == limits_selection_perc.tolist()


### PR DESCRIPTION
This fixes #44. 

_Description:_
The selection seems to be ignored when calculating limits that are not `minmax`. For `minmax` the selection is obeyed, as shown by already implemented tests, and via manual testing.
```
limits = df.limits('x', value='90%', sel='x>5')  # selection is ignored
```
However, calculating limits on a filtered DataFrame gives the correct result:
```
df2 = df[df.x > 5]
limits = df2.limit('x', value='90%')  # give the correct result
```
_Checklist:_
- [x] Problem exposed via a unit-test
- [ ] Unit-test passes