### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/examples/vaexclient.py
+++ b/examples/vaexclient.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'breddels'
 import vaex as vx
 import numpy as np
@@ -8,9 +9,9 @@ server = vx.server("localhost")
 
 
 list = server.list_datasets()
-print list
+print(list)
 ds = server.open(list[0])
-print "length", len(ds)
+print("length", len(ds))
 subspace = ds("x", "y")
 limits = subspace.limits_sigma(sigmas=3, square=True)
 
@@ -18,12 +19,12 @@ ds.select("z>50")
 selected = subspace.selected()
 
 
-print subspace.mean()
-print subspace.var()
-print subspace.limits_sigma()
-print subspace.limits_sigma(sigmas=1)
+print(subspace.mean())
+print(subspace.var())
+print(subspace.limits_sigma())
+print(subspace.limits_sigma(sigmas=1))
 #limits = subspace.minmax()
-print "square limits", limits
+print("square limits", limits)
 grid = subspace.histogram(limits=limits)
 grid_selected = selected.histogram(limits=limits)
 subspace.plot(np.log(grid), limits=limits)
@@ -34,25 +35,25 @@ pylab.contour(np.log(grid_selected), 2, linewidth="2pt", colors="blue", extent=l
 pylab.show()
 
 
-print "datasets", list
-dsa
+print("datasets", list)
+# dsa
 dataset = None
 import traceback
 
 def printminmax(args):
 	subspace, limits = args
-	print "minmax for", subspace, limits
+	print("minmax for", subspace, limits)
 	return subspace, limits
 
 def getminmax__(dataset):
 	dataset("x", "y").minmax()
-	print "get min max for", dataset
+	print("get min max for", dataset)
 	#try:
 	if 1:
 		subspace = dataset("x", "y")
-		print "subspace", subspace
+		print("subspace", subspace)
 		promise = subspace.minmax()
-		print "promise", promise
+		print("promise", promise)
 		#promise.then(printminmax, on_error)
 		return promise
 	#except Exception, e:
@@ -63,26 +64,26 @@ def list_datasets(result):
 	global dataset
 	import json
 	list = json.loads(result.body)
-	print "list datasets", list
+	print("list datasets", list)
 	opened = server.open(list[5])
 	def plot(args):
 		subspace, limits, size, data = args
-		print "plot"
+		print("plot")
 		#pylab.imshow(log(data))
 		pylab.figure()
-		print data.max(), data.sum()
+		print(data.max(), data.sum())
 		subspace.plot(np.log(data), limits=limits)
 		pylab.show()
 		#subspace.plot()
 	def histogram(args):
 		subspace, limits = args
-		print subspace
+		print(subspace)
 		return subspace.histogram(limits=limits, size=256).then(plot)
 	opened.then(lambda dataset: dataset("x", "y").minmax()).then(printminmax, on_error).then(histogram).then(None, on_error)
 
 
 def on_error(exception=None):
-	print "error", exception
+	print("error", exception)
 	traceback.print_exc()
 
 end = server.list_datasets().then(list_datasets, on_error)


### PR DESCRIPTION
@maartenbreddels Your review, please.

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.