### PR TITLE
Fix: .percentile_approx endpoints

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1414,10 +1414,10 @@ class DataFrame(object):
                 percentiles = []
                 for p in percentages:
                     if p == 0:
-                        percentiles.append(percentile_limits[0])
+                        percentiles.append(percentile_limits[i][0])
                         continue
                     if p == 100:
-                        percentiles.append(percentile_limits[1])
+                        percentiles.append(percentile_limits[i][1])
                         continue
                     values = np.array((totalcounts + 1) * p / 100.)  # make sure it's an ndarray
                     values[empty] = 0
@@ -2010,11 +2010,11 @@ class DataFrame(object):
 
     def data_type(self, expression, array_type=None, internal=False, check_alias=True):
         """Return the datatype for the given expression, if not a column, the first row will be evaluated to get the data type.
-        
+
         Example:
-        
+
         >>> df = vaex.from_scalars(x=1, s='Hi')
-        
+
         :param str array_type: 'numpy', 'arrow' or None, to indicate if the data type should be converted
         """
         expression = _ensure_string_from_expression(expression)

--- a/tests/percentile_approx_test.py
+++ b/tests/percentile_approx_test.py
@@ -9,7 +9,6 @@ version = tuple(map(int, np.__version__.split('.')))
 
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
-@pytest.mark.xfail
 def test_percentile_approx():
     df = vaex.example()
     # Simple test
@@ -30,7 +29,6 @@ def test_percentile_approx():
 
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
-@pytest.mark.xfail
 def test_percentile_1d():
     x = np.array([0, 0, 10, 100, 200])
     df = vaex.from_arrays(x=x)

--- a/tests/percentile_approx_test.py
+++ b/tests/percentile_approx_test.py
@@ -8,9 +8,8 @@ import sys
 version = tuple(map(int, np.__version__.split('.')))
 
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
-@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
-@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
-@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,8), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
 def test_percentile_approx():
     df = vaex.example()
     # Simple test
@@ -30,9 +29,8 @@ def test_percentile_approx():
 
 
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
-@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
-@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
-@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,8), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
 def test_percentile_1d():
     x = np.array([0, 0, 10, 100, 200])
     df = vaex.from_arrays(x=x)

--- a/tests/percentile_approx_test.py
+++ b/tests/percentile_approx_test.py
@@ -9,6 +9,8 @@ version = tuple(map(int, np.__version__.split('.')))
 
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,8), reason="strange ref count issue with numpy")
 def test_percentile_approx():
     df = vaex.example()
     # Simple test
@@ -29,6 +31,8 @@ def test_percentile_approx():
 
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,8), reason="strange ref count issue with numpy")
 def test_percentile_1d():
     x = np.array([0, 0, 10, 100, 200])
     df = vaex.from_arrays(x=x)

--- a/tests/percentile_approx_test.py
+++ b/tests/percentile_approx_test.py
@@ -10,6 +10,7 @@ version = tuple(map(int, np.__version__.split('.')))
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,8), reason="strange ref count issue with numpy")
 def test_percentile_approx():
     df = vaex.example()
     # Simple test
@@ -31,6 +32,7 @@ def test_percentile_approx():
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,1)) and platform.system().lower() == 'windows', reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,6), reason="strange ref count issue with numpy")
 @pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,7), reason="strange ref count issue with numpy")
+@pytest.mark.skipif(((1,17,0) <= version <= (1,18,5)) and platform.system().lower() == 'linux' and sys.version_info[:2] == (3,8), reason="strange ref count issue with numpy")
 def test_percentile_1d():
     x = np.array([0, 0, 10, 100, 200])
     df = vaex.from_arrays(x=x)


### PR DESCRIPTION
Small fix for `.percentile_approx` when the precentages include values like 0 or 100.

- [x] enable already written unit-tests
- [x] tests pass
- [ ] review