### PR TITLE
Feat(ml): Support for `predict_proba` and `predict_log_proba` for sklearn classifiers

### DIFF
--- a/docs/source/example_ml_iris.ipynb
+++ b/docs/source/example_ml_iris.ipynb
@@ -338,10 +338,10 @@
     "                                          random_state=42)\n",
     "\n",
     "# Make it a vaex transformer (for the automagic pipeline and lazy predictions)\n",
-    "model = vaex.ml.sklearn.SKLearnPredictor(features=train_features, \n",
-    "                                         target=target,\n",
-    "                                         model=booster, \n",
-    "                                         prediction_name='prediction')\n",
+    "model = vaex.ml.sklearn.Predictor(features=train_features, \n",
+    "                                  target=target,\n",
+    "                                  model=booster, \n",
+    "                                  prediction_name='prediction')\n",
     "\n",
     "# Train and predict\n",
     "model.fit(df=df_train)\n",
@@ -523,7 +523,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -56,10 +56,21 @@ class Predictor(state.HasState):
     features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
     target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
     prediction_name = traitlets.Unicode(default_value='prediction', help='The name of the virtual column housing the predictions.')
+    prediction_type = traitlets.Enum(values=['predict', 'predict_proba', 'predict_log_proba'], default_value='predict',
+                                     help='Which method to use to get the predictions. \
+                                     Can be "predict", "predict_proba" or "predict_log_proba".')
+
+    # if not hasattr(model, prediction_type):
+    #     raise AttributeError(f'The specified sklearn model does not have a {prediction_type} attribute')
 
     def __call__(self, *args):
         X = np.vstack([arg.astype(np.float64) for arg in args]).T.copy()
-        return self.model.predict(X)
+        if self.prediction_type == 'predict':
+            return self.model.predict(X)
+        elif self.prediction_type == 'predict_proba':
+            return self.model.predict_proba(X)
+        else:
+            return self.model.predict_log_proba(X)
 
     def predict(self, df):
         '''Get an in-memory numpy array with the predictions of the SKLearnPredictor.self
@@ -68,8 +79,7 @@ class Predictor(state.HasState):
         :returns: A in-memory numpy array containing the SKLearnPredictor predictions.
         :rtype: numpy.array
         '''
-        data = df[self.features].values
-        return self.model.predict(data)
+        return self.transform(df)[self.prediction_name].values
 
     def transform(self, df):
         '''Transform a DataFrame such that it contains the predictions of the SKLearnPredictor.
@@ -173,11 +183,19 @@ class IncrementalPredictor(state.HasState):
     num_epochs = traitlets.Int(default_value=1, allow_none=False, help='Number of times each batch is sent to the model.')
     shuffle = traitlets.Bool(default_value=False, allow_none=False, help='If True, shuffle the samples before sending them to the model.')
     prediction_name = traitlets.Unicode(default_value='prediction', help='The name of the virtual column housing the predictions.')
+    prediction_type = traitlets.Enum(values=['predict', 'predict_proba', 'predict_log_proba'], default_value='predict',
+                                     help='Which method to use to get the predictions. \
+                                     Can be "predict", "predict_proba" or "predict_log_proba".')
     partial_fit_kwargs = traitlets.Dict(default_value={}, help='A dictionary of key word arguments to be passed on to the `fit_predict` method of the `model`.')
 
     def __call__(self, *args):
         X = np.vstack([arg.astype(np.float64) for arg in args]).T.copy()
-        return self.model.predict(X)
+        if self.prediction_type == 'predict':
+            return self.model.predict(X)
+        elif self.prediction_type == 'predict_proba':
+            return self.model.predict_proba(X)
+        else:
+            return self.model.predict_log_proba(X)
 
     def predict(self, df):
         '''Get an in-memory numpy array with the predictions of the SKLearnPredictor.self

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -109,17 +109,6 @@ class Predictor(state.HasState):
 
 @vaex.serialize.register
 @generate.register
-class SKLearnPredictor(Predictor):
-
-    def __init__(self):
-        super(SKLearnPredictor, self).__init__()
-        warnings.warn(message='''This class is deprecated and it will be removed in vaex-ml 0.8.
-                      Please use vaex.ml.sklearn.Predictor instead.''',
-                      category=DeprecationWarning)
-
-
-@vaex.serialize.register
-@generate.register
 class IncrementalPredictor(state.HasState):
     '''This class wraps any scikit-learn estimator (a.k.a predictions) that has
     a `.partial_fit` method, and makes it a vaex pipeline object.


### PR DESCRIPTION
Requested in #920 .

This PR adds support for obtaining probabilities and log probabilities from sklearn classifiers. 
The `Predictor` and `IncrementalPredictor` classes now have a `prediction_type` kwarg, which can be set to `predict` (default), `predict_proba` and `predict_log_proba`. Each option will trigger the appropriate method in the sklearn classifier at prediction time.

Note: in this PR we are also removing a deprecated class (`vaex.ml.sklearn.SKLearnPredictor`), as it's deprecation period has expired. 

Checklist:
 - [x] Implementation 
 - [x] Update of unit-tests
 - [ ] Review