### PR TITLE
Feature: batch training for Catboost

### DIFF
--- a/packages/vaex-ml/vaex/ml/catboost.py
+++ b/packages/vaex-ml/vaex/ml/catboost.py
@@ -63,8 +63,8 @@ class CatBoostModel(state.HasState):
     prediction_name = traitlets.Unicode(default_value='catboost_prediction', help='The name of the virtual column housing the predictions.')
     prediction_type = traitlets.Enum(values=['Probability', 'Class', 'RawFormulaVal'], default_value='Probability',
                                      help='The form of the predictions. Can be "RawFormulaVal", "Probability" or "Class".')
-    batch_size = traitlets.CInt(default_value=None, allow_none=True, help='If provided, will train in batches of this size')
-    batch_weights = traitlets.List(traitlets.Float(), default_value=None, allow_none=True, help="Weights to sum models at the end of training in batches")
+    batch_size = traitlets.CInt(default_value=None, allow_none=True, help='If provided, will train in batches of this size.')
+    batch_weights = traitlets.List(traitlets.Float(), default_value=None, allow_none=True, help='Weights to sum models at the end of training in batches.')
     evals_result_ = traitlets.List(traitlets.Dict(), default_value=[], help="Evaluation results")
 
     def __call__(self, *args):
@@ -98,6 +98,7 @@ class CatBoostModel(state.HasState):
             If *verbose_eval* is True then the evaluation metric on the validation set is printed at each boosting stage.
         :param bool plot: if True, display an interactive widget in the Jupyter
             notebook of how the train and validation sets score on each boosting iteration.
+        :param progress: If True display a progressbar when the training is done in batches.
         '''
         self.pool_params['feature_names'] = self.features
         if evals is not None:
@@ -112,13 +113,13 @@ class CatBoostModel(state.HasState):
             target_data = df[self.target].values
             dtrain = catboost.Pool(data=data, label=target_data, **self.pool_params)
             model = catboost.train(params=self.params,
-                                          dtrain=dtrain,
-                                          num_boost_round=self.num_boost_round,
-                                          evals=evals,
-                                          early_stopping_rounds=early_stopping_rounds,
-                                          verbose_eval=verbose_eval,
-                                          plot=plot,
-                                          **kwargs)
+                                   dtrain=dtrain,
+                                   num_boost_round=self.num_boost_round,
+                                   evals=evals,
+                                   early_stopping_rounds=early_stopping_rounds,
+                                   verbose_eval=verbose_eval,
+                                   plot=plot,
+                                   **kwargs)
             self.booster = model
             self.evals_result_ = [model.evals_result_]
             self.feature_importances_ = list(model.feature_importances_)
@@ -138,13 +139,13 @@ class CatBoostModel(state.HasState):
                 target_data = chunk[self.target].values
                 dtrain = catboost.Pool(data=data, label=target_data, **self.pool_params)
                 model = catboost.train(params=self.params,
-                                          dtrain=dtrain,
-                                          num_boost_round=self.num_boost_round,
-                                          evals=evals,
-                                          early_stopping_rounds=early_stopping_rounds,
-                                          verbose_eval=verbose_eval,
-                                          plot=plot,
-                                          **kwargs)
+                                       dtrain=dtrain,
+                                       num_boost_round=self.num_boost_round,
+                                       evals=evals,
+                                       early_stopping_rounds=early_stopping_rounds,
+                                       verbose_eval=verbose_eval,
+                                       plot=plot,
+                                       **kwargs)
                 self.evals_result_.append(model.evals_result_)
                 models.append(model)
             progressbar(1.0)

--- a/packages/vaex-ml/vaex/ml/catboost.py
+++ b/packages/vaex-ml/vaex/ml/catboost.py
@@ -133,12 +133,9 @@ class CatBoostModel(state.HasState):
             models = []
             batch_weights = self.batch_weights if 0 < len(self.batch_weights) else None
 
-            def iterator(df, n):
-                l = len(df)
-                for ndx in range(0, l, n):
-                    yield df[ndx:min(ndx + n, l)]
-
-            for chunk in iterator(df, self.batch_size):
+            column_names = self.features + [self.target]
+            iterator = df[column_names].to_pandas_df(chunk_size=self.batch_size)
+            for i1, i2, chunk in iterator:
                 data = chunk[self.features].values
                 target_data = chunk[self.target].values
                 dtrain = catboost.Pool(data=data, label=target_data, **self.pool_params)

--- a/packages/vaex-ml/vaex/ml/catboost.py
+++ b/packages/vaex-ml/vaex/ml/catboost.py
@@ -86,14 +86,7 @@ class CatBoostModel(state.HasState):
         copy.add_virtual_column(self.prediction_name, expression, unique=False)
         return copy
 
-    def get_feature_importance(self, data=None, type=catboost.EFstrType.FeatureImportance, prettified=False,
-                               thread_count=-1, verbose=False):
-        if self.booster is None:
-            raise RuntimeError("Model was not trained, feature importance is not available")
-        return self.booster.get_feature_importance(data=data, type=type,prettified=prettified,
-                                                   thread_count=thread_count, verbose=verbose)
-
-    def fit(self, df, evals=None, early_stopping_rounds=None, verbose_eval=None, plot=False, **kwargs):
+    def fit(self, df, evals=None, early_stopping_rounds=None, verbose_eval=None, plot=False, progress=None, **kwargs):
         '''Fit the CatBoostModel model given a DataFrame.
         This method accepts all key word arguments for the catboost.train method.
 

--- a/tests/ml/catboost_test.py
+++ b/tests/ml/catboost_test.py
@@ -1,8 +1,8 @@
-import numpy as np
 import catboost as cb
+import numpy as np
 import vaex.ml.catboost
 import vaex.ml.datasets
-
+from sklearn.metrics import roc_auc_score, accuracy_score
 
 # the parameters of the model
 params_multiclass = {
@@ -56,6 +56,57 @@ def test_catboost():
     state = ds_train.state_get()
     ds_test.state_set(state)
     assert np.all(ds_test.col.class_.values == np.argmax(ds_test.catboost_prediction.values, axis=1))
+
+
+def test_catboost_batch_training():
+    """
+    We train three models. One on 10 samples. the second on 100 samples with batches of 10,
+    and the third too on 100 samples with batches of 10, but we weight the models as if only the first batch matters.
+    A model trained on more data, should do better than the model who only trained on 10 samples,
+    and the weighted model will do exactly as good as the one who trained on 10 samples as it ignore the rest by weighting.
+    """
+    ds = vaex.ml.datasets.load_iris()
+    ds_train, ds_test = ds.ml.train_test_split(test_size=0.2, verbose=False)
+    features = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width']
+    target = 'class_'
+    prediction_type = 'Probability'
+    vanilla = vaex.ml.catboost.CatBoostModel(num_boost_round=1,
+                                             params=params_multiclass,
+                                             features=features,
+                                             target=target,
+                                             prediction_type=prediction_type)
+    batch_booster = vaex.ml.catboost.CatBoostModel(num_boost_round=1,
+                                                   params=params_multiclass,
+                                                   features=features,
+                                                   target=target,
+                                                   prediction_type=prediction_type,
+                                                   batch_size=10)
+    weights = [1.0] + [0.0] * 9
+    weights_booster = vaex.ml.catboost.CatBoostModel(num_boost_round=1,
+                                                     params=params_multiclass,
+                                                     features=features,
+                                                     target=target,
+                                                     prediction_type=prediction_type,
+                                                     batch_size=10,
+                                                     batch_weights=weights)
+
+    vanilla.fit(ds_train.head(10), evals=[ds_test])
+    batch_booster.fit(ds_train.head(100), evals=[ds_test])
+    weights_booster.fit(ds_train.head(100), evals=[ds_test])
+
+    ground_truth = ds_test[target].values
+    vanilla_accuracy = accuracy_score(ground_truth, np.argmax(vanilla.predict(ds_test), 1))
+    batch_accuracy = accuracy_score(ground_truth, np.argmax(batch_booster.predict(ds_test), 1))
+    weighted_accuracy = accuracy_score(ground_truth, np.argmax(weights_booster.predict(ds_test), 1))
+    assert vanilla_accuracy == weighted_accuracy < batch_accuracy
+
+    vanilla_auc = roc_auc_score(ground_truth, vanilla.predict(ds_test), multi_class='ovr')
+    batch_auc = roc_auc_score(ground_truth, batch_booster.predict(ds_test), multi_class='ovr')
+    weighted_auc = roc_auc_score(ground_truth, weights_booster.predict(ds_test), multi_class='ovr')
+    assert vanilla_auc == weighted_auc < batch_auc
+
+    assert list(weights_booster.get_feature_importance()) == list(vanilla.get_feature_importance()) != list(
+        batch_booster.get_feature_importance())
 
 
 def test_catboost_numerical_validation():


### PR DESCRIPTION
Added four new params to *CatBoostModel*.
* **batch_size** - If provided, train in batches of that size.
* **batch_weights** - If provided and *batch_size* is provided, used to sum the models trained in batches and their feature importance. 
* **evals_result_** - Saving evals_result_ for all batches during training as the [sum_models](https://catboost.ai/docs/concepts/python-reference_sum_models.html) ignores it.

Implemented *get_feature_importance* to match the [Catboost method](https://catboost.ai/docs/concepts/python-reference_catboost_get_feature_importance.html).

Added feature_names to the data Pool such that the Catboost booster acknowledges the feature names.

Note - 
I designed it to run differently on a single run vs batch instead of a "cleaner" single batch version if batch_size isn't provided because the *sum_models* method loses all kind of information which we might want keep if we can.