### PR TITLE
Fix: minmax operations on datetime columns

### DIFF
--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -1,7 +1,12 @@
-from common import *
-import numpy as np
-import pandas as pd
 import datetime
+
+import numpy as np
+
+import pandas as pd
+
+import pytest
+
+import vaex
 
 
 def test_datetime_operations():
@@ -131,13 +136,14 @@ def test_create_datetime64_column_from_str():
     assert expr.values.astype(np.datetime64).tolist() == expr.astype('datetime64').tolist()
     assert expr.values.astype('datetime64[ns]').tolist() == expr.astype('datetime64[ns]').tolist()
 
+
 def test_create_str_column_from_datetime64():
     date = np.array([np.datetime64('2009-10-12T03:31:00'),
-                np.datetime64('2016-02-11T10:17:34'),
-                np.datetime64('2015-11-12T11:34:22'),
-                np.datetime64('2003-03-03T00:33:15'),
-                np.datetime64('2014-07-23T15:08:05'),
-                np.datetime64('2011-01-01T07:02:01')], dtype='<M8[ns]')
+                     np.datetime64('2016-02-11T10:17:34'),
+                     np.datetime64('2015-11-12T11:34:22'),
+                     np.datetime64('2003-03-03T00:33:15'),
+                     np.datetime64('2014-07-23T15:08:05'),
+                     np.datetime64('2011-01-01T07:02:01')], dtype='<M8[ns]')
 
     df = vaex.from_arrays(date=date)
     pandas_df = df.to_pandas_df()

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -1,5 +1,7 @@
 from common import *
 import numpy as np
+import pandas as pd
+import datetime
 
 
 def test_datetime_operations():
@@ -143,3 +145,22 @@ def test_create_str_column_from_datetime64():
     date_format = "%Y/%m/%d"
 
     assert df.date.dt.strftime(date_format).values.tolist() == pandas_df.date.dt.strftime(date_format).values.tolist()
+
+
+def test_datetime_nat_minmax_consistency():
+    pandas_df = pd.DataFrame({'t': [pd.NaT,
+                                    datetime.datetime(2019, 1, 1),
+                                    datetime.datetime(2019, 2, 1),
+                                    datetime.datetime(2019, 4, 1),
+                                    datetime.datetime(2019, 5, 1)]})
+    df = vaex.from_pandas(pandas_df)
+
+    t_min = np.datetime64(df.t.min())
+    assert t_min == np.datetime64('2019-01-01')
+
+    t_max = np.datetime64(df.t.max())
+    assert t_max == np.datetime64('2019-05-01')
+
+    t_minmax = df.minmax(['t'])
+    assert t_minmax[0, 0] == t_min
+    assert t_minmax[0, 1] == t_max


### PR DESCRIPTION
This PR addresses an issue with computing `.min`, `.max` and `.minmax` on `np.datetime64` columns in the presence of `pd.NaT` (not a time) i.e. missing time values.

Checklist:
- [x] make test
- [ ] make test pass