### PR TITLE
fix(ml): weight of evidence encoder can handle edge cases

### DIFF
--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -751,6 +751,7 @@ class WeightOfEvidenceEncoder(Transformer):
             # Instead of counting the goods and bad, we divide by the count
             # which reduces to the mean
             agg = df.groupby(feature, agg={'positive': vaex.agg.mean(self.target)})
+            agg['positive'] = agg.func.where(agg['positive'] == 0, self.epsilon, agg['positive'])
             agg['negative'] = 1 - agg.positive
             agg['negative'] = agg.func.where(agg['negative'] == 0, self.epsilon, agg['negative'])
             agg['woe'] = np.log(agg.positive/agg.negative)

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -364,6 +364,19 @@ def test_weight_of_evidence_encoder_bad_values():
     df = vaex.from_arrays(x=['a', 'b'], y=y)
     trans.fit_transform(df)
 
+def test_weight_of_evidence_encoder_edge_cases():
+    y = [1, 0, 1, 0, 1, 0, 0, 0, 1, 1]
+    x = ['a', 'a', 'a', 'b', 'b', 'b', 'c', 'c', 'd', 'd']
+    df = vaex.from_arrays(x=x, y=y)
+
+    woe_encoder = vaex.ml.WeightOfEvidenceEncoder(features=['x'], target='y', unseen='zero')
+    df = woe_encoder.fit_transform(df)
+
+    expected_values = [0.69314, 0.69314, 0.69314, -0.69314, -0.69314,
+                      -0.69314, -13.81550, -13.81550, 13.81551, 13.81551]
+    np.testing.assert_array_almost_equal(df.woe_encoded_x.tolist(),
+                                         expected_values,
+                                         decimal=5)
 
 def test_groupby_transformer_basics():
     df_train = vaex.from_arrays(x=['dog', 'dog', 'dog', 'cat', 'cat'], y=[2, 3, 4, 10, 20])


### PR DESCRIPTION
This PR fixes an issue with the `WeightOfEvidence` encoder, that happens when a feature has no positive targets (binary classification case). 

Note: the case when a feature has no negative targets was already handled in the initial implementation. The same approach is used here for the other edge case.

 - [x] test covering these edge cases
 - [x] test passes