### PR TITLE
cardinality implementation

### DIFF
--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -964,6 +964,14 @@ def f({0}):
     def is_masked(self):
         return self.ds.is_masked(self.expression)
 
+    def cardinality(self):
+        """
+        :return the unique count divided by size
+        :param kwargs:
+        :return:
+        """
+        return len(self.unique()) / len(self.ds)
+
 
 class FunctionSerializable(object):
     pass

--- a/packages/vaex-core/vaex/test/cardinality_test.py
+++ b/packages/vaex-core/vaex/test/cardinality_test.py
@@ -1,0 +1,12 @@
+import vaex
+
+
+def test_cardinality():
+    df = vaex.from_dict({'x': [1.1, 1.1, 2.2, 2.2],
+                         'y': ['a', 'a', 'b', 'b'],
+                         'z': [1, 2, 3, 4],
+                         'w': [1, 1, 2, 3]})
+    assert df.x.cardinality() == 0.5
+    assert df.y.cardinality() == 0.5
+    assert df.z.cardinality() == 1
+    assert df.w.cardinality() == 0.75


### PR DESCRIPTION
implement a cardinality measure.
Simply put: 
```len(df.x.unique())/len(df)```

Notes:
Cardinality By definition is just the count of different elements, so maybe the naming is not optimal. 