### PR TITLE
Fix: unique on str column that has missing values

### DIFF
--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -33,6 +33,13 @@ def same_type(type1, type2):
         return False
 
 
+def tolist(ar):
+    if isinstance(ar, supported_arrow_array_types):
+        return ar.to_pylist()
+    else:
+        return ar.tolist()
+
+
 def to_numpy(x, strict=False):
     import vaex.arrow.convert
     import vaex.column

--- a/tests/arrow/assumptions_test.py
+++ b/tests/arrow/assumptions_test.py
@@ -12,6 +12,16 @@ def test_non_native():
     with pytest.raises(pa.lib.ArrowNotImplementedError):
         pa.array(x)
 
+@pytest.mark.skip(reason="Only the case for Arrow 0.17, leaving this is as 'documentation'")
+def test_null_behaviour():
+    assert pa.NULL in ['Confused'], "Arrow 0.17 "
+
+
+def test_in_pylist():
+    # this reflects the to_pylist in DataFrame.ordinal_encode
+    ar = pa.array(['red', 'green'])
+    assert ar[0] not in ar.to_pylist(), "Arrow 1.0.1 says no"
+
 
 def test_cannot_convert_nulls_to_masked():
     x = np.arange(4)

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -216,6 +216,38 @@ def test_one_hot_encoding():
     ohe = vaex.ml.OneHotEncoder(features=['kids', 'animals', 'numbers'])
     ohe.fit_transform(ds)
 
+def test_one_hot_encoding_with_na():
+    x = ['Reggie', 'Michael', None, 'Reggie']
+    y = [31, 23, np.nan, 31]
+    df_train = vaex.from_arrays(x=x, y=y)
+
+    x = ['Michael', 'Reggie', None, None]
+    y = [23, 31, np.nan, np.nan]
+    df_test = vaex.from_arrays(x=x, y=y)
+
+
+    enc = vaex.ml.OneHotEncoder(features=['x', 'y'])
+    enc.fit(df_train)
+
+    assert enc.uniques_[0] == [None, 'Michael', 'Reggie']
+    np.testing.assert_array_equal(enc.uniques_[1], [np.nan, 23.0, 31.0])
+
+    df_train = enc.transform(df_train)
+    assert df_train.x_missing.tolist() == [0, 0, 1, 0]
+    assert df_train.x_Michael.tolist() == [0, 1, 0, 0]
+    assert df_train.x_Reggie.tolist() == [1, 0, 0, 1]
+    assert df_train['y_23.0'].tolist() == [0, 1, 0, 0]
+    assert df_train['y_31.0'].tolist() == [1, 0, 0, 1]
+    assert df_train['y_nan'].tolist() == [0, 0, 1, 0]
+
+    df_test = enc.transform(df_test)
+    assert df_test.x_missing.tolist() == [0, 0, 1, 1]
+    assert df_test.x_Michael.tolist() == [1, 0, 0, 0]
+    assert df_test.x_Reggie.tolist() == [0, 1, 0, 0]
+    assert df_test['y_23.0'].tolist() == [1, 0, 0, 0]
+    assert df_test['y_31.0'].tolist() == [0, 1, 0, 0]
+    assert df_test['y_nan'].tolist() == [0, 0, 1, 1]
+
 
 def test_maxabs_scaler():
     x = np.array([-2.65395789, -7.97116295, -4.76729177, -0.76885033, -6.45609635])

--- a/tests/unique_test.py
+++ b/tests/unique_test.py
@@ -1,25 +1,31 @@
-from common import *
+from common import small_buffer
+
+import numpy as np
+
+import vaex
+
 
 def test_unique_arrow():
     ds = vaex.from_arrays(x=vaex.string_column(['a', 'b', 'a', 'a', 'a', 'b', 'b', 'b', 'b', 'a']))
     with small_buffer(ds, 2):
-        assert set(ds.unique(ds.x).astype('U').tolist()) == {'a', 'b'}
+        assert set(ds.unique(ds.x).to_pylist()) == {'a', 'b'}
         values, index = ds.unique(ds.x, return_inverse=True)
-        assert values[index].tolist() == ds.x.tolist()
+        assert np.array(values)[index].tolist() == ds.x.tolist()
 
 
 def test_unique():
     ds = vaex.from_arrays(colors=['red', 'green', 'blue', 'green'])
     with small_buffer(ds, 2):
-        assert set(ds.unique(ds.colors).astype('U').tolist()) == {'red', 'green', 'blue'}
+        assert set(ds.unique(ds.colors).to_pylist()) == {'red', 'green', 'blue'}
         values, index = ds.unique(ds.colors, return_inverse=True)
-        assert values[index].tolist() == ds.colors.tolist()
+        assert np.array(values)[index].tolist() == ds.colors.tolist()
 
     ds = vaex.from_arrays(x=['a', 'b', 'a', 'a', 'a', 'b', 'b', 'b', 'b', 'a'])
     with small_buffer(ds, 2):
-        assert set(ds.unique(ds.x).astype('U').tolist()) == {'a', 'b'}
+        assert set(ds.unique(ds.x).to_pylist()) == {'a', 'b'}
         values, index = ds.unique(ds.x, return_inverse=True)
-        assert values[index].tolist() == ds.x.tolist()
+        assert np.array(values)[index].tolist() == ds.x.tolist()
+
 
 def test_unique_f4():
     x = np.array([np.nan, 0, 1, np.nan, 2, np.nan], dtype='f4')
@@ -38,9 +44,21 @@ def test_unique_nan():
         assert values[~mask].tolist() == df.x.values[~mask].tolist()
         # assert indices.tolist() == [0, 1, 2, 0, 3, 0]
 
+
 def test_unique_missing():
     # Create test databn
-    x = np.array([None, 'A', 'B', -1, 0, 2, '', '', None, None, None, np.nan, np.nan, np.nan, np.nan,])
+    x = np.array([None, 'A', 'B', -1, 0, 2, '', '', None, None, None, np.nan, np.nan, np.nan, np.nan])
     df = vaex.from_arrays(x=x)
     uniques = df.x.unique(dropnan=True).tolist()
     assert set(uniques) == set(['', 'A', 'B', -1, 0, 2, None])
+
+
+def test_unique_string_missing():
+    x = ['John', None, 'Sally', None, '0.0']
+    df = vaex.from_arrays(x=x)
+    result = df.x.unique().to_pylist()
+
+    assert len(result) == 4
+    assert'John' in result
+    assert None in result
+    assert 'Sally'


### PR DESCRIPTION
This addresses  an issue of `.unique` when applied on a string column that has missing value.

I am not completely sure, but fixing this might fix #879 

Checklist
- [x] Make test
- [ ] Make em pass