### PR TITLE
Fix: value counts on added/concatenated strings

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: packages/vaex-core/build
-        key: ${{ runner.OS }}-${{ matrix.python-version }}-${{ hashFiles('packages/vaex-core/src/*') }}-v1
+        key: ${{ runner.OS }}-${{ matrix.python-version }}-${{ hashFiles('packages/vaex-core/src/*') }}-v2
     - name: Fix cache timestamp
       if: steps.cache-compiled-binaries.outputs.cache-hit == 'true' && matrix.os != 'windows-latest'
       shell: bash

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -599,7 +599,7 @@ class Expression(with_metaclass(Meta)):
         :returns: Pandas series containing the counts
         """
         from pandas import Series
-        dtype = self.dtype
+        data_type = self.data_type()
 
         transient = self.transient or self.ds.filtered or self.ds.is_masked(self.expression)
         if self.is_string() and not transient:
@@ -608,12 +608,12 @@ class Expression(with_metaclass(Meta)):
             if not isinstance(ar, ColumnString):
                 transient = True
 
-        counter_type = counter_type_from_dtype(self.dtype, transient)
+        counter_type = counter_type_from_dtype(data_type, transient)
         counters = [None] * self.ds.executor.thread_pool.nthreads
         def map(thread_index, i1, i2, ar):
             if counters[thread_index] is None:
                 counters[thread_index] = counter_type()
-            if vaex.array_types.is_string_type(dtype):
+            if vaex.array_types.is_string_type(data_type):
                 previous_ar = ar
                 ar = _to_string_sequence(ar)
                 if not transient:

--- a/packages/vaex-core/vaex/hash.py
+++ b/packages/vaex-core/vaex/hash.py
@@ -19,6 +19,8 @@ def counter_type_from_dtype(dtype, transient=True):
         postfix = str(dtype)
         if postfix == '>f8':
             postfix = 'float64'
+        if postfix == 'double':  # arrow
+            postfix = 'float64'
     name = 'counter_' + postfix
     return globals()[name]
 

--- a/tests/value_counts_test.py
+++ b/tests/value_counts_test.py
@@ -102,3 +102,14 @@ def test_value_counts_masked_str():
     assert value_counts['A'] == 2
     assert value_counts['B'] == 1
     assert value_counts[''] == 2
+
+
+def test_value_counts_add_strings():
+    x = ['car', 'car', 'boat']
+    y = ['red', 'red', 'blue']
+    df = vaex.from_arrays(x=x, y=y)
+    df['z'] = df.x + '-' + df.y
+
+    value_counts = df.z.value_counts()
+    assert list(value_counts.index) == ['car-red', 'boat-blue']
+    assert value_counts.values.tolist() == [2, 1]


### PR DESCRIPTION
This PR handles the issue of doing value counts on a virtual column which is created by adding or concatenating strings.

 - [x] Reproducing via a unit-test
 - [ ] Make test pass