### PR TITLE
Fix: multiple dropna() was using cached length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # vaex 3.1.0 (unreleased)
 
 ## vaex-core 2.1.0-dev (unreleased)
+   * Fixes
+      * Repeated dropna/dropnan/dropmissing could report cached length [#874](https://github.com/vaexio/vaex/pull/874)
    * Features
-       * Arrow is now a core dependency, vaex-arrow is deprecated. Much better chunked array support, numpy conversion is done lazily. [#517](https://github.com/vaexio/vaex/pull/517)
+      * Arrow is now a core dependency, vaex-arrow is deprecated. Much better chunked array support, numpy conversion is done lazily. [#517](https://github.com/vaexio/vaex/pull/517)
 
 ## vaex-arrow (DEPRECATED)
    This is now part of vaex-core.

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4378,13 +4378,11 @@ class DataFrame(object):
         return self._filter_all(self.func.isinf, column_names)
 
     def _filter_all(self, f, column_names=None):
-        copy = self.copy()
         column_names = column_names or self.get_column_names(virtual=False)
         expression = f(self[column_names[0]])
         for column in column_names[1:]:
             expression = expression | f(self[column])
-        copy.select(~expression, name=FILTER_SELECTION_NAME, mode='and')
-        return copy
+        return self.filter(~expression, mode='and')
 
     def select_nothing(self, name="default"):
         """Select nothing."""

--- a/tests/dropna_test.py
+++ b/tests/dropna_test.py
@@ -9,6 +9,20 @@ def test_dropna_objects(df_local_non_arrow):
     assert np.isnan(float_elements).any() == False, 'np.nan still exists in column'
 
 
+def test_dropna_cache_bug():
+    # tests https://github.com/vaexio/vaex/pull/874
+    # where repeated dropna would use a cached length
+    df = vaex.from_arrays(
+        x=[1, None, 2],
+        y=[3, 4, None],
+    )
+    df1 = df.dropna('x')
+    assert len(df1) == 2
+
+    df2 = df1.dropna('y')
+    assert len(df2) == 1
+
+
 def test_dropna(ds_local):
     ds = ds_local
     ds_copy = ds.copy()


### PR DESCRIPTION
This PR addresses a rather exotic case when the `repr` breaks when one drops NA, then filteres the dataframe, then drops NA on some different columns again. See unit-test for details.

Checklist:
- [x] make unit-test
- [ ] unit-test passes

