### PR TITLE
fix: mybinder links have to be markdown (due to nbsphinx limitation)

### DIFF
--- a/docs/source/example_dask.ipynb
+++ b/docs/source/example_dask.ipynb
@@ -8,7 +8,8 @@
     "\n",
     "If you want to try out this notebook with a live Python kernel, use mybinder:\n",
     "\n",
-    "<a class=\"reference external image-reference\" href=\"https://mybinder.org/v2/gh/vaexio/vaex/latest?filepath=docs%2Fsource%2Fexample_dask.ipynb\"><img alt=\"https://mybinder.org/badge_logo.svg\" src=\"https://mybinder.org/badge_logo.svg\" width=\"150px\"></a>\n",
+    "[![dask example](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/vaexio/vaex/stable?filepath=docs%2Fsource%2Fexample_dask.ipynb)\n",
+    "\n",
     "\n",
     "## Dask.array\n",
     "A vaex dataframe can be lazily converted to a [dask.array](https://docs.dask.org/en/latest/array.html) using [DataFrame.to_dask_array](api.rst#vaex.dataframe.DataFrame.to_dask_array)."


### PR DESCRIPTION
Fixes #856

@JovanVeljanoski : could you finish this further? Basically we have to repeat this for every item in 4be22b7f102a6873f5d4d24c135c73f14a167cc2