### PR TITLE
feat(core): dispatch compute on arrow arrays to numpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,6 @@ catboost_info/
 .vscode
 
 # symlinks generated in setup.py
-packages/vaex-core/vaex/arrow
 packages/vaex-core/vaex/astro
 packages/vaex-core/vaex/distributed
 packages/vaex-core/vaex/graphql

--- a/packages/vaex-core/vaex/arrow/numpy_dispatch.py
+++ b/packages/vaex-core/vaex/arrow/numpy_dispatch.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pyarrow as pa
+import vaex
+from ..expression import _binary_ops, _unary_ops, reversable
+
+class NumpyDispatch:
+    def __init__(self, arrow_array):
+        self.arrow_array = arrow_array
+        self._numpy_array = None
+
+    @property
+    def numpy_array(self):
+        # convert lazily, since not all arrow arrays (e.g. lists) can be converted
+        if self._numpy_array is None:
+            self._numpy_array = vaex.array_types.to_numpy(self.arrow_array)
+        return self._numpy_array
+
+
+for op in _binary_ops:
+    def closure(op=op):
+        def operator(a, b):
+            if isinstance(a, NumpyDispatch):
+                a = a.numpy_array
+            if isinstance(b, NumpyDispatch):
+                b = b.numpy_array
+            return NumpyDispatch(pa.array(op['op'](a, b)))
+        return operator
+    method_name = '__%s__' % op['name']
+    setattr(NumpyDispatch, method_name, closure())
+    # to support e.g. (1 + ...)
+    if op['name'] in reversable:
+        def closure(op=op):
+            def operator(b, a):
+                return NumpyDispatch(pa.array(op['op'](a, b.numpy_array)))
+            return operator
+        method_name = '__r%s__' % op['name']
+        setattr(NumpyDispatch, method_name, closure())
+
+
+for op in _unary_ops:
+    def closure(op=op):
+        def operator(a):
+            a = a.numpy_array
+            return NumpyDispatch(pa.array(op['op'](a)))
+        return operator
+    method_name = '__%s__' % op['name']
+    setattr(NumpyDispatch, method_name, closure())
+
+
+
+def unwrap(value):
+    if isinstance(value, NumpyDispatch):
+        # import pdb
+        # pdb.set_trace()
+        return value.arrow_array
+    # for performance reasons we don't visit lists and dicts
+    return value
+
+
+def autowrapper(f):
+    '''Takes a function f, and will unwrap all its arguments and wrap the return value'''
+    def wrapper(*args, **kwargs):
+        args = map(unwrap, args)
+        kwargs = {k: unwrap(v) for k, v, in kwargs.items()}
+        result = f(*args, **kwargs)
+        if isinstance(result, vaex.array_types.supported_arrow_array_types):
+            result = NumpyDispatch(result)
+        return result
+    return wrapper

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -180,6 +180,7 @@ class TaskPartStatistic:
 
         masks = [np.ma.getmaskarray(block) for block in blocks if np.ma.isMaskedArray(block)]
         blocks = [block.data if np.ma.isMaskedArray(block) else block for block in blocks]
+        blocks = [np.asarray(k) for k in blocks]
         mask = None
 
         # blocks = [as_flat_float(block) for block in blocks]
@@ -356,6 +357,8 @@ class TaskPartAggregations:
                 selection_mask = None
                 if selection:
                     selection_mask = self.df.evaluate_selection_mask(selection, i1=i1, i2=i2, cache=True)  # TODO
+                    # TODO: we probably want a way to avoid a to numpy conversion?
+                    selection_mask = np.asarray(selection_mask)
                     references.append(selection_mask)
                     # some aggregators make a distiction between missing value and no value
                     # like nunique, they need to know if they should take the value into account or not
@@ -408,6 +411,7 @@ class TaskPartAggregations:
             result = np.asarray(grids) if selection_waslist else grids[0]
             if agg_desc.dtype_out != str:
                 dtype_out = vaex.utils.to_native_dtype(agg_desc.dtype_out)
+                dtype_out = vaex.array_types.to_numpy_type(dtype_out)
                 result = result.view(dtype_out)
             result = result.copy()
             results.append(result)

--- a/packages/vaex-core/vaex/encoding.py
+++ b/packages/vaex-core/vaex/encoding.py
@@ -162,6 +162,9 @@ class dtype_encoding:
             return pa.string()
         if type_spec == 'large_string':
             return pa.large_string()
+        # TODO: find a proper way to support all arrow types
+        if type_spec == 'timestamp[ms]':
+            return pa.timestamp('ms')
         else:
             return np.dtype(type_spec)
 

--- a/packages/vaex-core/vaex/export.py
+++ b/packages/vaex-core/vaex/export.py
@@ -165,7 +165,7 @@ def _export_column(dataset_input, dataset_output, column_name, shuffle, sort, se
         if 1:
             block_scope = dataset_input._block_scope(0, vaex.execution.buffer_size_default)
             to_array = dataset_output.columns[column_name]
-            dtype = dataset_input.data_type(column_name)
+            dtype = dataset_input.data_type(column_name, array_type='numpy')
             is_string = vaex.array_types.is_string_type(dtype)
             if is_string:
                 assert isinstance(to_array, pa.Array)  # we don't support chunked arrays here
@@ -189,7 +189,7 @@ def _export_column(dataset_input, dataset_output, column_name, shuffle, sort, se
 
             for i1, i2 in vaex.utils.subdivide(count, max_length=max_length):
                 logger.debug("from %d to %d (total length: %d, output length: %d)", i1, i2, len(dataset_input), N)
-                values = dataset_input.evaluate(column_name, i1=i1, i2=i2, filtered=True, parallel=False, selection=selection)
+                values = dataset_input.evaluate(column_name, i1=i1, i2=i2, filtered=True, parallel=False, selection=selection, array_type='numpy')
                 no_values = len(values)
                 if no_values:
                     if is_string:

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -1082,7 +1082,7 @@ class FunctionSerializableJit(FunctionSerializable):
         # TODO: can we do the above using the Expressio API?s
 
         arguments = list(set(names))
-        argument_dtypes = [df.data_type(argument) for argument in arguments]
+        argument_dtypes = [df.data_type(argument, array_type='numpy') for argument in arguments]
         return_dtype = df[expression].dtype
         return cls(str(expression), arguments, argument_dtypes, return_dtype, verbose, compile=compile)
 
@@ -1133,6 +1133,7 @@ def f({0}):
         exec(code, scope)
         func = scope['f']
         def wrapper(*args):
+            args = [vaex.array_types.to_numpy(k) for k in args]
             args = [vaex.utils.to_native_array(arg) if isinstance(arg, np.ndarray) else arg for arg in args]
             args = [cupy.asarray(arg) if isinstance(arg, np.ndarray) else arg for arg in args]
             return cupy.asnumpy(func(*args))

--- a/packages/vaex-core/vaex/formatting.py
+++ b/packages/vaex-core/vaex/formatting.py
@@ -2,6 +2,7 @@ import numpy as np
 import numbers
 import six
 import datetime
+import pyarrow as pa
 
 
 MAX_LENGTH = 50
@@ -10,6 +11,12 @@ MAX_LENGTH = 50
 def _format_value(value):
     if isinstance(value, six.string_types):
         value = str(value)
+    elif isinstance(value, pa.lib.Scalar):
+        value = value.as_py()
+        if value is None:
+            value = '--'
+        else:
+            value = repr(value)
     elif isinstance(value, bytes):
         value = repr(value)
     elif isinstance(value, np.ma.core.MaskedConstant):

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -6,10 +6,12 @@ import pyarrow.compute as pc
 from vaex import column
 from vaex.column import _to_string_sequence, _to_string_column, _to_string_list_sequence, _is_stringy
 from vaex.dataframe import docsubst
+import vaex.arrow.numpy_dispatch
 import re
 import vaex.expression
 import functools
 import six
+
 
 # @vaex.serialize.register_function
 # class Function(FunctionSerializable):
@@ -76,6 +78,7 @@ def register_function(scope=None, as_property=False, name=None, on_expression=Tr
             def closure(name=name, full_name=full_name, function=f):
                 def wrapper(self, *args, **kwargs):
                     lazy_func = getattr(self.df.func, full_name)
+                    lazy_func = vaex.arrow.numpy_dispatch.autowrapper(lazy_func)
                     return lazy_func(*args, **kwargs)
                 return functools.wraps(function)(wrapper)
             if as_property:
@@ -88,6 +91,7 @@ def register_function(scope=None, as_property=False, name=None, on_expression=Tr
                     def closure(name=name, full_name=full_name, function=f):
                         def wrapper(self, *args, **kwargs):
                             lazy_func = getattr(self.expression.ds.func, full_name)
+                            lazy_func = vaex.arrow.numpy_dispatch.autowrapper(lazy_func)
                             args = (self.expression, ) + args
                             return lazy_func(*args, **kwargs)
                         return functools.wraps(function)(wrapper)
@@ -99,11 +103,12 @@ def register_function(scope=None, as_property=False, name=None, on_expression=Tr
                     def closure(name=name, full_name=full_name, function=f):
                         def wrapper(self, *args, **kwargs):
                             lazy_func = getattr(self.ds.func, full_name)
+                            lazy_func = vaex.arrow.numpy_dispatch.autowrapper(lazy_func)
                             args = (self, ) + args
                             return lazy_func(*args, **kwargs)
                         return functools.wraps(function)(wrapper)
                     setattr(vaex.expression.Expression, name, closure())
-        vaex.expression.expression_namespace[prefix + name] = f
+        vaex.expression.expression_namespace[prefix + name] = vaex.arrow.numpy_dispatch.autowrapper(f)
         return f  # we leave the original function as is
     return wrapper
 

--- a/packages/vaex-core/vaex/selections.py
+++ b/packages/vaex-core/vaex/selections.py
@@ -132,7 +132,7 @@ class SelectionExpression(Selection):
             N = i2 - i1
             current_mask = np.full(N, result)
         else:
-            current_mask = result.astype(np.bool)
+            current_mask = result #.astype(np.bool)
         if previous_mask is None:
             logger.debug("setting mask")
             mask = current_mask
@@ -184,6 +184,9 @@ class SelectionLasso(Selection):
         radius = np.sqrt((meanx - x)**2 + (meany - y)**2).max()
         blockx = df._evaluate(self.boolean_expression_x, i1=i1, i2=i2, filter_mask=filter_mask)
         blocky = df._evaluate(self.boolean_expression_y, i1=i1, i2=i2, filter_mask=filter_mask)
+        # TODO: can we do without arrow->numpy conversion?
+        blockx = vaex.array_types.to_numpy(blockx)
+        blocky = vaex.array_types.to_numpy(blocky)
         (blockx, blocky), excluding_mask = _split_and_combine_mask([blockx, blocky])
         blockx = as_flat_float(blockx)
         blocky = as_flat_float(blocky)

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -16,6 +16,7 @@ import numbers
 import keyword
 
 import numpy as np
+import pyarrow as pa
 import progressbar
 import psutil
 import six
@@ -726,7 +727,7 @@ def _issequence(x):
 
 
 def _isnumber(x):
-    return isinstance(x, numbers.Number)
+    return isinstance(x, (numbers.Number, pa.Scalar))
 
 
 def _is_limit(x):
@@ -860,6 +861,8 @@ def find_type_from_dtype(namespace, prefix, dtype, transient=True):
         else:
             postfix = 'string' # view not support atm
     else:
+        import vaex
+        dtype = vaex.array_types.to_numpy_type(dtype)
         postfix = str(dtype)
         if postfix == '>f8':
             postfix = 'float64'
@@ -878,7 +881,7 @@ def find_type_from_dtype(namespace, prefix, dtype, transient=True):
 
 
 def to_native_dtype(dtype):
-    if dtype.byteorder not in "<=|":
+    if isinstance(dtype, np.dtype) and dtype.byteorder not in "<=|":
         return dtype.newbyteorder()
     else:
         return dtype
@@ -904,14 +907,18 @@ def unmask_selection_mask(selection_mask):
 
 
 def upcast(dtype):
-    if dtype.kind == "b":
-        return np.dtype('int64')
-    if dtype.kind == "i":
-        return np.dtype('int64')
-    if dtype.kind == "u":
-        return np.dtype('uint64')
-    if dtype.kind == "f":
-        return np.dtype('float64')
+    if isinstance(dtype, np.dtype):
+        if dtype.kind == "b":
+            return np.dtype('int64')
+        if dtype.kind == "i":
+            return np.dtype('int64')
+        if dtype.kind == "u":
+            return np.dtype('uint64')
+        if dtype.kind == "f":
+            return np.dtype('float64')
+    else:
+        # TODO: arrow
+        pass
     return dtype
 
 

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -147,7 +147,7 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
                 sparse_groups[id(sparse_matrix)].append(column_name)
                 sparse_matrices[id(sparse_matrix)] = sparse_matrix
                 continue
-            dtype = dataset.data_type(column_name)
+            dtype = dataset.data_type(column_name, array_type='numpy')
             shape = (N, ) + dataset._shape_of(column_name)[1:]
             h5column_output = h5columns_output.require_group(column_name)
             if vaex.array_types.is_string_type(dtype):

--- a/tests/arrow/compute_test.py
+++ b/tests/arrow/compute_test.py
@@ -1,9 +1,18 @@
+import pytest
+import vaex
+import pyarrow as pa
 
-def test_mul(df_trimmed):
+@pytest.mark.parametrize('op', vaex.expression._binary_ops)
+def test_binary_ops(df_trimmed, op):
+    if op['name'] in ['contains', 'and', 'xor', 'or', 'is', 'is_not', 'matmul']:
+        return
+    
+    operator = op['op']
     df = df_trimmed
-    x = df.x.values
-    y = df.y.values
-    df['x'] = df.x.as_arrow()
-    df['y'] = df.y.as_arrow()
-    df['p'] = df.x.as_numpy() * df.y.as_numpy()
-    assert df.p.tolist() == (x * y).tolist()
+    x = df.x.astype(pa.int32()).to_numpy()
+    y = df.y.astype(pa.int64()).to_numpy()
+    df['x'] = df.x.astype(pa.int32()).as_arrow()
+    df['y'] = df.y.astype(pa.int64()).as_arrow()
+    df['pa'] = operator(df.x, 1 + df.y)
+    assert df.pa.tolist() == operator(x, 1 + y).tolist()
+    assert df.pa.values.to_pylist() == operator(x, 1 + y).tolist()

--- a/tests/astype_test.py
+++ b/tests/astype_test.py
@@ -9,7 +9,7 @@ def test_astype(ds_local):
     ds['x'] = ds['x'].astype('f4')
 
     assert ds.x.evaluate().dtype == np.float32
-    assert ds.x.tolist() == ds_original.x.evaluate().astype(np.float32).tolist()
+    assert ds.x.tolist() == ds_original.x.as_numpy().evaluate().astype(np.float32).tolist()
 
 
 def test_astype_str():

--- a/tests/common.py
+++ b/tests/common.py
@@ -221,7 +221,7 @@ def df_arrow(df_arrow_cache):
 @pytest.fixture
 def df_arrow_cache(df_arrow_raw):
     # we add the filter and virtual columns again to avoid the expression rewriting
-    df = df_arrow_raw.as_numpy().drop_filter()
+    df = df_arrow_raw.drop_filter()
     del df['z']
     df.select('(x >= 0) & (x < 10)', name=vaex.dataframe.FILTER_SELECTION_NAME)
     df.add_virtual_column("z", "x+t*y")
@@ -233,7 +233,9 @@ def df_arrow_raw(df_filtered):
     df = df_filtered.copy()
     df.drop('obj', inplace=True)
     df.drop('timedelta', inplace=True)
-    df.columns = {k: vaex.array_types.to_arrow(v, convert_to_native=True) for k, v in df.columns.items()}
+    columns = {k: vaex.array_types.to_arrow(v, convert_to_native=True) for k, v in df.columns.items()}
+    dataset = vaex.dataset.DatasetArrays(columns)
+    df.dataset = dataset
     return df
 
 

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -7,7 +7,7 @@ def test_dtype_basics(df):
         if df.is_string(name):
             assert df[name].to_numpy().dtype.kind in 'OSU'
         else:
-            assert df[name].values.dtype == df.data_type(df[name])
+            assert vaex.array_types.same_type(vaex.array_types.data_type(df[name].values), df.data_type(df[name]))
 
 
 def test_dtypes(df_local):

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -8,7 +8,7 @@ def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
     df = df_local
     x = df.x.to_numpy()
     total = 0
-    for i1, i2, chunk in df_local.evaluate_iterator('x', chunk_size=chunk_size, prefetch=prefetch, parallel=parallel):
+    for i1, i2, chunk in df_local.evaluate_iterator('x', chunk_size=chunk_size, prefetch=prefetch, parallel=parallel, array_type='numpy'):
         assert x[i1:i2].tolist() == chunk.tolist()
         total += chunk.sum()
     assert total == x.sum()
@@ -16,7 +16,7 @@ def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
 
 @pytest.mark.parametrize("chunk_size", [2, 5])
 @pytest.mark.parametrize("parallel", [True, False])
-@pytest.mark.parametrize("array_type", [None, 'list', 'xarray'])
+@pytest.mark.parametrize("array_type", ['numpy', 'list', 'xarray'])
 def test_to_items(df_local, chunk_size, parallel, array_type):
     df = df_local
     x = df.x.to_numpy()
@@ -29,7 +29,7 @@ def test_to_items(df_local, chunk_size, parallel, array_type):
 
 @pytest.mark.parametrize("chunk_size", [2, 5])
 @pytest.mark.parametrize("parallel", [True, False])
-@pytest.mark.parametrize("array_type", [None, 'list', 'xarray'])
+@pytest.mark.parametrize("array_type", ['numpy', 'list', 'xarray'])
 def test_to_dict(df_local, chunk_size, parallel, array_type):
     df = df_local
     x = df.x.to_numpy()
@@ -42,7 +42,7 @@ def test_to_dict(df_local, chunk_size, parallel, array_type):
 
 @pytest.mark.parametrize("chunk_size", [2, 5])
 @pytest.mark.parametrize("parallel", [True, False])
-@pytest.mark.parametrize("array_type", [None, 'list', 'xarray'])
+@pytest.mark.parametrize("array_type", ['numpy', 'list', 'xarray'])
 def test_to_arrays(df_local, chunk_size, parallel, array_type):
     df = df_local
     x = df.x.to_numpy()

--- a/tests/materialize_test.py
+++ b/tests/materialize_test.py
@@ -10,5 +10,5 @@ def test_materialize(ds_local):
     assert 'r' not in ds.virtual_columns
     assert 'r' in ds.columns
     assert hasattr(ds, 'r')
-    assert ds.r.evaluate().tolist() == np.sqrt(ds.x.evaluate()**2 + ds.y.evaluate()**2).tolist()
+    assert ds.r.evaluate().tolist() == np.sqrt(ds.x.to_numpy()**2 + ds.y.to_numpy()**2).tolist()
 

--- a/tests/rename_test.py
+++ b/tests/rename_test.py
@@ -23,7 +23,7 @@ def test_rename_existing_expression(df_local):
 
 def test_reassign_virtual(ds_local):
     df = ds_local
-    x = df.x.values
+    x = df.x.to_numpy()
     df['r'] = df.x+1
     assert df.r.tolist() == (x+1).tolist()
     df['r'] = df.r+1
@@ -32,7 +32,7 @@ def test_reassign_virtual(ds_local):
 
 def test_reassign_column(ds_filtered):
     df = ds_filtered.extract()
-    x = df.x.values
+    x = df.x.to_numpy()
     df['r'] = (df.x+1).evaluate()
     df['r'] = (df.r+1).evaluate()
     assert df.r.tolist() == (x+2).tolist()

--- a/tests/values_test.py
+++ b/tests/values_test.py
@@ -9,7 +9,7 @@ def test_values(ds_local):
     assert ds['name'].tolist() == ds.evaluate('name', array_type='arrow').to_pylist()
     if 'obj' in ds:   # df_arrow does not have it
         assert ds['obj'].tolist() == ds.evaluate('obj').tolist()
-    assert ds[['x', 'y']].values.tolist() == np.array([ds.evaluate('x'), ds.evaluate('y')]).T.tolist()
+    assert ds[['x', 'y']].values.tolist() == np.array([ds.x.to_numpy(), ds.y.to_numpy()]).T.tolist()
     assert ds[['x', 'y']].values.shape == (len(ds), 2)
     assert ds[['m']].values[9].tolist()[0] == None
     assert ds[['m', 'x']].values[9].tolist()[0] == None


### PR DESCRIPTION
A proof of concept that we can wrap Arrow arrays to dispatch calculations to Numpy.
The main point of this is that we can work towards running the full test suite in an
Arrow backed dataframe. We can gradually remove them over time when Arrow gets more
compute kernels.
