### PR TITLE
Fix join when there are None values in left index

### DIFF
--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -332,3 +332,29 @@ def test_join_f_c_inner_none():
     assert df.w2.tolist() == [True, False]
     assert df.z1.tolist() == [-1.0, -2.0]
     assert df.z2.tolist() == [True, False]
+
+
+def test_join_f_c_left_none_fillna():
+    df_f_copy = df_f.copy()
+    df_f_copy['f'] = df_f_copy.f.fillna(value='missing')
+    df = df_f_copy.join(df_c, left_on='f', right_on='c', how='left')
+    assert df.shape == (2, 6)
+    assert df.f.tolist() == ['B', 'C']
+    assert df.c.tolist() == ['B', 'C']
+    assert df.w1.tolist() == ['dog', 'cat']
+    assert df.w2.tolist() == [True, False]
+    assert df.z1.tolist() == [-1.0, -2.0]
+    assert df.z2.tolist() == [True, False]
+
+
+def test_join_f_c_inner_none_fillna():
+    df_f_copy = df_f.copy()
+    df_f_copy['f'] = df_f_copy.f.fillna(value='missing')
+    df = df_f_copy.join(df_c, left_on='f', right_on='c', how='inner')
+    assert df.shape == (3, 6)
+    assert df.f.tolist() == ['B', 'C', None]
+    assert df.c.tolist() == ['B', 'C', None]
+    assert df.w1.tolist() == ['dog', 'cat', 'mouse']
+    assert df.w2.tolist() == [True, False, True]
+    assert df.z1.tolist() == [-1.0, -2.0, None]
+    assert df.z2.tolist() == [True, False, None]

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -313,7 +313,7 @@ def test_with_masked_no_short_circuit():
 
 
 def test_join_f_c_left_none():
-    df = df_f.join(df_c, left_on='f', right_on='c', how='inner')
+    df = df_f.join(df_c, left_on='f', right_on='c', how='left')
     assert df.shape == (3, 6)
     assert df.f.tolist() == ['B', 'C', None]
     assert df.c.tolist() == ['B', 'C', None]

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -37,6 +37,11 @@ df_e = vaex.from_arrays(a=np.array(['X', 'Y', 'Z']),
                         x2=np.array([3.1, 25, np.nan]),
                         )
 
+df_f = vaex.from_arrays(f=np.array(['B', 'C', None]),
+                        w1=np.array(['dog', 'cat', 'mouse']),
+                        w2=np.array([True, False, True])
+                        )
+
 
 def test_no_on():
     # just adds the columns
@@ -305,3 +310,25 @@ def test_with_masked_no_short_circuit():
     assert dfj[:10].columns['j'].masked
     assert dfj['j'][:10].tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, None]
     dfj['j'].tolist()  # make sure we can evaluate the whole column
+
+
+def test_join_f_c_left_none():
+    df = df_f.join(df_c, left_on='f', right_on='c', how='inner')
+    assert df.shape == (3, 6)
+    assert df.f.tolist() == ['B', 'C', None]
+    assert df.c.tolist() == ['B', 'C', None]
+    assert df.w1.tolist() == ['dog', 'cat', 'mouse']
+    assert df.w2.tolist() == [True, False, True]
+    assert df.z1.tolist() == [-1.0, -2.0, None]
+    assert df.z2.tolist() == [True, False, None]
+
+
+def test_join_f_c_inner_none():
+    df = df_f.join(df_c, left_on='f', right_on='c', how='inner')
+    assert df.shape == (2, 6)
+    assert df.f.tolist() == ['B', 'C']
+    assert df.c.tolist() == ['B', 'C']
+    assert df.w1.tolist() == ['dog', 'cat']
+    assert df.w2.tolist() == [True, False]
+    assert df.z1.tolist() == [-1.0, -2.0]
+    assert df.z2.tolist() == [True, False]


### PR DESCRIPTION
This PR addresses the following problems with join:
 - If the index column on the left dataframe contains `None` (and the right does not in this case), those rows on the right will be filled with the 1st group, rather than being themselves `None` (or masked), since there is no match.
- The same issue repeats when one is using `how=inner` with the same configuration as the previous point. 
- If one tries to "fix" this by `df_left['index'] = df_left['index'].fillna(value='missing_value')`, than join crashes for both left and inner. 

See screenshot below for a better explanation:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/18574951/83929379-7d279a80-a793-11ea-9713-d4fa32150803.png">

Expectation is that the last element in columns c, z1, z2 should be masked.

checklist:
- [x] Implement tests
- [ ] Make tests pass
