### PR TITLE
Feature: adding `dt.floor()` method

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -669,6 +669,36 @@ def dt_strftime(x, date_format):
     import pandas as pd
     return pd.Series(_pandas_dt_fix(x)).dt.strftime(date_format)
 
+@register_function(scope='dt')
+def dt_floor(x, freq, *args):
+    """Perform floor operation on an expression for a given frequency.
+
+    :param freq: The frequency level to floor the index to. Must be a fixed frequency like 'S' (second), or 'H' (hour), but not 'ME' (month end).
+    :returns: an expression containing the floored datetime column.
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> date = np.array(['2009-10-12T03:31:00', '2016-02-11T10:17:34', '2015-11-12T11:34:22'], dtype=np.datetime64)
+    >>> df = vaex.from_arrays(date=date)
+    >>> df
+      #  date
+      0  2009-10-12 03:31:00
+      1  2016-02-11 10:17:34
+      2  2015-11-12 11:34:22
+
+    >>> df.date.dt.floor("H")
+    Expression = dt_floor(date, 'H')
+    Length: 3 dtype: datetime64[ns] (expression)
+    --------------------------------------------
+    0  2009-10-12 03:00:00.000000000
+    1  2016-02-11 10:00:00.000000000
+    2  2015-11-12 11:00:00.000000000
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.floor(freq, *args)
+
 ########## timedelta operations ##########
 
 @register_function(scope='td', as_property=True)

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -27,6 +27,7 @@ def test_datetime_operations():
     assert df.date.dt.weekofyear.values.tolist() == pandas_df.date.dt.weekofyear.values.tolist()
     assert df.date.dt.dayofyear.values.tolist() == pandas_df.date.dt.dayofyear.values.tolist()
     assert df.date.dt.dayofweek.values.tolist() == pandas_df.date.dt.dayofweek.values.tolist()
+    assert df.date.dt.floor('H').values.tolist() == pandas_df.date.dt.floor('H').values.tolist()
 
 
 def test_datetime_agg():
@@ -127,7 +128,7 @@ def test_create_datetime64_column_from_str():
     expr = df.year + '-' + df.month + '-' + df.day + 'T' + df.hour + ':' + df.minute
     assert expr.values.astype(np.datetime64).tolist() == expr.astype('datetime64').tolist()
     assert expr.values.astype('datetime64[ns]').tolist() == expr.astype('datetime64[ns]').tolist()
-    
+
 def test_create_str_column_from_datetime64():
     date = np.array([np.datetime64('2009-10-12T03:31:00'),
                 np.datetime64('2016-02-11T10:17:34'),
@@ -135,10 +136,10 @@ def test_create_str_column_from_datetime64():
                 np.datetime64('2003-03-03T00:33:15'),
                 np.datetime64('2014-07-23T15:08:05'),
                 np.datetime64('2011-01-01T07:02:01')], dtype='<M8[ns]')
-                
+
     df = vaex.from_arrays(date=date)
     pandas_df = df.to_pandas_df()
-    
+
     date_format = "%Y/%m/%d"
 
     assert df.date.dt.strftime(date_format).values.tolist() == pandas_df.date.dt.strftime(date_format).values.tolist()


### PR DESCRIPTION
As suggested by #842, this PR adds  the `.floor()` datetime method.

The usage is as shown in the picture below:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/18574951/84919298-0c04b300-b0c2-11ea-8144-22666b47d791.png">
