### PR TITLE
Improvement: percentile_approx should work with the 0th and 100th percentile

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1383,9 +1383,14 @@ class DataFrame(object):
                 # if we have an off  # of elements, say, N=3, the center is at i=1=(N-1)/2
                 # if we have an even # of elements, say, N=4, the center is between i=1=(N-2)/2 and i=2=(N/2)
                 # index = (shape[-1] -1-3) * percentage/100. # the -3 is for the edges
-                waslist_percentage, [percentages, ] = vaex.utils.listify(percentage)
                 percentiles = []
                 for p in percentages:
+                    if p == 0:
+                        percentiles.append(percentile_limits[0])
+                        continue
+                    if p == 100:
+                        percentiles.append(percentile_limits[1])
+                        continue
                     values = np.array((totalcounts + 1) * p / 100.)  # make sure it's an ndarray
                     values[empty] = 0
                     floor_values = np.array(np.floor(values))

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1383,6 +1383,7 @@ class DataFrame(object):
                 # if we have an off  # of elements, say, N=3, the center is at i=1=(N-1)/2
                 # if we have an even # of elements, say, N=4, the center is between i=1=(N-2)/2 and i=2=(N/2)
                 # index = (shape[-1] -1-3) * percentage/100. # the -3 is for the edges
+                waslist_percentage, [percentages, ] = vaex.utils.listify(percentage)
                 percentiles = []
                 for p in percentages:
                     if p == 0:

--- a/tests/percentile_approx_test.py
+++ b/tests/percentile_approx_test.py
@@ -18,8 +18,8 @@ def test_percentile_approx():
     np.testing.assert_almost_equal(percentile, expected_result, decimal=1)
 
     # Test for multiple percentages
-    percentiles = df.percentile_approx('x', percentage=[25, 50, 75], percentile_shape=65536)
-    expected_result = [-3.5992, -0.0367, 3.4684]
+    percentiles = df.percentile_approx('x', percentage=[0, 25, 50, 75, 100], percentile_shape=65536)
+    expected_result = [-78.133026, -3.5992, -0.0367, 3.4684, 130.49751]
     np.testing.assert_array_almost_equal(percentiles, expected_result, decimal=1)
 
     # Test for multiple expressions


### PR DESCRIPTION
Making the `percentile_approx` work with the 0th and 100th percentile.

Checklist: 
- [x] Update test
- [ ] Make test pass