### PR TITLE
Fix: export_csv in presence of aliased columns

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5817,14 +5817,15 @@ class DataFrameLocal(DataFrame):
         """
         import pandas as pd
 
-        expressions = self.get_column_names(virtual=virtual)
+        column_names = self.get_column_names(virtual=virtual, alias=True)
+        expressions = self.get_column_names(virtual=virtual, alias=False)
         progressbar = vaex.utils.progressbars(progress)
         dtypes = self[expressions].dtypes
         n_samples = len(self)
 
         for i1, i2, chunks in self.evaluate_iterator(expressions, chunk_size=chunk_size, selection=selection):
             progressbar( i1 / n_samples)
-            chunk_dict = {col: values for col, values in zip(expressions, chunks)}
+            chunk_dict = {col: values for col, values in zip(column_names, chunks)}
             chunk_pdf = pd.DataFrame(chunk_dict)
 
             if i1 == 0:  # Only the 1st chunk should have a header and the rest will be appended

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -120,3 +120,18 @@ def test_multi_file_naive_read_convert_export(tmpdir, dtypes):
     assert len(df) == len(df_verify)
     assert df['name'].tolist() == df_verify['name'].tolist()
     assert df['age'].fillnan(magic_value).tolist() == df_verify['age'].fillnan(magic_value).tolist()
+
+
+def test_import_pandas_export_csv(tmpdir):
+    # Create a dataframe with column names that need aliases
+    d = {'player-name': ['Reggie', 'Michael', 'Kobe'],
+         'player-last-name': ['Miller', 'Jordan', 'Bryant']}
+    pandas_df = pd.DataFrame(d)
+    df = vaex.from_pandas(pandas_df)
+    assert list(pandas_df.columns) == df.get_column_names()
+
+    path = str(tmpdir.join('test.csv'))
+    df.export_csv(path)
+    df_opened = vaex.from_csv(path)
+    assert df_opened.shape == df.shape
+    assert df_opened.get_column_names() == df.get_column_names()


### PR DESCRIPTION
This PR addresses #790, which exposed an issue with exporting data to csv when aliased columns are present in the dataframe. 

- [x] Write a test
- [x] Make test pass