### PR TITLE
Feat: stream hdf5 files directly from GCS

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -174,6 +174,8 @@ def open(path, convert=False, shuffle=False, copy_index=False, *args, **kwargs):
                 # TODO: can we do glob with s3?
                 if path.startswith('s3://'):
                     filenames.append(path)
+                elif path.startswith('gs://'):
+                    filenames.append(path)
                 else:
                     # sort to get predictable behaviour (useful for testing)
                     filenames.extend(list(sorted(glob.glob(path))))
@@ -202,8 +204,6 @@ def open(path, convert=False, shuffle=False, copy_index=False, *args, **kwargs):
                 if ds is None:
                     if os.path.exists(path):
                         raise IOError('Could not open file: {}, did you install vaex-hdf5? Is the format supported?'.format(path))
-                    if os.path.exists(path):
-                        raise IOError('Could not open file: {}, it does not exist?'.format(path))
             elif len(filenames) > 1:
                 if convert not in [True, False]:
                     filename_hdf5 = convert

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -125,7 +125,7 @@ def open(path, convert=False, shuffle=False, copy_index=False, *args, **kwargs):
 
     S3 support:
 
-    Vaex supports streaming in hdf5 files from Amazon AWS object storage S3.
+    Vaex supports streaming of hdf5 files from Amazon AWS object storage S3.
     Files are by default cached in $HOME/.vaex/file-cache/s3 such that successive access
     is as fast as native disk access. The following url parameters control S3 options:
 
@@ -141,6 +141,18 @@ def open(path, convert=False, shuffle=False, copy_index=False, *args, **kwargs):
     >>> df = vaex.open('s3://vaex/taxi/yellow_taxi_2015_f32s.hdf5', anon=True)  # Note that anon is a boolean, not the string 'true'
     >>> df = vaex.open('s3://mybucket/path/to/file.hdf5?profile_name=myprofile')
 
+    GCS support:
+    Vaex supports streaming of hdf5 files from Google Cloud Storage.
+    Files are by default cached in $HOME/.vaex/file-cache/gs such that successive access
+    is as fast as native disk access. The following url parameters control GCS options:
+     * token: Authentication method for GCP. Use 'anon' for annonymous access. See https://gcsfs.readthedocs.io/en/latest/index.html#credentials for more details.
+     * use_cache: Use the disk cache or not, only set to false if the data should be accessed once. (Allowed values are: true,True,1,false,False,0).
+     * project and other arguments are passed to :py:class:`gcsfs.core.GCSFileSystem`
+
+    Examples:
+
+    >>> df = vaex.open('gs://vaex-data/airlines/us_airline_data_1988_2019.hdf5?token=anon')
+    >>> df = vaex.open('gs://vaex-data/testing/xys.hdf5?token=anon&cache=False')
     """
     import vaex
     try:

--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -48,5 +48,7 @@ def dup(file):
         return file.dup()
     elif vaex.file.s3.s3fs is not None and isinstance(file, vaex.file.s3.s3fs.core.S3File):
         return vaex.file.s3.dup(file)
+    elif vaex.file.gcs.gcsfs is not None and isinstance(file, vaex.file.gcs.gcsfs.core.GCSFile):
+        return vaex.file.gcs.dup(file)
     else:
         return normal_open(file.name, file.mode)

--- a/packages/vaex-core/vaex/file/gcs.py
+++ b/packages/vaex-core/vaex/file/gcs.py
@@ -1,0 +1,48 @@
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
+
+try:
+    import gcsfs
+except Exception as e:
+    import_exception = e
+    gcsfs = None
+
+import vaex.file.cache
+
+
+normal_open = open
+
+
+def is_gs_path(path):
+    return path.startswith('gs://')
+
+
+def dup(f):
+    return f.gcsfs.open(f.path, f.mode)
+
+
+def open(path, mode='rb', **kwargs):
+    if not is_gs_path(path):
+        return normal_open(path, mode)
+    if gcsfs is None:
+        raise import_exception
+    o = urlparse(path)
+    assert o.scheme == 'gs'
+    naked_path = path
+    if '?' in naked_path:
+        naked_path = naked_path[:naked_path.index('?')]
+    # only use the first item
+    options = {key: values[0] for key, values in parse_qs(o.query).items()}
+    options.update(kwargs)
+    use_cache = options.get('cache', 'true') in ['true', 'True', '1']
+    if 'cache' in options:
+        del options['cache']
+    fs = gcsfs.GCSFileSystem(**options)
+    if use_cache:
+        fp = lambda: fs.open(naked_path, mode)
+        fp = vaex.file.cache.CachedFile(fp, naked_path)
+    else:
+        fp = fs.open(naked_path, mode)
+    return fp

--- a/packages/vaex-hdf5/setup.py
+++ b/packages/vaex-hdf5/setup.py
@@ -13,7 +13,7 @@ author_email = "maartenbreddels@gmail.com"
 license = 'MIT'
 version = version.__version__
 url = 'https://www.github.com/maartenbreddels/vaex'
-install_requires_hdf5 = ["vaex-core>=2.0.2,<3", "h5py>=2.9", "s3fs<0.3"]
+install_requires_hdf5 = ["vaex-core>=2.0.2,<3", "h5py>=2.9", "s3fs<0.3", "gcsfs>=0.6.2"]
 
 setup(name=name + '-hdf5',
       version=version,

--- a/tests/gcs_test.py
+++ b/tests/gcs_test.py
@@ -1,0 +1,23 @@
+import vaex
+import pytest
+
+
+@pytest.mark.skipif(vaex.utils.devmode, reason='runs too slow when developing')
+def test_s3():
+    df = vaex.open('gs://vaex-data/testing/xys.hdf5?cache=false&token=anon')
+    assert df.x.tolist() == [1, 2]
+    assert df.y.tolist() == [3, 4]
+    assert df.s.tolist() == ['5', '6']
+
+    df = vaex.open('gs://vaex-data/testing/xys.hdf5?cache=true&token=anon')
+    assert df.x.tolist() == [1, 2]
+    assert df.y.tolist() == [3, 4]
+    assert df.s.tolist() == ['5', '6']
+
+
+@pytest.mark.skipif(vaex.utils.devmode, reason='runs too slow when developing')
+def test_s3_masked():
+    df = vaex.open('gs://vaex-data/testing/xys-masked.hdf5?cache=false&token=anon')
+    assert df.x.tolist() == [1, None]
+    assert df.y.tolist() == [None, 4]
+    assert df.s.tolist() == ['5', None]

--- a/tests/gcs_test.py
+++ b/tests/gcs_test.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.skipif(vaex.utils.devmode, reason='runs too slow when developing')
-def test_s3():
+def test_gcs():
     df = vaex.open('gs://vaex-data/testing/xys.hdf5?cache=false&token=anon')
     assert df.x.tolist() == [1, 2]
     assert df.y.tolist() == [3, 4]
@@ -16,7 +16,7 @@ def test_s3():
 
 
 @pytest.mark.skipif(vaex.utils.devmode, reason='runs too slow when developing')
-def test_s3_masked():
+def test_gcs_masked():
     df = vaex.open('gs://vaex-data/testing/xys-masked.hdf5?cache=false&token=anon')
     assert df.x.tolist() == [1, None]
     assert df.y.tolist() == [None, 4]


### PR DESCRIPTION
This PR enables the streaming of HDF5 files directly from Google cloud storage. 
Vaex could already do this from S3, now we bring support for GCS as well. 

The usage is the same:
```
import vaex
df = vaex.open('gs://vaex-data/testing/xys.hdf5?cache=false&token=anon')
```

Note the slight differences compared to reading from S3. For reading data from GCP we are currently using `gcsfs` so the url parameters should be compatible with `gcsfs.GCSFileSystem`