### PR TITLE
Fix: minmax method for different dtypes

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1255,7 +1255,7 @@ class DataFrame(object):
         dtypes = [self.data_type(expr) for expr in expressions]
         dtype0 = dtypes[0]
         if not all([k.kind == dtype0.kind for k in dtypes]):
-            raise ValueError("cannot mix datetime and non-datetime expressions")
+            raise TypeError("cannot mix different dtypes in 1 minmax call")
         progressbar = vaex.utils.progressbars(progress, name="minmaxes")
         limits = self.limits(binby, limits, selection=selection, delay=True)
         all_tasks = [calculate(expression, limits) for expression in expressions]

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -415,15 +415,16 @@ class MinMaxScaler(Transformer):
         :param df: A vaex DataFrame.
         '''
 
-        fmin = df.min(self.features, delay=True)
-        fmax = df.max(self.features, delay=True)
+        minmax = []
+        for feat in self.features:
+            minmax.append(df.minmax(feat, delay=True))
 
         @vaex.delayed
-        def assign(fmin, fmax):
-            self.fmin_ = fmin.tolist()
-            self.fmax_ = fmax.tolist()
+        def assign(minmax):
+            self.fmin_ = [elem[0] for elem in minmax]
+            self.fmax_ = [elem[1] for elem in minmax]
 
-        assign(fmin, fmax)
+        assign(minmax)
         df.execute()
 
     def transform(self, df):

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -247,7 +247,8 @@ def test_minmax_mixed_types():
     x = np.array([1, 0], dtype=np.int)
     y = np.array([0.5, 1.5], dtype=np.float)
     df = vaex.from_arrays(x=x, y=y)
-    assert df.minmax(['x', 'y']).tolist() == [[0.0, 1.0], [0.5, 1.5]]
+    with pytest.raises(TypeError):
+        df.minmax(['x', 'y'])
 
 
 def test_big_endian_binning():

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -243,6 +243,13 @@ def test_minmax_all_dfs(df):
     assert df.max(df.x) == vmax
 
 
+def test_minmax_mixed_types():
+    x = np.array([1, 0], dtype=np.int)
+    y = np.array([0.5, 1.5], dtype=np.float)
+    df = vaex.from_arrays(x=x, y=y)
+    assert df.minmax(['x', 'y']).tolist() == [[0.0, 1.0], [0.5, 1.5]]
+
+
 def test_big_endian_binning():
     x = np.arange(10, dtype='>f8')
     y = np.zeros(10, dtype='>f8')


### PR DESCRIPTION
This PR enables the `df.minmax()` method to be applied on multiple expressions of different numeric types (e.g. int, float) at the same time.

Checklist:
 - [x] test
 - [ ] make test pass