### PR TITLE
Fix: Left join when the right dataframe is filtered

### DIFF
--- a/tests/column_test.py
+++ b/tests/column_test.py
@@ -91,3 +91,13 @@ def test_column_count():
 
     # We can count hidden columns if explicity specified
     assert df.column_count(hidden=True) == 3
+
+
+def test_column_indexed(df_local):
+    df = df_local
+    dff = df.take([1, 3, 5, 7, 9])
+    assert isinstance(dff.columns['x'], vaex.column.ColumnIndexed)
+    assert dff.x.tolist() == [1, 3, 5, 7, 9]
+
+    column_masked = vaex.column.ColumnIndexed.index(dff, dff.columns['x'], 'x', np.array([0, -1, 2, 3, 4]), {}, True)
+    assert column_masked[:].tolist() == [1, None, 5, 7, 9]

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -114,6 +114,23 @@ def test_inner_a_b_filtered():
     assert df.evaluate('y_r').tolist() == [1]
 
 
+def test_left_a_b_filtered_right():
+    # similar to test_left_a_b_filtered, but now the df we join is filtered
+    # take b without the last tow
+    df_bf = df_b[df_b.b.str.contains('A|B')]
+    df = df_a.join(df_bf, how='left', on='x', rsuffix='_r')
+    # columns of the left df
+    assert df.x.tolist() == [0, 1, 2]
+    assert df.a.tolist() == ['A', 'B', 'C']
+    assert df.y.tolist() == [0, None, 2]
+    assert df.m.tolist() == [1, None, 3]
+    # columns of the right df
+    assert df.b.tolist() == [None, 'B', 'A']
+    assert df.x_r.tolist() == [None, 1, 2]
+    assert df.y_r.tolist() == [None, 1, None]
+    assert df.m_r.tolist() == [None, 1, None]
+
+
 def test_right_x_x():
     df = df_a.join(other=df_b, on='x', rsuffix='_r', how='right')
     assert df.evaluate('a').tolist() == ['C', 'B', 'A']


### PR DESCRIPTION
Adds a test that exposes a bug with left join when the right dataframe is filtered. 
Originally reported in #732 

- [x] Add a test
- [x] Make the test pass