### PR TITLE
[Feat]: shift column

### DIFF
--- a/tests/shift_test.py
+++ b/tests/shift_test.py
@@ -1,0 +1,40 @@
+import vaex
+
+
+def test_shift():
+    df = vaex.from_dict({'x': [0, 1, 2, 3, 4],
+                         'y': [0.1, 10.2, 20.3, 30.4, 40.5],
+                         'z': ['aa', 'bb', 'cc', 'dd', 'ee']})
+    df['r'] = df.x + df.y
+
+    df_shifted = df.shift(columns=['r', 'x', 'z'], periods=-3, cyclic=False)
+    assert df_shifted.column_count() == 3
+    assert df_shifted.x.tolist() == [3, 4, None, None, None]
+    assert df_shifted.r.tolist() == [33.4, 44.5, None, None, None]
+    assert df_shifted.z.tolist() == ['dd', 'ee', None, None, None]
+
+    # Same as above but specify fill_value
+    df_shifted = df.shift(columns=['r', 'x', 'z'], periods=-3, cyclic=False, fill_value='15')
+    assert df_shifted.column_count() == 3
+    assert df_shifted.x.tolist() == [3, 4, 15, 15, 15]
+    assert df_shifted.r.tolist() == [33.4, 44.5, 15, 15, 15]
+    assert df_shifted.z.tolist() == ['dd', 'ee', '15', '15', '15']
+
+    # NOTE: This block fails most likely due to a concat issue
+    df_shifted = df.shift(columns=['r', 'x', 'z'], periods=3, cyclic=False)
+    assert df_shifted.column_count() == 3
+    assert df_shifted.x.tolist() == [None, None, None, 0, 1]
+    assert df_shifted.r.tolist() == [None, None, None, 0.1, 11.2]
+    assert df_shifted.z.tolist() == [None, None, None, 'aa', 'bb']
+
+    df_shifted = df.shift(columns=['r', 'x', 'z'], periods=-3, cyclic=True)
+    assert df_shifted.column_count() == 3
+    assert df_shifted.x.tolist() == [3, 4, 0, 1, 2]
+    assert df_shifted.r.tolist() == [33.4, 44.5, 0.1, 11.2, 22.3]
+    assert df_shifted.z.tolist() == ['dd', 'ee', 'aa', 'bb', 'cc']
+
+    df_shifted = df.shift(columns=['r', 'x', 'z'], periods=3, cyclic=True)
+    assert df_shifted.column_count() == 3
+    assert df_shifted.x.tolist() == [2, 3, 4, 0, 1]
+    assert df_shifted.r.tolist() == [22.3, 33.4, 44.5, 0.1, 11.2]
+    assert df_shifted.z.tolist() == ['cc', 'dd', 'ee', 'aa', 'bb']


### PR DESCRIPTION
This is an attempt at implementing `df.shift(...)`.  Currently, the methods shifts columns by a specified number of rows.

Some notes:
 - currently the test fails when a virtual column is shifted by a positive number of periods. It is most likely a concat related issue.
 - Ideally we should like to support shifting by a period related to a datetime column by a given frequency (as in pandas), thus being able to shift for a day/month/minute etc...
 - We need to think on how to add this to the state (or what the state will become in the future). Maybe this is not needed, but perhaps a discussion would be useful.