### PR TITLE
Feat: recognize pandas "string" dtype

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -387,6 +387,7 @@ def from_pandas(df, name="pandas", copy_index=False, index_name="index"):
     import six
     import pandas as pd
     import numpy as np
+    import pyarrow as pa
     columns = {}
 
     def add(name, column):
@@ -394,6 +395,8 @@ def from_pandas(df, name="pandas", copy_index=False, index_name="index"):
         # the first test is to support (partially) pandas 0.23
         if hasattr(pd.core.arrays, 'integer') and isinstance(values, pd.core.arrays.integer.IntegerArray):
             values = np.ma.array(values._data, mask=values._mask)
+        elif hasattr(pd.core.arrays, 'StringArray') and isinstance(values, pd.core.arrays.StringArray):
+            values = pa.array(values)
         try:
             columns[name] = vaex.dataset.to_supported_array(values)
         except Exception as e:

--- a/tests/from_pandas_test.py
+++ b/tests/from_pandas_test.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import numpy as np
+import vaex
+import datetime
+
+
+def test_from_pandas():
+    dd_dict = {
+        'boolean': [True, True, False, None, True],
+        'text': ['This', 'is', 'some', 'text', 'so...'],
+        'text_missing': pd.Series(['Some', 'parts', None, 'missing', None], dtype='string'),
+        'float': [1, 30, -2, 1.5, 0.000],
+        'float_missing': [1, None, -2, 1.5, 0.000],
+        'int_missing': pd.Series([1, None, 5, 1, 10], dtype='Int64'),
+        'datetime_1': [pd.NaT, datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1)],
+        'datetime_2': [pd.NaT, None, pd.NaT, pd.NaT, pd.NaT],
+        'datetime_3': [pd.Timedelta('1M'), pd.Timedelta('1D'), pd.Timedelta('100M'), pd.Timedelta('2D'), pd.Timedelta('1H')],
+        'datetime_4': [pd.Timestamp('2001-1-1 2:2:11'), pd.Timestamp('2001-12'), pd.Timestamp('2001-10-1'), pd.Timestamp('2001-03-1 2:2:11'), pd.Timestamp('2001-1-1 2:2:11')],
+        'datetime_5': [datetime.date(2010, 1, 1), datetime.date(2010, 1, 1), datetime.date(2010, 1, 1), datetime.date(2010, 1, 1), datetime.date(2010, 1, 1)],
+        'datetime_6': [datetime.time(21, 1, 1), datetime.time(21, 1, 1), datetime.time(21, 1, 1), datetime.time(21, 1, 1), datetime.time(21, 1, 1)],
+    }
+
+    # Get pandas dataframe
+    pandas_df = pd.DataFrame(dd_dict)
+    pandas_df['datetime_7'] = pd.to_timedelta(pandas_df['datetime_2'] - pandas_df['datetime_1'])
+    vaex_df = vaex.from_pandas(pandas_df)
+    repr_value = repr(vaex_df)
+    str_value = str(vaex_df)
+
+    assert 'NaT' in repr_value
+    assert 'NaT' in str_value
+    assert '--' in repr_value
+    assert '--' in str_value
+
+    # string columns are now arrows arrays
+    # assert vaex_df.text_missing.is_masked == True
+    assert vaex_df.int_missing.is_masked == True
+    assert vaex_df.float_missing.is_masked == False
+    assert vaex_df.int_missing.tolist() == [1, None, 5, 1, 10]
+    assert vaex_df.text_missing.tolist() == ['Some', 'parts', None, 'missing', None]
+    assert vaex_df.float_missing.values[[0, 2, 3, 4]].tolist() == [1.0, -2.0, 1.5, 0.0]
+    assert np.isnan(vaex_df.float_missing.values[1])

--- a/tests/repr_test.py
+++ b/tests/repr_test.py
@@ -67,28 +67,3 @@ def test_slice_filtered_remte(ds_remote):
     df = ds_remote
     dff = df[df.x > 0]
     assert "0.0bla" not in repr(dff[['x']])
-
-
-def test_repr_from_pandas():
-    dd_dict = {
-        'boolean': [True, True, False, None, True],
-        'text': ['This', 'is', 'some', 'text', 'so...'],
-        'numbers_1': [1, 30, -2, 1.5, 0.000],
-        'numbers_2': [1, None, -2, 1.5, 0.000],
-        'numbers_3': [1, np.nan, -2, 1.5, 0.000],
-        'datetime_1': [pd.NaT, datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1)],
-        'datetime_2': [pd.NaT, None, pd.NaT, pd.NaT, pd.NaT],
-        'datetime_3': [pd.Timedelta('1M'), pd.Timedelta('1D'), pd.Timedelta('100M'), pd.Timedelta('2D'), pd.Timedelta('1H')],
-        'datetime_4': [pd.Timestamp('2001-1-1 2:2:11'), pd.Timestamp('2001-12'), pd.Timestamp('2001-10-1'), pd.Timestamp('2001-03-1 2:2:11'), pd.Timestamp('2001-1-1 2:2:11')],
-        'datetime_5': [datetime.date(2010, 1, 1), datetime.date(2010, 1, 1), datetime.date(2010, 1, 1), datetime.date(2010, 1, 1), datetime.date(2010, 1, 1)],
-        'datetime_6': [datetime.time(21, 1, 1), datetime.time(21, 1, 1), datetime.time(21, 1, 1), datetime.time(21, 1, 1), datetime.time(21, 1, 1)],
-    }
-
-    # Get pandas dataframe
-    dd = pd.DataFrame(dd_dict)
-    dd['datetime_7'] = pd.to_timedelta(dd['datetime_2'] - dd['datetime_1'])
-    ds = vaex.from_pandas(dd)
-    repr_value = repr(ds)
-    str_value = str(ds)
-    assert 'NaT' in repr_value
-    assert 'NaT' in str_value


### PR DESCRIPTION
Enable `vaex.from_pandas()` to recognize the new `pandas.StringDtype` (or "string" for short when using it in pandas).
Also, update the test to cover these cases.

Checklist:
 - [x] Update tests
 - [x] Update functionality
 - [x] Review