### PR TITLE
Fix(core): not all operators where supported in expresso

### DIFF
--- a/tests/expresso_test.py
+++ b/tests/expresso_test.py
@@ -1,5 +1,22 @@
+import pytest
+
 from vaex.expresso import parse_expression, node_to_string, simplify, translate, validate_expression
 import vaex
+
+
+@pytest.mark.parametrize('op', vaex.expression._binary_ops)
+def test_binary_ops(op):
+    expression = f'(a {op["code"]} b)'
+    node = parse_expression(expression)
+    assert node_to_string(node) == expression
+    validate_expression(expression, {'a', 'b'})
+
+
+@pytest.mark.parametrize('op', vaex.expression._unary_ops)
+def test_unary_ops(op):
+    expression = f'{op["code"]}a'
+    node = parse_expression(expression)
+    assert node_to_string(node) == expression
 
 
 def test_compare():
@@ -14,6 +31,7 @@ def test_compare():
     expr = "(x // 10)"
     node = parse_expression(expr)
     assert expr == node_to_string(node)
+
 
 def test_simplify():
     assert simplify("0 + 1") == "1"


### PR DESCRIPTION
This PR fixes the issue that sometimes happens when chaining certain type of arithmetic operations. The issue is exposed via a unit-test.

Checklist:
- [x] Implement a unit-test
- [ ] Make the unit-test pass