### PR TITLE
Fix: Preserve dtype string after fillna() operation

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -23,7 +23,8 @@ url = 'https://www.github.com/maartenbreddels/vaex'
 install_requires_core = ["numpy>=1.16", "astropy>=2", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2", "psutil>=1.2.1",
                          "requests", "six", "cloudpickle", "pandas", "dask[array]",
-                         "nest-asyncio>=1.3.3", "pyarrow>=1.0"]
+                         "nest-asyncio>=1.3.3", "pyarrow>=1.0", "frozendict",
+                         "blake3"]
 if sys.version_info[0] == 2:
     install_requires_core.append("futures>=2.2.0")
 install_requires_viz = ["matplotlib>=1.3.1", ]

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -348,15 +348,8 @@ def from_arrays(**arrays):
     """
     import numpy as np
     import six
-    from .column import Column, supported_column_types
-    df = vaex.dataframe.DataFrameArrays("array")
-    for name, array in arrays.items():
-        if isinstance(array, supported_column_types):
-            df.add_column(name, array)
-        else:
-            array = np.asanyarray(array)
-            df.add_column(name, array)
-    return df
+    dataset = vaex.dataset.DatasetArrays(arrays)
+    return vaex.dataframe.DataFrameLocal(dataset)
 
 def from_arrow_table(table, as_numpy=True):
     """Creates a vaex DataFrame from an arrow Table.

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -253,7 +253,7 @@ def open_many(filenames):
         filename = filename.strip()
         if filename and filename[0] != "#":
             dfs.append(open(filename))
-    return vaex.dataframe.DataFrameConcatenated(dfs=dfs)
+    return concat(dfs)
 
 
 def from_samp(username=None, password=None):

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -804,8 +804,8 @@ def concat(dfs):
 
     :rtype: DataFrame
     '''
-    ds = reduce((lambda x, y: x.concat(y)), dfs)
-    return ds
+    df, *tail = dfs
+    return df.concat(*tail)
 
 def vrange(start, stop, step=1, dtype='f8'):
     """Creates a virtual column which is the equivalent of numpy.arange, but uses 0 memory"""

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -270,7 +270,8 @@ def from_samp(username=None, password=None):
 def from_astropy_table(table):
     """Create a vaex DataFrame from an Astropy Table."""
     import vaex.file.other
-    return vaex.file.other.DatasetAstropyTable(table=table)
+    ds = vaex.file.other.DatasetAstropyTable(table=table)
+    return vaex.dataframe.DataFrameLocal(ds)
 
 
 def from_dict(data):
@@ -426,7 +427,7 @@ def from_ascii(path, seperator=None, names=True, skip_lines=0, skip_after=0, **k
     """
 
     import vaex.ext.readcol as rc
-    ds = vaex.dataframe.DataFrameArrays(path)
+    ds = vaex.dataframe.DataFrameLocal()
     if names not in [True, False]:
         namelist = names
         names = False

--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -25,6 +25,7 @@ def filter(ar, boolean_mask):
     else:
         return ar[boolean_mask]
 
+
 def same_type(type1, type2):
     try:
         return type1 == type2

--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -33,6 +33,13 @@ def same_type(type1, type2):
         return False
 
 
+def data_type(ar):
+    if isinstance(ar, supported_arrow_array_types):
+        return ar.type
+    else:
+        return ar.dtype
+
+
 def to_numpy(x, strict=False):
     import vaex.arrow.convert
     import vaex.column

--- a/packages/vaex-core/vaex/arrow/dataset.py
+++ b/packages/vaex-core/vaex/arrow/dataset.py
@@ -11,11 +11,10 @@ logger = logging.getLogger("vaex.arrow")
 
 
 def from_table(table, as_numpy=True):
-    df = vaex.dataframe.DataFrameLocal(None, None, [])
-    df._length_unfiltered = df._length_original = table.num_rows
-    df._index_end = df._length_original = table.num_rows
-    for col, name in zip(table.columns, table.schema.names):
-        df.add_column(name, col)
+    columns = dict(zip(table.schema.names, table.columns))
+    # TODO: this should be an DatasetArrow and/or DatasetParquet
+    dataset = vaex.dataset.DatasetArrays(columns)
+    df = vaex.dataframe.DataFrameLocal(dataset)
     return df.as_numpy() if as_numpy else df
 
 

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -121,9 +121,6 @@ class ColumnArrowLazyCast(Column):
             return pa.Array.from_pandas(self.ar[slice], type=self.type)
         return pa.array(self.ar[slice], type=self.type)
 
-    # def __setitem__(self, slice, value):
-    #     self.ar[slice] = value
-
 
 class ColumnIndexed(Column):
     def __init__(self, column, indices, masked=False):

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -105,6 +105,10 @@ class ColumnArrowLazyCast(Column):
         self.ar = ar  # this should behave like a numpy array
         self.type = type
 
+    @property
+    def dtype(self):
+        return vaex.array_types.to_numpy_type(self.type)
+
     def __len__(self):
         return len(self.ar)
 
@@ -112,6 +116,9 @@ class ColumnArrowLazyCast(Column):
         return type(self)(self.ar[i1:i2], self.type)
 
     def __getitem__(self, slice):
+        if self.ar.dtype == object and vaex.array_types.is_string_type(self.type):
+            # this seem to be the only way to convert mixed str and nan to include nulls
+            return pa.Array.from_pandas(self.ar[slice], type=self.type)
         return pa.array(self.ar[slice], type=self.type)
 
     # def __setitem__(self, slice, value):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2902,7 +2902,6 @@ class DataFrame(object):
         """
         from astropy.table import Table, Column, MaskedColumn
         meta = dict()
-        meta["name"] = self.name
         meta["description"] = self.description
 
         table = Table(meta=meta)
@@ -3418,7 +3417,7 @@ class DataFrame(object):
         for name in self.get_column_names():
             parts += ["<tr>"]
             parts += ["<td>%s</td>" % name]
-            virtual = column_name in self.virtual_columns
+            virtual = name in self.virtual_columns
             if not virtual:
                 dtype = str(self.data_type(name)) if self.data_type(name) != str else 'str'
             else:
@@ -3430,7 +3429,7 @@ class DataFrame(object):
             if description:
                 parts += ["<td ><pre>%s</pre></td>" % self.descriptions.get(name, "")]
             if virtual:
-                parts += ["<td><code>%s</code></td>" % self.virtual_columns[column_name]]
+                parts += ["<td><code>%s</code></td>" % self.virtual_columns[name]]
             else:
                 parts += ["<td></td>"]
             parts += ["</tr>"]
@@ -4896,6 +4895,10 @@ class DataFrameLocal(DataFrame):
             dataset = vaex.dataset.DatasetArrays()
         super(DataFrameLocal, self).__init__(dataset.keys())
         self.dataset = dataset
+        if hasattr(dataset, 'units'):
+            self.units.update(dataset.units)
+        if hasattr(dataset, 'ucds'):
+            self.ucds.update(dataset.ucds)
         self.column_names = list(self.dataset)
         for column_name in self.column_names:
             self._initialize_column(column_name)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -6142,32 +6142,3 @@ def _is_dtype_ok(dtype):
 
 def _is_array_type_ok(array):
     return _is_dtype_ok(array.dtype)
-
-
-# class DataFrameArrays(DataFrameLocal):
-#     """Represent an in-memory DataFrame of numpy arrays, see :func:`from_arrays` for usage."""
-
-#     def __init__(self, name="arrays"):
-#         super(DataFrameArrays, self).__init__(None, None, [])
-#         self.name = name
-#         self.path = "/has/no/path/" + name
-
-#     # def __len__(self):
-#     #   return len(self.columns.values()[0])
-
-#     def add_column(self, name, data, dtype=None):
-#         """Add a column to the DataFrame
-
-#         :param str name: name of column
-#         :param data: numpy array with the data
-#         """
-#         # assert _is_array_type_ok(data), "dtype not supported: %r, %r" % (data.dtype, data.dtype.type)
-#         # self._length = len(data)
-#         # if self._length_unfiltered is None:
-#         #     self._length_unfiltered = len(data)
-#         #     self._length_original = len(data)
-#         #     self._index_end = self._length_unfiltered
-#         super(DataFrameArrays, self).add_column(name, data, dtype=dtype)
-#         self._length_unfiltered = int(round(self._length_original * self._active_fraction))
-#         # self.set_active_fraction(self._active_fraction)
-

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3882,17 +3882,7 @@ class DataFrame(object):
         df = self if inplace else self.copy()
         if self._index_start == 0 and self._index_end == self._length_original:
             return df
-        for name in df.columns.keys():
-            column = df.columns.get(name)
-            if column is not None:
-                if self._index_start == 0 and len(column) == self._index_end:
-                    pass  # we already assigned it in .copy
-                else:
-                    if isinstance(column, array_types.supported_array_types):  # real array
-                        df.columns[name] = column[self._index_start:self._index_end]
-                    else:
-                        df.columns[name] = column.trim(self._index_start, self._index_end)
-
+        df.dataset = self.dataset[self._index_start:self._index_end]
         df._length_original = self.length_unfiltered()
         df._length_unfiltered = df._length_original
         df._cached_filtered_length = None

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5343,9 +5343,9 @@ class DataFrameLocal(DataFrame):
                 df_concat.column_names.append(name)
             df_concat._save_assign_expression(name)
 
-        for df in tail:
+        for df in dfs:
             for name, value in list(df.variables.items()):
-                if name not in self.variables:
+                if name not in df_concat.variables:
                     df_concat.set_variable(name, value, write=False)
         return df_concat
 

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -61,9 +61,10 @@ def hash_array(ar):
             return str(uuid.uuid4())
         if np.ma.isMaskedArray(ar):
             data_byte_ar = _to_bytes(ar.data)
-            mask_byte_ar = _to_bytes(ar.mask)
             blake = blake3.blake3(data_byte_ar, multithreading=True)
-            blake.update(mask_byte_ar)
+            if ar.mask is not True and ar.mask is not False and ar.mask is not np.True_ and ar.mask is not np.False_:
+                mask_byte_ar = _to_bytes(ar.mask)
+                blake.update(mask_byte_ar)
             return blake.hexdigest()
         else:
             try:

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -30,5 +30,203 @@ from .dataframe import (
 # alias kept for backward compatibility
 Dataset = DataFrame
 DatasetLocal = DataFrameLocal
-DatasetArrays = DataFrameArrays
+# DatasetArrays = DataFrameArrays
 DatasetConcatenated = DataFrameConcatenated
+
+import os
+import collections.abc
+from frozendict import frozendict
+import blake3
+import numpy as np
+import uuid
+
+from .column import Column, supported_column_types
+import pyarrow as pa
+
+def _to_bytes(ar):
+    try:
+        return ar.view(np.uint8)
+    except ValueError:
+        return ar.copy().view(np.uint8)
+
+
+def hash_array(ar):
+    if isinstance(ar, np.ndarray):
+        if ar.dtype == np.object_:
+            return str(uuid.uuid4())
+        if np.ma.isMaskedArray(ar):
+            data_byte_ar = _to_bytes(ar.data)
+            mask_byte_ar = _to_bytes(ar.mask)
+            blake = blake3.blake3(data_byte_ar, multithreading=True)
+            blake.update(mask_byte_ar)
+            return blake.hexdigest()
+        else:
+            try:
+                byte_ar = _to_bytes(ar)
+            except ValueError:
+                byte_ar = ar.copy().view(np.uint8)
+            return blake3.blake3(byte_ar, multithreading=True).hexdigest()
+    else:
+        # TODO: dtype is not included in hash
+        try:
+            ar = pa.array(ar)
+        except:  # dtype=o for lazy columns doesn't work..
+            return str(uuid.uuid4())
+        blake = blake3.blake3(multithreading=True)
+        for buffer in ar.buffers():
+            if buffer is not None:
+                # TODO: we need to make a copy here, a memoryview would be better
+                # or possible patch the blake module to accept a memoryview https://github.com/oconnor663/blake3-py/issues/9
+                # or feed in the buffer in batches
+                # blake.update(buffer)
+                blake.update(memoryview((buffer)).tobytes())
+        return blake.hexdigest()
+
+
+def to_supported_array(ar):
+    if not isinstance(ar, supported_column_types):
+        ar = np.asanyarray(ar)
+    if isinstance(ar, np.ndarray) and ar.dtype.kind == 'O':
+        ar_data = ar
+        if np.ma.isMaskedArray(ar):
+            ar_data = ar.data
+
+        try:
+            # "k != k" is a way to detect NaN's and NaT's
+            types = list({type(k) for k in ar_data if k is not None and k == k})
+        except ValueError:
+            # If there is an array value in the column, Numpy throws a ValueError
+            # "The truth value of an array with more than one element is ambiguous".
+            # We don't handle this by default as it is a bit slower.
+            def is_missing(k):
+                if k is None:
+                    return True
+                try:
+                    # a way to detect NaN's and NaT
+                    return not (k == k)
+                except ValueError:
+                    # if a value is an array, this will fail, and it is a non-missing
+                    return False
+            types = list({type(k) for k in ar_data if k is not is_missing(k)})
+
+        if len(types) == 1 and issubclass(types[0], six.string_types):
+            # TODO: how do we know it should not be large_string?
+            # self._dtypes_override[valid_name] = pa.string()
+            ar = vaex.column.ColumnArrowLazyCast(ar, pa.string())
+        if len(types) == 0:  # can only be if all nan right?
+            ar = ar.astype(np.float64)
+    return ar
+
+
+class Dataset(collections.abc.Mapping):
+    def __init__(self):
+        super().__init__()
+        self._columns = frozendict()
+
+    def renamed(self, renaming):
+        return DatasetRenamed(self, renaming)
+
+    def merged(self, rhs):
+        return DatasetMerged(self, rhs)
+
+    def dropped(self, *names):
+        return DatasetDropped(self, names)
+
+    def __getitem__(self, name):
+        return self._columns[name]
+    
+    def __len__(self):
+        return len(self._columns)
+
+    def __iter__(self):
+        return iter(self._columns)
+
+    def get_data(self, i1, i2, names):
+        raise NotImplementedError
+
+    def __eq__(self, rhs):
+        if not isinstance(rhs, Dataset):
+            return NotImplemented
+        return self._ids == rhs._ids
+
+
+class DatasetRenamed(Dataset):
+    def __init__(self, original, renaming):
+        self.original = original
+        self._columns = frozendict({renaming.get(name, name): ar for name, ar in original.items()})
+        self._ids = frozendict({renaming.get(name, name): ar for name, ar in original._ids.items()})
+
+
+class DatasetDropped(Dataset):
+    def __init__(self, original, names):
+        self.original = original
+        self._columns = frozendict({name: ar for name, ar in original.items() if name not in names})
+        self._ids = frozendict({name: ar for name, ar in original._ids.items() if name not in names})
+
+
+class DatasetMerged(Dataset):
+    def __init__(self, left, right):
+        overlap = set(left) & set(right)
+        if overlap:
+            raise NameError(f'Duplicate names: {overlap}')
+        self._columns = frozendict({**left._columns, **right._columns})
+        self._ids = frozendict({**left._ids, **right._ids})
+
+
+class DatasetArrays(Dataset):
+    def __init__(self, mapping=None, **kwargs):
+        if mapping is None:
+            mapping = {}
+        columns = {**mapping, **kwargs}
+        columns = {key: to_supported_array(ar) for key, ar in columns.items()}
+        self._columns = frozendict(columns)
+        self._ids = frozendict({key: hash_array(array) for key, array in self._columns.items()})
+
+    # TODO: we might want to really get rid of these, since we want to avoid copying them over the network?
+    # def dropped(self, names):
+
+class DatasetFile(Dataset):
+    """Datasets that map to a file can keep their ids/hashes in the file itself,
+    or keep them in a meta file.
+    """
+    def __init__(self, path):
+        self.path = path
+        self._columns = {}
+        self._ids = {}
+
+    def __getstate__(self):
+        # we don't have the columns in the state, since we should be able
+        # to get them from disk again
+        return {
+            '_ids': self._ids
+        }
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._columns = {}
+
+    def add_column(self, name, data):
+        self._columns[name] = data
+        # we wanna cache this
+        # if unpickled, the ids are already there
+        if name not in self._ids:
+            self._ids[name] = hash_array(data)
+
+        # self._columns, self._ids, self.attrs = read_hdf5(path)
+
+
+    def _get_private_dir(self, create=False):
+        """Each DataFrame has a directory where files are stored for metadata etc.
+
+        Example
+
+        >>> ds._get_private_dir()
+        '/Users/users/breddels/.vaex/dataset/_Users_users_breddels_vaex-testing_data_helmi-dezeeuw-2000-10p.hdf5'
+
+        :param bool create: is True, it will create the directory if it does not exist
+        """
+        name = os.path.abspath(self.path).replace(os.path.sep, "_")[:250]  # should not be too long for most os'es
+        name = name.replace(":", "_")  # for windows drive names
+        dir = os.path.join(vaex.utils.get_private_dir(), "dataset", name)
+        os.makedirs(dir, exist_ok=create)
+        return dir

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -1,53 +1,21 @@
-from pathlib import Path
-from .dataframe import *
-from .dataframe import (
-    # .dataframe imports from .utils
-    _ensure_strings_from_expressions,
-    _ensure_string_from_expression,
-    _ensure_list,
-    _is_limit,
-    _isnumber,
-    _issequence,
-    _is_string,
-    _parse_reduction,
-    _parse_n,
-    _normalize_selection_name,
-    _normalize,
-    _parse_f,
-    _expand,
-    _expand_shape,
-    _expand_limits,
-    _split_and_combine_mask,
-    # dataframe definitions
-    ColumnConcatenatedLazy as _ColumnConcatenatedLazy,
-    _doc_snippets,
-    _functions_statistics_1d,
-    _hidden,
-    _is_array_type_ok,
-    _is_dtype_ok,
-    _requires
-)
-
-# alias kept for backward compatibility
-Dataset = DataFrame
-DatasetLocal = DataFrameLocal
-# DatasetArrays = DataFrameArrays
-DatasetConcatenated = DataFrameConcatenated
-
 import os
+from pathlib import Path
 import collections.abc
-import numpy as np
-import uuid
 import logging
+import uuid
 from urllib.parse import urlparse
+
+import numpy as np
+import blake3
+from frozendict import frozendict
+import pyarrow as pa
+
+import vaex
+from .column import Column, ColumnIndexed, ColumnConcatenatedLazy, supported_column_types
+from . import array_types
 
 logger = logging.getLogger('vaex.dataset')
 
-import blake3
-from frozendict import frozendict
-
-from .column import Column, supported_column_types
-import pyarrow as pa
 
 def _to_bytes(ar):
     try:
@@ -129,7 +97,7 @@ def to_supported_array(ar):
                     return False
             types = list({type(k) for k in ar_data if k is not is_missing(k)})
 
-        if len(types) == 1 and issubclass(types[0], six.string_types):
+        if len(types) == 1 and issubclass(types[0], str):
             # TODO: how do we know it should not be large_string?
             # self._dtypes_override[valid_name] = pa.string()
             ar = vaex.column.ColumnArrowLazyCast(ar, pa.string())

--- a/packages/vaex-core/vaex/dataset_mmap.py
+++ b/packages/vaex-core/vaex/dataset_mmap.py
@@ -27,7 +27,7 @@ class DatasetMemoryMapped(vaex.dataset.DatasetFile):
 
     # nommap is a hack to get in memory datasets working
     def __init__(self, path, write=False, nommap=False):
-        super().__init__(path=os.path.abspath(path), write=write)
+        super().__init__(path=path, write=write)
         # self.name = name or os.path.splitext(os.path.basename(self.path))[0]
         # self.path = os.path.abspath(path) if path is not None else None
         self.nommap = nommap

--- a/packages/vaex-core/vaex/dataset_mmap.py
+++ b/packages/vaex-core/vaex/dataset_mmap.py
@@ -24,18 +24,12 @@ no_mmap = os.environ.get('VAEX_NO_MMAP', False)
 class DatasetMemoryMapped(vaex.dataset.DatasetFile):
     """Represents a dataset where the data is memory mapped for efficient reading"""
 
-    # nommap is a hack to get in memory datasets working
     def __init__(self, path, write=False, nommap=False):
         super().__init__(path=path, write=write)
-        # self.name = name or os.path.splitext(os.path.basename(self.path))[0]
-        # self.path = os.path.abspath(path) if path is not None else None
         self.nommap = nommap
         self.file_map = {}
         self.fileno_map = {}
         self.mapping_map = {}
-
-        # self._mappings = []
-        # self.samp_id = None
 
     def __getstate__(self):
         return {
@@ -82,19 +76,6 @@ class DatasetMemoryMapped(vaex.dataset.DatasetFile):
             for name, memmap in self.mapping_map.items():
                 memmap.close()
 
-    # def addFile(self, path, write=False):
-    #     self.file_map[path] = open(path, "rb+" if write else "rb")
-    #     self.fileno_map[path] = self.file_map[path].fileno()
-    #     self.mapping_map[path] = mmap.mmap(self.fileno_map[path], 0, prot=mmap.PROT_READ | 0 if not write else mmap.PROT_WRITE)
-
-    # def matches_url(self, url):
-    #     path = url
-    #     if path.startswith("file:/"):
-    #         path = path[5:]
-    #     similar = os.path.splitext(os.path.abspath(self.path))[0] == os.path.splitext(path)[0]
-    #     logger.info("matching urls: %r == %r == %r" % (os.path.splitext(self.path)[0], os.path.splitext(path)[0], similar))
-    #     return similar
-
     def close(self):
         self.file.close()
         self.mapping.close()
@@ -102,71 +83,13 @@ class DatasetMemoryMapped(vaex.dataset.DatasetFile):
     def _map_array(self, offset=None, length=None, dtype=np.float64, path=None):
         if path is None:
             path = self.path
-
-        # self._mappings.append({
-        #     'offset': offset,
-        #     'length': length,
-        #     'dtype': dtype,
-        #     'path': path
-        # })
         return self._do_map(path, offset, length, dtype)
     
     def _do_map(self, path, offset, length, dtype):        
         if self.nommap:
-            # file = self.file_map[path]
             file = self._get_file(path)
             column = ColumnFile(file, offset, length, dtype, write=self.write, path=self.path)
         else:
-            # mapping = self.mapping_map[path]
             mapping = self._get_mapping(path)
             column = np.frombuffer(mapping, dtype=dtype, count=length, offset=offset)
         return column
-
-    # def _add_column(self, name, offset=None, length=None, dtype=np.float64, stride=1, path=None, array=None):
-    #     array = self._map_array(offset, length, dtype, stride, path, array, name=name)
-    #     if array is not None:
-    #         if self._length_original is None:
-    #             self._length_unfiltered = len(array)
-    #             self._length_original = len(array)
-    #             self._index_end = self._length_unfiltered
-    #         self.columns[name] = array
-    #         self.column_names.append(name)
-    #         self._save_assign_expression(name, Expression(self, name))
-    #         self.all_columns[name] = array
-    #         self.all_column_names.append(name)
-    #         # self.column_names.sort()
-    #         self.nColumns += 1
-    #         self.nRows = self._length_original
-    #         self.offsets[name] = offset
-    #         self.strides[name] = stride
-    #         if path is not None:
-    #             self.paths[name] = os.path.abspath(path)
-    #         self.dtypes[name] = dtype
-
-    # def _addRank1(self, name, offset, length, length1, dtype=np.float64, stride=1, stride1=1, path=None, transposed=False):
-    #     if path is None:
-    #         path = self.path
-    #     mapping = self.mapping_map[path]
-    #     if (not transposed and self._length is not None and length != self._length) or (transposed and self._length is not None and length1 != self._length):
-    #         logger.error("inconsistent length", "length of column %s is %d, while %d was expected" % (name, length, self._length))
-    #     else:
-    #         if self.current_slice is None:
-    #             self.current_slice = (0, length if not transposed else length1)
-    #             self.fraction = 1.
-    #             self._length_unfiltered = length if not transposed else length1
-    #             self._length = self._length_unfiltered
-    #             self._index_end = self._length_unfiltered
-    #         self._length = length if not transposed else length1
-    #         # print self.mapping, dtype, length if stride is None else length * stride, offset
-    #         rawlength = length * length1
-    #         rawlength *= stride
-    #         rawlength *= stride1
-
-    #         mmapped_array = np.frombuffer(mapping, dtype=dtype, count=rawlength, offset=offset)
-    #         mmapped_array = mmapped_array.reshape((length1 * stride1, length * stride))
-    #         mmapped_array = mmapped_array[::stride1, ::stride]
-
-    #         self.rank1s[name] = mmapped_array
-    #         self.rank1names.append(name)
-    #         self.all_columns[name] = mmapped_array
-    #         self.all_column_names.append(name)

--- a/packages/vaex-core/vaex/dataset_mmap.py
+++ b/packages/vaex-core/vaex/dataset_mmap.py
@@ -21,66 +21,62 @@ osname = vaex.utils.osname
 no_mmap = os.environ.get('VAEX_NO_MMAP', False)
 
 
-class DatasetMemoryMapped(DatasetLocal):
+
+class DatasetMemoryMapped(vaex.dataset.DatasetFile):
     """Represents a dataset where the data is memory mapped for efficient reading"""
 
     # nommap is a hack to get in memory datasets working
-    def __init__(self, filename, write=False, nommap=False, name=None):
-        super(DatasetMemoryMapped, self).__init__(name=name or os.path.splitext(os.path.basename(filename))[0], path=os.path.abspath(filename) if filename is not None else None, column_names=[])
-        self.filename = filename or "no file"
+    def __init__(self, path, write=False, nommap=False):
+        super().__init__(path=os.path.abspath(path))
+        self.path = path or "no file"
         self.write = write
-        # self.name = name or os.path.splitext(os.path.basename(self.filename))[0]
-        # self.path = os.path.abspath(filename) if filename is not None else None
+        # self.name = name or os.path.splitext(os.path.basename(self.path))[0]
+        # self.path = os.path.abspath(path) if path is not None else None
         self.nommap = nommap
-        if not nommap:
-            self.file = open(self.filename, "rb+" if write else "rb")
-            self.fileno = self.file.fileno()
+        self.file_map = {}
+        self.fileno_map = {}
+        self.mapping_map = {}
+
+        # self._mappings = []
+        # self.samp_id = None
+
+    def __getstate__(self):
+        return {
+            **super().__getstate__(),
+            'write': self.write,
+            'path': self.path,
+            'nommap': self.nommap
+        }
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self.mapping_map = {}
+        self.fileno_map = {}
+        self.file_map = {}
+
+
+    def _get_file(self, path):
+        assert self.nommap
+        if path not in self.file_map:
+            file = open(path, "rb+" if self.write else "rb")
+            self.file_map[path] = file
+        return self.file_map[path]
+
+    def _get_mapping(self, path):
+        assert not self.nommap
+        if path not in self.mapping_map:
+            file = open(path, "rb+" if self.write else "rb")
+            fileno = file.fileno()
             kwargs = {}
             if vaex.utils.osname == "windows":
-                kwargs["access"] = mmap.ACCESS_READ | 0 if not write else mmap.ACCESS_WRITE
+                kwargs["access"] = mmap.ACCESS_READ | 0 if not self.write else mmap.ACCESS_WRITE
             else:
-                kwargs["prot"] = mmap.PROT_READ | 0 if not write else mmap.PROT_WRITE
-            self.mapping = mmap.mmap(self.fileno, 0, **kwargs)
-            self.file_map = {filename: self.file}
-            self.fileno_map = {filename: self.fileno}
-            self.mapping_map = {filename: self.mapping}
-        else:
-            self.file_map = {}
-            self.fileno_map = {}
-            self.mapping_map = {}
-        self._length_original = None
-        # self._fraction_length = None
-        self.nColumns = 0
-        self.column_names = []
-        self.rank1s = {}
-        self.rank1names = []
-        self.virtual_columns = collections.OrderedDict()
-
-        self.axes = {}
-        self.axis_names = []
-
-        # these are replaced by variables
-        # self.properties = {}
-        # self.property_names = []
-
-        self.current_slice = None
-        self.fraction = 1.0
-
-        self.selected_row_index = None
-        self.selected_serie_index = 0
-        self.row_selection_listeners = []
-        self.serie_index_selection_listeners = []
-        # self.mask_listeners = []
-
-        self.all_columns = {}
-        self.all_column_names = []
-        self.global_links = {}
-
-        self.offsets = {}
-        self.strides = {}
-        self.filenames = {}
-        self.samp_id = None
-        # self.variables = collections.OrderedDict()
+                kwargs["prot"] = mmap.PROT_READ | 0 if not self.write else mmap.PROT_WRITE
+            mapping = mmap.mmap(fileno, 0, **kwargs)
+            self.file_map[path] = file
+            self.fileno_map[path] = fileno
+            self.mapping_map[path] = mapping
+        return self.mapping_map[path]
 
     def close_files(self):
         for name, file in self.file_map.items():
@@ -91,210 +87,91 @@ class DatasetMemoryMapped(DatasetLocal):
             for name, memmap in self.mapping_map.items():
                 memmap.close()
 
-    def has_snapshots(self):
-        return len(self.rank1s) > 0
+    # def addFile(self, path, write=False):
+    #     self.file_map[path] = open(path, "rb+" if write else "rb")
+    #     self.fileno_map[path] = self.file_map[path].fileno()
+    #     self.mapping_map[path] = mmap.mmap(self.fileno_map[path], 0, prot=mmap.PROT_READ | 0 if not write else mmap.PROT_WRITE)
 
-    def get_path(self):
-        return self.path
-
-    def addFile(self, filename, write=False):
-        self.file_map[filename] = open(filename, "rb+" if write else "rb")
-        self.fileno_map[filename] = self.file_map[filename].fileno()
-        self.mapping_map[filename] = mmap.mmap(self.fileno_map[filename], 0, prot=mmap.PROT_READ | 0 if not write else mmap.PROT_WRITE)
-
-    def selectSerieIndex(self, serie_index):
-        self.selected_serie_index = serie_index
-        for serie_index_selection_listener in self.serie_index_selection_listeners:
-            serie_index_selection_listener(serie_index)
-        self.signal_sequence_index_change.emit(self, serie_index)
-
-    def matches_url(self, url):
-        filename = url
-        if filename.startswith("file:/"):
-            filename = filename[5:]
-        similar = os.path.splitext(os.path.abspath(self.filename))[0] == os.path.splitext(filename)[0]
-        logger.info("matching urls: %r == %r == %r" % (os.path.splitext(self.filename)[0], os.path.splitext(filename)[0], similar))
-        return similar
+    # def matches_url(self, url):
+    #     path = url
+    #     if path.startswith("file:/"):
+    #         path = path[5:]
+    #     similar = os.path.splitext(os.path.abspath(self.path))[0] == os.path.splitext(path)[0]
+    #     logger.info("matching urls: %r == %r == %r" % (os.path.splitext(self.path)[0], os.path.splitext(path)[0], similar))
+    #     return similar
 
     def close(self):
         self.file.close()
         self.mapping.close()
 
-    def addAxis(self, name, offset=None, length=None, dtype=np.float64, stride=1, filename=None):
-        if filename is None:
-            filename = self.filename
-        mapping = self.mapping_map[filename]
-        mmapped_array = np.frombuffer(mapping, dtype=dtype, count=length if stride is None else length * stride, offset=offset)
-        if stride:
-            mmapped_array = mmapped_array[::stride]
-        self.axes[name] = mmapped_array
-        self.axis_names.append(name)
+    def _map_array(self, offset=None, length=None, dtype=np.float64, path=None):
+        if path is None:
+            path = self.path
 
-    def _map_array(self, offset=None, length=None, dtype=np.float64, stride=1, filename=None, array=None, name='unknown'):
-        if filename is None:
-            filename = self.filename
-        if not self.nommap:
-            mapping = self.mapping_map[filename]
-
-        if array is not None:
-            length = len(array)
-
-        # if self._length_original is not None and length != self._length_original:
-        #     logger.error("inconsistent length", "length of column %s is %d, while %d was expected" % (name, length, self._length))
-        # else:
-            # self._length_unfiltered = length
-            # self._length_original = length
-            # if self.current_slice is None:
-            #     self.current_slice = (0, length)
-            #     self.fraction = 1.
-            #     self._length = length
-            #     self._index_end = self._length_unfiltered
-            #     self._index_start = 0
-            # print self.mapping, dtype, length if stride is None else length * stride, offset
-        if 1:
-            if array is not None:
-                length = len(array)
-                mmapped_array = array
-                stride = None
-                offset = None
-                dtype = array.dtype
-                column = array
-            else:
-                if offset is None:
-                    print("offset is None")
-                    sys.exit(0)
-
-                file = self.file_map[filename]
-                if self.nommap:
-                    column = ColumnFile(file, offset, length, dtype, write=self.write, path=self.path)
-                else:
-                    column = np.frombuffer(mapping, dtype=dtype, count=length if stride is None else length * stride, offset=offset)
-                    if stride and stride != 1:
-                        column = column[::stride]
-            return column
-
-    def addColumn(self, name, offset=None, length=None, dtype=np.float64, stride=1, filename=None, array=None):
-        array = self._map_array(offset, length, dtype, stride, filename, array, name=name)
-        if array is not None:
-            if self._length_original is None:
-                self._length_unfiltered = len(array)
-                self._length_original = len(array)
-                self._index_end = self._length_unfiltered
-            self.columns[name] = array
-            self.column_names.append(name)
-            self._save_assign_expression(name, Expression(self, name))
-            self.all_columns[name] = array
-            self.all_column_names.append(name)
-            # self.column_names.sort()
-            self.nColumns += 1
-            self.nRows = self._length_original
-            self.offsets[name] = offset
-            self.strides[name] = stride
-            if filename is not None:
-                self.filenames[name] = os.path.abspath(filename)
-            self.dtypes[name] = dtype
-
-    def addRank1(self, name, offset, length, length1, dtype=np.float64, stride=1, stride1=1, filename=None, transposed=False):
-        if filename is None:
-            filename = self.filename
-        mapping = self.mapping_map[filename]
-        if (not transposed and self._length is not None and length != self._length) or (transposed and self._length is not None and length1 != self._length):
-            logger.error("inconsistent length", "length of column %s is %d, while %d was expected" % (name, length, self._length))
+        # self._mappings.append({
+        #     'offset': offset,
+        #     'length': length,
+        #     'dtype': dtype,
+        #     'path': path
+        # })
+        return self._do_map(path, offset, length, dtype)
+    
+    def _do_map(self, path, offset, length, dtype):        
+        if self.nommap:
+            # file = self.file_map[path]
+            file = self._get_file(path)
+            column = ColumnFile(file, offset, length, dtype, write=self.write, path=self.path)
         else:
-            if self.current_slice is None:
-                self.current_slice = (0, length if not transposed else length1)
-                self.fraction = 1.
-                self._length_unfiltered = length if not transposed else length1
-                self._length = self._length_unfiltered
-                self._index_end = self._length_unfiltered
-            self._length = length if not transposed else length1
-            # print self.mapping, dtype, length if stride is None else length * stride, offset
-            rawlength = length * length1
-            rawlength *= stride
-            rawlength *= stride1
+            # mapping = self.mapping_map[path]
+            mapping = self._get_mapping(path)
+            column = np.frombuffer(mapping, dtype=dtype, count=length, offset=offset)
+        return column
 
-            mmapped_array = np.frombuffer(mapping, dtype=dtype, count=rawlength, offset=offset)
-            mmapped_array = mmapped_array.reshape((length1 * stride1, length * stride))
-            mmapped_array = mmapped_array[::stride1, ::stride]
+    # def _add_column(self, name, offset=None, length=None, dtype=np.float64, stride=1, path=None, array=None):
+    #     array = self._map_array(offset, length, dtype, stride, path, array, name=name)
+    #     if array is not None:
+    #         if self._length_original is None:
+    #             self._length_unfiltered = len(array)
+    #             self._length_original = len(array)
+    #             self._index_end = self._length_unfiltered
+    #         self.columns[name] = array
+    #         self.column_names.append(name)
+    #         self._save_assign_expression(name, Expression(self, name))
+    #         self.all_columns[name] = array
+    #         self.all_column_names.append(name)
+    #         # self.column_names.sort()
+    #         self.nColumns += 1
+    #         self.nRows = self._length_original
+    #         self.offsets[name] = offset
+    #         self.strides[name] = stride
+    #         if path is not None:
+    #             self.paths[name] = os.path.abspath(path)
+    #         self.dtypes[name] = dtype
 
-            self.rank1s[name] = mmapped_array
-            self.rank1names.append(name)
-            self.all_columns[name] = mmapped_array
-            self.all_column_names.append(name)
+    # def _addRank1(self, name, offset, length, length1, dtype=np.float64, stride=1, stride1=1, path=None, transposed=False):
+    #     if path is None:
+    #         path = self.path
+    #     mapping = self.mapping_map[path]
+    #     if (not transposed and self._length is not None and length != self._length) or (transposed and self._length is not None and length1 != self._length):
+    #         logger.error("inconsistent length", "length of column %s is %d, while %d was expected" % (name, length, self._length))
+    #     else:
+    #         if self.current_slice is None:
+    #             self.current_slice = (0, length if not transposed else length1)
+    #             self.fraction = 1.
+    #             self._length_unfiltered = length if not transposed else length1
+    #             self._length = self._length_unfiltered
+    #             self._index_end = self._length_unfiltered
+    #         self._length = length if not transposed else length1
+    #         # print self.mapping, dtype, length if stride is None else length * stride, offset
+    #         rawlength = length * length1
+    #         rawlength *= stride
+    #         rawlength *= stride1
 
+    #         mmapped_array = np.frombuffer(mapping, dtype=dtype, count=rawlength, offset=offset)
+    #         mmapped_array = mmapped_array.reshape((length1 * stride1, length * stride))
+    #         mmapped_array = mmapped_array[::stride1, ::stride]
 
-class HansMemoryMapped(DatasetMemoryMapped):
-    def __init__(self, filename, filename_extra=None):
-        super(HansMemoryMapped, self).__init__(filename)
-        self.pageSize, \
-            self.formatSize, \
-            self.numberParticles, \
-            self.numberTimes, \
-            self.numberParameters, \
-            self.numberCompute, \
-            self.dataOffset, \
-            self.dataHeaderSize = struct.unpack("Q" * 8, self.mapping[:8 * 8])
-        zerooffset = offset = self.dataOffset
-        length = self.numberParticles + 1
-        stride = self.formatSize // 8  # stride in units of the size of the element (float64)
-
-        # TODO: ask Hans for the self.numberTimes-2
-        lastoffset = offset + (self.numberParticles + 1) * (self.numberTimes - 2) * self.formatSize
-        t_index = 3
-        names = "x y z vx vy vz".split()
-        midoffset = offset + (self.numberParticles + 1) * self.formatSize * t_index
-        names = "x y z vx vy vz".split()
-
-        for i, name in enumerate(names):
-            self.addColumn(name + "_0", offset + 8 * i, length, dtype=np.float64, stride=stride)
-
-        for i, name in enumerate(names):
-            self.addColumn(name + "_last", lastoffset + 8 * i, length, dtype=np.float64, stride=stride)
-
-        names = "x y z vx vy vz".split()
-
-        if 1:
-            stride = self.formatSize // 8
-            # stride1 = self.numberTimes #*self.formatSize/8
-            for i, name in enumerate(names):
-                # TODO: ask Hans for the self.numberTimes-1
-                self.addRank1(name, offset + 8 * i, length=self.numberParticles + 1, length1=self.numberTimes - 1, dtype=np.float64, stride=stride, stride1=1)
-
-        if filename_extra is None:
-            basename = os.path.basename(filename)
-            if os.path.exists(basename + ".omega2"):
-                filename_extra = basename + ".omega2"
-
-        if filename_extra is not None:
-            self.addFile(filename_extra)
-            mapping = self.mapping_map[filename_extra]
-            names = "J_r J_theta J_phi Theta_r Theta_theta Theta_phi Omega_r Omega_theta Omega_phi r_apo r_peri".split()
-            offset = 0
-            stride = 11
-            # import pdb
-            # pdb.set_trace()
-            for i, name in enumerate(names):
-                # TODO: ask Hans for the self.numberTimes-1
-                self.addRank1(name, offset + 8 * i, length=self.numberParticles + 1, length1=self.numberTimes - 1, dtype=np.float64, stride=stride, stride1=1, filename=filename_extra)
-
-                self.addColumn(name + "_0", offset + 8 * i, length, dtype=np.float64, stride=stride, filename=filename_extra)
-                self.addColumn(name + "_last", offset + 8 * i + (self.numberParticles + 1) * (self.numberTimes - 2) * 11 * 8, length, dtype=np.float64, stride=stride, filename=filename_extra)
-
-    @classmethod
-    def can_open(cls, path, *args, **kwargs):
-        return os.path.splitext(path)[-1] == ".bin"
-        basename, ext = os.path.splitext(path)
-        # if os.path.exists(basename + ".omega2"):
-        # return True
-        # return True
-
-    @classmethod
-    def get_options(cls, path):
-        return []
-
-    @classmethod
-    def option_to_args(cls, option):
-        return []
-
-
-dataset_type_map["buist"] = HansMemoryMapped
+    #         self.rank1s[name] = mmapped_array
+    #         self.rank1names.append(name)
+    #         self.all_columns[name] = mmapped_array
+    #         self.all_column_names.append(name)

--- a/packages/vaex-core/vaex/dataset_mmap.py
+++ b/packages/vaex-core/vaex/dataset_mmap.py
@@ -6,7 +6,6 @@ import logging
 import numpy as np
 import numpy.ma
 import vaex
-from vaex.dataset import DatasetLocal
 import vaex.dataset
 import vaex.file
 from vaex.expression import Expression

--- a/packages/vaex-core/vaex/dataset_mmap.py
+++ b/packages/vaex-core/vaex/dataset_mmap.py
@@ -27,9 +27,7 @@ class DatasetMemoryMapped(vaex.dataset.DatasetFile):
 
     # nommap is a hack to get in memory datasets working
     def __init__(self, path, write=False, nommap=False):
-        super().__init__(path=os.path.abspath(path))
-        self.path = path or "no file"
-        self.write = write
+        super().__init__(path=os.path.abspath(path), write=write)
         # self.name = name or os.path.splitext(os.path.basename(self.path))[0]
         # self.path = os.path.abspath(path) if path is not None else None
         self.nommap = nommap
@@ -43,8 +41,6 @@ class DatasetMemoryMapped(vaex.dataset.DatasetFile):
     def __getstate__(self):
         return {
             **super().__getstate__(),
-            'write': self.write,
-            'path': self.path,
             'nommap': self.nommap
         }
 

--- a/packages/vaex-core/vaex/encoding.py
+++ b/packages/vaex-core/vaex/encoding.py
@@ -224,6 +224,10 @@ class Encoding:
         encoded = [self.registry[typename].encode(self, k) for k in values]
         return encoded
 
+    def encode_list2(self, typename, values):
+        encoded = [self.encode_list(typename, k) for k in values]
+        return encoded
+
     def encode_dict(self, typename, values):
         encoded = {key: self.registry[typename].encode(self, value) for key, value in values.items()}
         return encoded
@@ -234,6 +238,10 @@ class Encoding:
 
     def decode_list(self, typename, values, **kwargs):
         decoded = [self.registry[typename].decode(self, k, **kwargs) for k in values]
+        return decoded
+
+    def decode_list2(self, typename, values, **kwargs):
+        decoded = [self.decode_list(typename, k, **kwargs) for k in values]
         return decoded
 
     def decode_dict(self, typename, values, **kwargs):

--- a/packages/vaex-core/vaex/export.py
+++ b/packages/vaex-core/vaex/export.py
@@ -299,7 +299,8 @@ def export_fits(dataset, path, column_names=None, shuffle=False, selection=False
         del data_types[-1]
         del data_shapes[-1]
     dataset_output = vaex.file.other.FitsBinTable(path, write=True)
-    _export(dataset_input=dataset, dataset_output=dataset_output, path=path, random_index_column=random_index_name,
+    df_output = vaex.dataframe.DataFrameLocal(dataset_output)
+    _export(dataset_input=dataset, dataset_output=df_output, path=path, random_index_column=random_index_name,
             column_names=column_names, selection=selection, shuffle=shuffle,
             progress=progress, sort=sort, ascending=ascending)
     dataset_output.close_files()
@@ -371,6 +372,7 @@ def main(argv):
             if not args.quiet:
                 print("generating soneira peebles dataset...")
             dataset = vaex.file.other.SoneiraPeebles(args.dimension, 2, args.max_level, args.lambdas)
+            dataset = vaex.dataframe.DataFrameLocal(dataset)
         else:
             return 1
     if args.task == "tap":

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -234,10 +234,7 @@ class Expression(with_metaclass(Meta)):
 
     @property
     def _ast_slices(self):
-        # if self._ast_slices is None:
         return expresso.slices(self.ast)
-        # return self._ast_slices
-
 
     @property
     def expression(self):

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -233,6 +233,13 @@ class Expression(with_metaclass(Meta)):
         return self._ast_names
 
     @property
+    def _ast_slices(self):
+        # if self._ast_slices is None:
+        return expresso.slices(self.ast)
+        # return self._ast_slices
+
+
+    @property
     def expression(self):
         if self._expression is None:
             self._expression = expresso.node_to_string(self.ast)
@@ -770,7 +777,11 @@ def f({0}):
             for node in expression.ast_names[old]:
                 node.id = new
             expression._ast_names[new] = expression._ast_names.pop(old)
-            expression._expression = None  # resets the cached string representation
+        slices = expression._ast_slices
+        if old in slices:
+            for node in slices[old]:
+                node.slice.value.s = new
+        expression._expression = None  # resets the cached string representation
         return expression
 
     def astype(self, data_type):

--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -20,6 +20,11 @@ else:  # Python3.8
     ast_Num = _ast.Constant
     ast_Str = _ast.Constant
 
+if hasattr(_ast, '_ast.NameConstant'):
+    ast_Constant = _ast.NameConstant
+else:
+    ast_Constant = _ast.Constant
+
 
 logger = logging.getLogger("expr")
 logger.setLevel(logging.ERROR)
@@ -121,11 +126,11 @@ def validate_expression(expr, variable_set, function_set=[], names=None):
             validate_expression(comparator, variable_set, function_set, names)
     elif isinstance(expr, _ast.keyword):
         validate_expression(expr.value, variable_set, function_set, names)
-    elif isinstance(expr, _ast.NameConstant):
+    elif isinstance(expr, ast_Constant):
         pass  # like True and False
     elif isinstance(expr, _ast.Subscript):
         validate_expression(expr.value, variable_set, function_set, names)
-        if isinstance(expr.slice.value, _ast.Num):
+        if isinstance(expr.slice.value, ast_Num):
             pass  # numbers are fine
         else:
             raise ValueError(

--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -14,7 +14,7 @@ import difflib
 
 
 if hasattr(_ast, 'Num'):
-    ast_Num = _ast.Num
+    ast_Num = ast_Num
     ast_Str = _ast.Str
 else:  # Python3.8
     ast_Num = _ast.Constant

--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -39,6 +39,7 @@ def open(path, *args, **kwargs):
             break
     if dataset_class:
         dataset = dataset_class(path, *args, **kwargs)
+        return vaex.dataframe.DataFrameLocal(dataset)
         return dataset
 
 

--- a/packages/vaex-core/vaex/file/other.py
+++ b/packages/vaex-core/vaex/file/other.py
@@ -311,7 +311,7 @@ class SoneiraPeebles(DatasetArrays):
 				reorder(array[i], array[-1], order)
 				self.addColumn(name, array=array[i])
 
-dataset_type_map["soneira-peebles"] = SoneiraPeebles
+# dataset_type_map["soneira-peebles"] = SoneiraPeebles
 
 
 class Zeldovich(DatasetArrays):
@@ -351,7 +351,7 @@ class Zeldovich(DatasetArrays):
 			self.add_column(name+"0", Q[d].reshape(-1) * scale)
 		return
 
-dataset_type_map["zeldovich"] = Zeldovich
+# dataset_type_map["zeldovich"] = Zeldovich
 
 
 class AsciiTable(DatasetMemoryMapped):
@@ -382,7 +382,7 @@ class AsciiTable(DatasetMemoryMapped):
 		can_open = path.endswith(".asc")
 		logger.debug("%r can open: %r"  %(cls.__name__, can_open))
 		return can_open
-dataset_type_map["ascii"] = AsciiTable
+# dataset_type_map["ascii"] = AsciiTable
 
 class MemoryMappedGadget(DatasetMemoryMapped):
 	def __init__(self, filename):
@@ -417,7 +417,7 @@ class MemoryMappedGadget(DatasetMemoryMapped):
 
 
 
-dataset_type_map["gadget-plain"] = MemoryMappedGadget
+# dataset_type_map["gadget-plain"] = MemoryMappedGadget
 
 class DatasetAstropyTable(DatasetArrays):
 	def __init__(self, filename=None, format=None, table=None, **kwargs):

--- a/packages/vaex-core/vaex/file/other.py
+++ b/packages/vaex-core/vaex/file/other.py
@@ -15,7 +15,7 @@ import astropy.io.fits as fits
 import re
 import six
 
-from vaex.dataset import DatasetLocal, DatasetArrays, DatasetFile
+from vaex.dataset import DatasetArrays, DatasetFile
 logger = logging.getLogger("vaex.file")
 import vaex.dataset
 import vaex.file

--- a/packages/vaex-core/vaex/file/other.py
+++ b/packages/vaex-core/vaex/file/other.py
@@ -15,7 +15,7 @@ import astropy.io.fits as fits
 import re
 import six
 
-from vaex.dataset import DatasetLocal, DatasetArrays
+from vaex.dataset import DatasetLocal, DatasetArrays, DatasetFile
 logger = logging.getLogger("vaex.file")
 import vaex.dataset
 import vaex.file
@@ -136,6 +136,8 @@ def _try_unit(unit):
 class FitsBinTable(DatasetMemoryMapped):
 	def __init__(self, filename, write=False):
 		super(FitsBinTable, self).__init__(filename, write=write)
+		self.ucds = {}
+		self.units = {}
 		with fits.open(filename) as fitsfile:
 			for table in fitsfile:
 				if isinstance(table, fits.BinTableHDU):
@@ -150,7 +152,7 @@ class FitsBinTable(DatasetMemoryMapped):
 							for i in range(len(table.columns)):
 								column = table.columns[i]
 								cannot_handle = False
-								column_name = _python_save_name(column.name.strip(), used=self.columns.keys())
+								column_name = column.name.strip()
 								self._get_column_meta_data(table, column_name, column, i)
 
 
@@ -180,7 +182,8 @@ class FitsBinTable(DatasetMemoryMapped):
 										dtypecode += str(arraylength)
 									logger.debug("column type: %r", (column.name, offset, dtype, length, column.format, column.dim))
 									if arraylength == 1 or dtypecode[0] == "a":
-										self.addColumn(column_name, offset=offset, dtype=dtype, length=length)
+										ar = self._map_array(offset=offset, dtype=dtype, length=length)
+										self.add_column(column_name, ar)
 									else:
 										for i in range(arraylength):
 											name = column_name+"_" +str(i)
@@ -203,16 +206,17 @@ class FitsBinTable(DatasetMemoryMapped):
 								self._check_null(table, column_name, column, i)
 			self._try_votable(fitsfile[0])
 
-		self.update_meta()
-		self.update_virtual_meta()
+		self._freeze()
+		# self.update_meta()
+		# self.update_virtual_meta()
 
 	def _check_null(self, table, column_name, column, i):
 		null_name = "TNULL%d" % (i+1)
 		if null_name in table.header:
 			mask_value = table.header[null_name]
-			array = self.columns[column_name]
+			array = self._columns[column_name]
 			mask = array == mask_value
-			self.columns[column_name] = numpy.ma.masked_array(array, mask)
+			self._columns[column_name] = numpy.ma.masked_array(array, mask)
 
 	def _try_votable(self, table):
 		try:
@@ -283,7 +287,7 @@ dataset_type_map["fits"] = FitsBinTable
 
 class SoneiraPeebles(DatasetArrays):
 	def __init__(self, dimension, eta, max_level, L):
-		super(SoneiraPeebles, self).__init__(name="soneira-peebles")
+		columns = {}
 		#InMemory.__init__(self)
 		def todim(value):
 			if isinstance(value, (tuple, list)):
@@ -302,14 +306,8 @@ class SoneiraPeebles(DatasetArrays):
 		for d in range(dimension):
 			vaex.vaexfast.soneira_peebles(array[d], 0, 1, L[d], eta, max_level)
 		for d, name in zip(list(range(dimension)), "x y z w v u".split()):
-			self.add_column(name, array[d])
-		if 0:
-			order = np.zeros(N, dtype=np.int64)
-			vaex.vaexfast.shuffled_sequence(order);
-			for i, name in zip(list(range(dimension)), "x y z w v u".split()):
-				#np.take(array[i], order, out=array[i])
-				reorder(array[i], array[-1], order)
-				self.addColumn(name, array=array[i])
+			columns[name] = array[d]
+		super(SoneiraPeebles, self).__init__(columns)
 
 # dataset_type_map["soneira-peebles"] = SoneiraPeebles
 
@@ -390,13 +388,21 @@ class MemoryMappedGadget(DatasetMemoryMapped):
 		#h5file = h5py.File(self.filename)
 		import vaex.file.gadget
 		length, posoffset, veloffset, header = vaex.file.gadget.getinfo(filename)
-		self.addColumn("x", posoffset, length, dtype=np.float32, stride=3)
-		self.addColumn("y", posoffset+4, length, dtype=np.float32, stride=3)
-		self.addColumn("z", posoffset+8, length, dtype=np.float32, stride=3)
+		self._add("x", posoffset, length, dtype=np.float32, stride=3)
+		self._add("y", posoffset+4, length, dtype=np.float32, stride=3)
+		self._add("z", posoffset+8, length, dtype=np.float32, stride=3)
 
-		self.addColumn("vx", veloffset, length, dtype=np.float32, stride=3)
-		self.addColumn("vy", veloffset+4, length, dtype=np.float32, stride=3)
-		self.addColumn("vz", veloffset+8, length, dtype=np.float32, stride=3)
+		self._add("vx", veloffset, length, dtype=np.float32, stride=3)
+		self._add("vy", veloffset+4, length, dtype=np.float32, stride=3)
+		self._add("vz", veloffset+8, length, dtype=np.float32, stride=3)
+		self._freeze()
+
+	def _add(self, name, offset, length, dtype, stride):
+		ar = self._map_array(offset, length, dtype)
+		ar = ar[::stride]
+		self.add_column(name, ar)
+
+
 	@classmethod
 	def can_open(cls, path, *args, **kwargs):
 		try:
@@ -417,19 +423,20 @@ class MemoryMappedGadget(DatasetMemoryMapped):
 
 
 
-# dataset_type_map["gadget-plain"] = MemoryMappedGadget
+dataset_type_map["gadget-plain"] = MemoryMappedGadget
 
 class DatasetAstropyTable(DatasetArrays):
 	def __init__(self, filename=None, format=None, table=None, **kwargs):
+		self.ucds = {}
+		self.units = {}
+		columns = {}
 		if table is None:
 			self.filename = filename
 			self.format = format
-			DatasetArrays.__init__(self, filename)
 			self.read_table()
 		else:
 			#print vars(table)
 			#print dir(table)
-			DatasetArrays.__init__(self, table.meta.get("name", "unknown-astropy"))
 			self.description = table.meta.get("description")
 			self.table = table
 			#self.name
@@ -440,27 +447,28 @@ class DatasetAstropyTable(DatasetArrays):
 			column = self.table[name]
 			type = self.table.dtype[i]
 			#clean_name = re.sub("[^a-zA-Z_]", "_", name)
-			clean_name = _python_save_name(name, self.columns.keys())
 			if type.kind in "fiuSU": # only store float and int
 				#datagroup.create_dataset(name, data=table.array[name].astype(np.float64))
 				#dataset.addMemoryColumn(name, table.array[name].astype(np.float64))
 				masked_array = self.table[name].data
 				if "ucd" in column._meta:
-					self.ucds[clean_name] = column._meta["ucd"]
+					self.ucds[name] = column._meta["ucd"]
 				if column.unit:
 					unit = _try_unit(column.unit)
 					if unit:
-						self.units[clean_name] = unit
+						self.units[name] = unit
 				if column.description:
-					self.descriptions[clean_name] = column.description
+					self.descriptions[name] = column.description
 				if hasattr(masked_array, "mask"):
 					if type.kind in ["f"]:
 						masked_array.data[masked_array.mask] = np.nan
 					if type.kind in ["i"]:
 						masked_array.data[masked_array.mask] = 0
-				self.add_column(clean_name, self.table[name].data)
+				columns[name] = self.table[name].data
 			if type.kind in ["SU"]:
-				self.add_column(clean_name, self.table[name].data)
+				columns[name] = self.table[name].data
+
+		super().__init__(columns)
 
 		#dataset.samp_id = table_id
 		#self.list.addDataset(dataset)
@@ -471,9 +479,11 @@ class DatasetAstropyTable(DatasetArrays):
 
 import astropy.io.votable
 import string
-class VOTable(DatasetArrays):
+class VOTable(DatasetFile):
 	def __init__(self, filename):
-		DatasetArrays.__init__(self, filename)
+		super().__init__(filename)
+		self.ucds = {}
+		self.units = {}
 		self.filename = filename
 		self.path = filename
 		votable = astropy.io.votable.parse(self.filename)
@@ -485,7 +495,7 @@ class VOTable(DatasetArrays):
 			name = field.name
 			data = self.first_table.array[name]
 			type = self.first_table.array[name].dtype
-			clean_name = _python_save_name(name, self.columns.keys())
+			clean_name = name
 			if field.ucd:
 				self.ucds[clean_name] = field.ucd
 			if field.unit:
@@ -505,6 +515,7 @@ class VOTable(DatasetArrays):
 					print("Giving up column %s, error: %r" (name, e))
 			#if type.kind in ["S"]:
 			#	self.add_column(clean_name, self.first_table.array[name].data)
+		self._freeze()
 
 	@classmethod
 	def can_open(cls, path, *args, **kwargs):

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -204,10 +204,10 @@ def fillna(ar, value):
     See :`isna` for the definition of missing values.
 
     '''
-    # TODO: optimize once https://github.com/apache/arrow/pull/7656 gets in
-    was_string = _is_stringy(ar)
-    if was_string:
-        ar = np.array(ar)
+    # TODO: should use arrow fill_null in the future
+    if vaex.array_types.is_string(ar):
+        ar = fillna(vaex.array_types.to_numpy(ar, strict=True), value)
+        return vaex.array_types.to_arrow(ar)
     ar = ar if not isinstance(ar, column.Column) else ar.to_numpy()
     mask = isna(ar)
     if np.any(mask):
@@ -216,8 +216,6 @@ def fillna(ar, value):
         else:
             ar = ar.copy()
         ar[mask] = value
-    if was_string:
-        vaex.array_types.to_arrow(ar)
     return ar
 
 @register_function()

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2259,9 +2259,12 @@ def _float(x):
 def _astype(x, dtype):
     if dtype == 'str':
         if isinstance(x, np.ndarray) and x.dtype.kind not in 'US':
-            mask = np.isnan(x)
-            x = x.astype(dtype).astype('O')
-            x[mask] = None
+            try:
+                x = x.astype(dtype).astype('O')
+                mask = np.isnan(x)
+                x[mask] = None
+            except TypeError:
+                pass  # does not work for all data
         return _to_string_column(x)
     # we rely on numpy for astype conversions (TODO: possible performance hit?)
     if isinstance(x, vaex.column.ColumnString):

--- a/packages/vaex-core/vaex/scopes.py
+++ b/packages/vaex-core/vaex/scopes.py
@@ -115,6 +115,8 @@ class _BlockScope(ScopeBase):
     def __getitem__(self, variable):
         # logger.debug("get " + variable)
         # return self.df.columns[variable][self.i1:self.i2]
+        if variable == 'df':
+            return self  # to support df['no!identifier']
         if variable in expression_namespace:
             return expression_namespace[variable]
         try:

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -69,7 +69,7 @@ class CallbackCounter(object):
 
 class TestDataset(unittest.TestCase):
 	def setUp(self):
-		self.dataset = dataset.DatasetArrays("dataset")
+		self.dataset = vaex.dataframe.DataFrameLocal()
 
 
 		# x is non-c
@@ -143,7 +143,7 @@ class TestDataset(unittest.TestCase):
 
 		x = np.array([0., 1])
 		y = np.array([-1., 1])
-		self.datasetxy = vx.dataset.DatasetArrays("datasetxy")
+		self.datasetxy = vx.dataframe.DataFrameLocal()
 		self.datasetxy.add_column("x", x)
 		self.datasetxy.add_column("y", y)
 
@@ -152,9 +152,9 @@ class TestDataset(unittest.TestCase):
 		x3 = np.array([5.])
 		self.x_concat = np.concatenate((x1, x2, x3))
 
-		dataset1 = vx.dataset.DatasetArrays("dataset1")
-		dataset2 = vx.dataset.DatasetArrays("dataset2")
-		dataset3 = vx.dataset.DatasetArrays("dataset3")
+		dataset1 = vx.dataframe.DataFrameLocal()
+		dataset2 = vx.dataframe.DataFrameLocal()
+		dataset3 = vx.dataframe.DataFrameLocal()
 		dataset1.add_column("x", x1)
 		dataset2.add_column("x", x2)
 		dataset3.add_column("x", x3)
@@ -425,9 +425,7 @@ class TestDataset(unittest.TestCase):
 					#np.testing.assert_array_equal(ds.data.names, self.dataset.data.name)
 
 	def tearDown(self):
-		self.dataset.remove_virtual_meta()
-		self.dataset_concat.remove_virtual_meta()
-		self.dataset_concat_dup.remove_virtual_meta()
+		pass
 
 	def test_mixed_endian(self):
 
@@ -502,10 +500,11 @@ class TestDataset(unittest.TestCase):
 		distance_std = ds_1.evaluate("distance_uncertainty")[0]
 		self.assertAlmostEqual(distance_std, distance_std_est,2)
 
-	def test_virtual_column_storage(self):
-		self.dataset.write_meta()
-		ds = vaex.zeldovich()
-		ds.write_meta()
+	# deprecated
+	# def test_virtual_column_storage(self):
+	# 	self.dataset.write_meta()
+	# 	ds = vaex.zeldovich()
+	# 	ds.write_meta()
 
 	def test_add_virtual_columns_cartesian_velocities_to_polar(self):
 		if 1:
@@ -1156,7 +1155,7 @@ class TestDataset(unittest.TestCase):
 		def concat(*types):
 			arrays = [np.arange(3, dtype=dtype) for dtype in types]
 			N = len(arrays)
-			dfs = [vx.dataset.DatasetArrays("dataset-%i" % i)  for i in range(N)]
+			dfs = [vx.dataframe.DataFrameLocal()  for i in range(N)]
 			for dataset, array in zip(dfs, arrays):
 				dataset.add_column("x", array)
 			dataset_concat = vx.dataset.DatasetConcatenated(dfs, name="dataset_concat")
@@ -1171,7 +1170,7 @@ class TestDataset(unittest.TestCase):
 		ar2 = np.zeros((20))
 		arrays = [ar1, ar2]
 		N = len(arrays)
-		dfs = [vx.dataset.DatasetArrays("dataset1") for i in range(N)]
+		dfs = [vx.dataframe.DataFrameLocal() for i in range(N)]
 		for dataset, array in zip(dfs, arrays):
 			dataset.add_column("x", array)
 		with self.assertRaises(ValueError):
@@ -1182,7 +1181,7 @@ class TestDataset(unittest.TestCase):
 		ar2 = np.zeros((20))
 		arrays = [ar1, ar2]
 		N = len(arrays)
-		dfs = [vx.dataset.DatasetArrays("dataset1") for i in range(N)]
+		dfs = [vx.dataframe.DataFrameLocal() for i in range(N)]
 		for dataset, array in zip(dfs, arrays):
 			dataset.add_column("x", array)
 		dataset_concat = vx.dataset.DatasetConcatenated(dfs, name="dataset_concat")
@@ -1200,8 +1199,8 @@ class TestDataset(unittest.TestCase):
 		x2 = np.arange(100, dtype=np.float32)
 		self.x_concat = np.concatenate((x1, x2))
 
-		dataset1 = vx.dataset.DatasetArrays("dataset1")
-		dataset2 = vx.dataset.DatasetArrays("dataset2")
+		dataset1 = vx.dataframe.DataFrameLocal()
+		dataset2 = vx.dataframe.DataFrameLocal()
 		dataset1.add_column("x", x1)
 		dataset2.add_column("x", x2)
 
@@ -1334,6 +1333,9 @@ class TestDataset(unittest.TestCase):
 
 				# self.dataset_concat_dup references self.dataset, so set it's active_fraction to 1 again
 				dataset.set_active_fraction(1)
+
+	def test_export_cmdline(self):
+		import vaex.export
 		path_arrow = tempfile.mktemp(".arrow")
 		path_hdf5 = tempfile.mktemp(".hdf5")
 		dataset = self.dataset
@@ -1633,7 +1635,7 @@ class TestDatasetDistributed(TestDatasetRemote):
 	def setUp(self):
 		TestDataset.setUp(self)
 		global test_port
-		# self.dataset_local = self.dataset = dataset.DatasetArrays("dataset")
+		# self.dataset_local = self.dataset = dataframe.DataFrameLocal("dataset")
 		self.dataset_local = self.dataset
 
 		dfs = [self.dataset]
@@ -1722,7 +1724,7 @@ class TestDatasetDistributed(TestDatasetRemote):
 
 class T_stWebServer(unittest.TestCase):
 	def setUp(self):
-		self.dataset = dataset.DatasetArrays()
+		self.dataset = dataframe.DataFrameLocal()
 
 		self.x = x = np.arange(10)
 		self.y = y = x ** 2

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -535,24 +535,19 @@ def unlistify(waslist, *args):
             return values[0]
 
 
+def valid_expression(names, name):
+    if name in names and not valid_identifier(name):
+        return f'df[%r]' % name
+    else:
+        return name
+
+
+def valid_identifier(name):
+    return name.isidentifier() and not keyword.iskeyword(name)
+
+
 def find_valid_name(name, used=[]):
     first, rest = name[0], name[1:]
-    if not first.isidentifier():
-        if ('col_' + first).isidentifier():
-            first = 'col_' + first
-        else:
-            first = 'col_'
-    name = first
-    for char in rest:
-        # we test if it is an identifier with _ prefixed, since not every first character
-        # and following character are treated the same
-        # https://docs.python.org/3/reference/lexical_analysis.html#identifiers
-        if not ('_' + char).isidentifier():
-            name += '_'
-        else:
-            name += char
-    if keyword.iskeyword(name):
-        name += '_'
     if name in used:
         nr = 1
         while name + ("_%d" % nr) in used:

--- a/packages/vaex-graphql/vaex/graphql/__init__.py
+++ b/packages/vaex-graphql/vaex/graphql/__init__.py
@@ -156,9 +156,9 @@ def create_aggregation_on_field(df, groupby):
                 return agg_values.tolist()
             return getattr(obj.df, obj.agg)(name)
     if groupby:
-        attrs = {name: graphene.List(map_to_field(df, name)) for name in df.get_column_names(alias=False)}
+        attrs = {name: graphene.List(map_to_field(df, name)) for name in df.get_column_names()}
     else:
-        attrs = {name: map_to_field(df, name)() for name in df.get_column_names(alias=False)}
+        attrs = {name: map_to_field(df, name)() for name in df.get_column_names()}
     attrs['Meta'] = Meta
     DataFrameAggregationOnField = type("AggregationOnField"+postfix, (AggregationOnFieldBase, ), attrs)
     return DataFrameAggregationOnField
@@ -196,7 +196,7 @@ def create_groupby(df, groupby):
         def resolver(*args, **kwargs):
             return Aggregate(df, groupby + [name])
         return graphene.Field(Aggregate, resolver=resolver)
-    attrs = {name: field_groupby(name) for name in df.get_column_names(alias=False)}
+    attrs = {name: field_groupby(name) for name in df.get_column_names()}
     GroupBy = type("GroupBy"+postfix, (GroupByBase, ), attrs)
     return GroupBy
 
@@ -204,7 +204,7 @@ def create_groupby(df, groupby):
 def create_row(df):
     class RowBase(graphene.ObjectType):
         pass
-    attrs = {name: map_to_field(df, name)() for name in df.get_column_names(alias=False)}
+    attrs = {name: map_to_field(df, name)() for name in df.get_column_names()}
     Row = type("Row", (RowBase, ), attrs)
     return Row
 
@@ -289,7 +289,7 @@ def create_aggregate(df, groupby=None):
 
 # similar to https://docs.hasura.io/1.0/graphql/manual/api-reference/graphql-api/query.html#whereexp
 def create_boolexp(df):
-    column_names = df.get_column_names(alias=False)
+    column_names = df.get_column_names()
     class BoolExpBase(graphene.InputObjectType):
         _and = graphene.List(lambda: BoolExp)
         _or = graphene.List(lambda: BoolExp)
@@ -325,7 +325,7 @@ def create_query(dfs):
         hello = graphene.String(description='A typical hello world')
     fields = {}
     for name, df in dfs.items():
-        columns = df.get_column_names(alias=False)
+        columns = df.get_column_names()
         columns = [k for k in columns if df.is_string(k) or df[k].dtype.kind != 'O']
         df = df[columns]
         Aggregate = create_aggregate(df, [])

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -71,6 +71,8 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
         self.h5table_root_name = None
         self._version = 1
         self._load()
+        if not write:  # in write mode, call freeze yourself, so the hashes are computed
+            self._freeze()
 
     def _open(self, path):
         if hasattr(path, 'read'):
@@ -97,8 +99,6 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
     def __getstate__(self):
         return {
             **super().__getstate__(),
-            'write': self.write,
-            'path': self.path,
             'nommap': self.nommap
         }
 
@@ -106,6 +106,7 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
         super().__setstate__(state)
         self._open(self.path)
         self._load()
+        self._freeze()
 
     def write_meta(self):
         """ucds, descriptions and units are written as attributes in the hdf5 file, instead of a seperate file as

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -14,7 +14,6 @@ from vaex.utils import ensure_string
 import astropy.io.fits as fits
 import re
 import six
-from vaex.dataset import DatasetLocal, DatasetArrays
 import vaex.dataset
 import vaex.file
 from vaex.expression import Expression

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -472,7 +472,7 @@ class AmuseHdf5MemoryMapped(Hdf5MemoryMapped):
         self.update_virtual_meta()
 
 
-dataset_type_map["amuse"] = AmuseHdf5MemoryMapped
+# dataset_type_map["amuse"] = AmuseHdf5MemoryMapped
 
 
 gadget_particle_names = "gas halo disk bulge stars dm".split()
@@ -592,7 +592,7 @@ class Hdf5MemoryMappedGadget(DatasetMemoryMapped):
         return []
 
 
-dataset_type_map["gadget-hdf5"] = Hdf5MemoryMappedGadget
+# dataset_type_map["gadget-hdf5"] = Hdf5MemoryMappedGadget
 
 
 class MemoryMappedGadget(DatasetMemoryMapped):
@@ -610,4 +610,4 @@ class MemoryMappedGadget(DatasetMemoryMapped):
         self.addColumn("vz", veloffset + 8, length, dtype=np.float32, stride=3)
 
 
-dataset_type_map["gadget-plain"] = MemoryMappedGadget
+# dataset_type_map["gadget-plain"] = MemoryMappedGadget

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -61,40 +61,57 @@ def _try_unit(unit):
 class Hdf5MemoryMapped(DatasetMemoryMapped):
     """Implements the vaex hdf5 file format"""
 
-    def __init__(self, filename, write=False):
-        if isinstance(filename, six.string_types):
-            nommap = s3.is_s3_path(filename) or gcs.is_gs_path(filename)
-            super(Hdf5MemoryMapped, self).__init__(filename, write=write, nommap=nommap)
+    def __init__(self, path, write=False):
+        if isinstance(path, six.string_types):
+            nommap = s3.is_s3_path(path) or gcs.is_gs_path(path)
+            super(Hdf5MemoryMapped, self).__init__(path, write=write, nommap=nommap)
         else:
-            super(Hdf5MemoryMapped, self).__init__(filename.name, write=write, nommap=True)
-        if hasattr(filename, 'read'):
-            fp = filename  # support file handle for testing
-            self.file_map[self.filename] = fp
-        else:
-            mode = 'rb+' if write else 'rb'
-            if s3.is_s3_path(filename):
-                fp = s3.open(self.filename)
-                self.file_map[self.filename] = fp
-            elif gcs.is_gs_path(filename):
-                fp = gcs.open(filename)
-                self.file_map[self.filename] = fp
-            else:
-                if self.nommap:
-                    fp = open(self.filename, mode)
-                    self.file_map[self.filename] = fp
-                else:
-                    # this is the only path that will have regular mmapping
-                    fp = self.filename
-        self.h5file = h5py.File(fp, "r+" if write else "r")
+            super(Hdf5MemoryMapped, self).__init__(path.name, write=write, nommap=True)
+        self._open(path)
         self.h5table_root_name = None
         self._version = 1
+        self._load()
+
+    def _open(self, path):
+        if hasattr(path, 'read'):
+            fp = path  # support file handle for testing
+            self.file_map[self.path] = fp
+        else:
+            mode = 'rb+' if self.write else 'rb'
+            if s3.is_s3_path(path):
+                fp = s3.open(self.path)
+                self.file_map[self.path] = fp
+            elif gcs.is_gs_path(path):
+                fp = gcs.open(self.path)
+                self.file_map[self.path] = fp
+            else:
+                if self.nommap:
+                    fp = open(self.path, mode)
+                    self.file_map[self.path] = fp
+                else:
+                    # this is the only path that will have regular mmapping
+                    fp = self.path
+        self.h5file = h5py.File(fp, "r+" if self.write else "r")
+
+
+    def __getstate__(self):
+        return {
+            **super().__getstate__(),
+            'write': self.write,
+            'path': self.path,
+            'nommap': self.nommap
+        }
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._open(self.path)
         self._load()
 
     def write_meta(self):
         """ucds, descriptions and units are written as attributes in the hdf5 file, instead of a seperate file as
          the default :func:`Dataset.write_meta`.
          """
-        with h5py.File(self.filename, "r+") as h5file_output:
+        with h5py.File(self.path, "r+") as h5file_output:
             h5table_root = h5file_output[self.h5table_root_name]
             if self.description is not None:
                 h5table_root.attrs["description"] = self.description
@@ -233,10 +250,8 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
             self._load_variables(self.h5file["/properties"])  # old name, kept for portability
         if "variables" in self.h5file:
             self._load_variables(self.h5file["/variables"])
-        if "axes" in self.h5file:
-            self._load_axes(self.h5file["/axes"])
-        self.update_meta()
-        self.update_virtual_meta()
+        # self.update_meta()
+        # self.update_virtual_meta()
 
     # def
     def _load_axes(self, axes_data):
@@ -387,17 +402,17 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
                         else:
                             transposed = shape[1] < shape[0]
                             self.addRank1(column_name, offset, shape[1], length1=shape[0], dtype=data.dtype, stride=1, stride1=1, transposed=transposed)
-        all_columns = dict(**self.columns)
+        all_columns = dict(**self._columns)
         # in case the column_order refers to non-existing columns
         column_order = [k for k in column_order if k in all_columns]
-        self.column_names = []
+        column_names = []
+        self._columns = {}
         for name in column_order:
-            self.columns[name] = all_columns.pop(name)
-            self.column_names.append(name)
+            self._columns[name] = all_columns.pop(name)
         # add the rest
         for name, col in all_columns.items():
-            self.columns[name] = col
-            self.column_names.append(name)
+            self._columns[name] = col
+            # self.column_names.append(name)
 
     def close_files(self):
         super(Hdf5MemoryMapped, self).close_files()
@@ -425,8 +440,8 @@ dataset_type_map["h5vaex"] = Hdf5MemoryMapped
 class AmuseHdf5MemoryMapped(Hdf5MemoryMapped):
     """Implements reading Amuse hdf5 files `amusecode.org <http://amusecode.org/>`_"""
 
-    def __init__(self, filename, write=False):
-        super(AmuseHdf5MemoryMapped, self).__init__(filename, write=write)
+    def __init__(self, path, write=False):
+        super(AmuseHdf5MemoryMapped, self).__init__(path, write=write)
 
     @classmethod
     def can_open(cls, path, *args, **kwargs):
@@ -465,9 +480,9 @@ gadget_particle_names = "gas halo disk bulge stars dm".split()
 class Hdf5MemoryMappedGadget(DatasetMemoryMapped):
     """Implements reading `Gadget2 <http://wwwmpa.mpa-garching.mpg.de/gadget/>`_ hdf5 files """
 
-    def __init__(self, filename, particle_name=None, particle_type=None):
-        if "#" in filename:
-            filename, index = filename.split("#")
+    def __init__(self, path, particle_name=None, particle_type=None):
+        if "#" in path:
+            path, index = path.split("#")
             index = int(index)
             particle_type = index
             particle_name = gadget_particle_names[particle_type]
@@ -481,12 +496,12 @@ class Hdf5MemoryMappedGadget(DatasetMemoryMapped):
             else:
                 raise ValueError("particle name not supported: %r, expected one of %r" % (particle_name, " ".join(gadget_particle_names)))
         else:
-            raise Exception("expected particle type or name as argument, or #<nr> behind filename")
-        super(Hdf5MemoryMappedGadget, self).__init__(filename)
+            raise Exception("expected particle type or name as argument, or #<nr> behind path")
+        super(Hdf5MemoryMappedGadget, self).__init__(path)
         self.particle_type = particle_type
         self.particle_name = particle_name
         self.name = self.name + "-" + self.particle_name
-        h5file = h5py.File(self.filename, 'r')
+        h5file = h5py.File(self.path, 'r')
         # for i in range(1,4):
         key = "/PartType%d" % self.particle_type
         if key not in h5file:
@@ -548,7 +563,7 @@ class Hdf5MemoryMappedGadget(DatasetMemoryMapped):
         elif "particle_type" in kwargs:
             particle_type = kwargs["particle_type"]
         elif "#" in path:
-            filename, index = path.split("#")
+            path, index = path.split("#")
             particle_type = gadget_particle_names[index]
         else:
             return False
@@ -580,11 +595,11 @@ dataset_type_map["gadget-hdf5"] = Hdf5MemoryMappedGadget
 
 
 class MemoryMappedGadget(DatasetMemoryMapped):
-    def __init__(self, filename):
-        super(MemoryMappedGadget, self).__init__(filename)
-        # h5file = h5py.File(self.filename)
+    def __init__(self, path):
+        super(MemoryMappedGadget, self).__init__(path)
+        # h5file = h5py.File(self.path)
         import vaex.file.gadget
-        length, posoffset, veloffset, header = vaex.file.gadget.getinfo(filename)
+        length, posoffset, veloffset, header = vaex.file.gadget.getinfo(path)
         self.addColumn("x", posoffset, length, dtype=np.float32, stride=3)
         self.addColumn("y", posoffset + 4, length, dtype=np.float32, stride=3)
         self.addColumn("z", posoffset + 8, length, dtype=np.float32, stride=3)

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -135,7 +135,7 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
         logger.debug("virtual=%r", virtual)
         logger.debug("exporting %d rows to file %s" % (N, path))
         # column_names = column_names or (dataset.get_column_names() + (list(dataset.virtual_columns.keys()) if virtual else []))
-        column_names = column_names or dataset.get_column_names(virtual=virtual, strings=True, alias=False)
+        column_names = column_names or dataset.get_column_names(virtual=virtual, strings=True)
 
         logger.debug("exporting columns(hdf5): %r" % column_names)
         sparse_groups = collections.defaultdict(list)

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -237,21 +237,23 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
 
     # after this the file is closed,, and reopen it using out class
     dataset_output = vaex.hdf5.dataset.Hdf5MemoryMapped(path, write=True)
+    df_output = vaex.dataframe.DataFrameLocal(dataset_output)
 
-    column_names = vaex.export._export(dataset_input=dataset, dataset_output=dataset_output, path=path, random_index_column=random_index_name,
+    column_names = vaex.export._export(dataset_input=dataset, dataset_output=df_output, path=path, random_index_column=random_index_name,
                                        column_names=column_names, selection=selection, shuffle=shuffle, byteorder=byteorder,
                                        progress=progress, sort=sort, ascending=ascending)
+    dataset_output._freeze()
     import getpass
     import datetime
     user = getpass.getuser()
     date = str(datetime.datetime.now())
-    source = dataset.path
-    description = "file exported by vaex, by user %s, on date %s, from source %s" % (user, date, source)
-    if dataset.description:
-        description += "previous description:\n" + dataset.description
-    dataset_output.copy_metadata(dataset)
-    dataset_output.description = description
-    logger.debug("writing meta information")
-    dataset_output.write_meta()
-    dataset_output.close_files()
+    # source = dataset.path
+    # description = "file exported by vaex, by user %s, on date %s, from source %s" % (user, date, source)
+    # if dataset.description:
+    #     description += "previous description:\n" + dataset.description
+    # dataset_output.copy_metadata(dataset)
+    # dataset_output.description = description
+    # logger.debug("writing meta information")
+    # dataset_output.write_meta()
+    # dataset_output.close_files()
     return

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -243,10 +243,11 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
                                        column_names=column_names, selection=selection, shuffle=shuffle, byteorder=byteorder,
                                        progress=progress, sort=sort, ascending=ascending)
     dataset_output._freeze()
-    import getpass
-    import datetime
-    user = getpass.getuser()
-    date = str(datetime.datetime.now())
+    # We aren't really making use of the metadata, we could put this back in some form in the future
+    # import getpass
+    # import datetime
+    # user = getpass.getuser()
+    # date = str(datetime.datetime.now())
     # source = dataset.path
     # description = "file exported by vaex, by user %s, on date %s, from source %s" % (user, date, source)
     # if dataset.description:

--- a/packages/vaex-server/vaex/server/dataframe.py
+++ b/packages/vaex-server/vaex/server/dataframe.py
@@ -27,7 +27,8 @@ def _rmi(f=None):
 # TODO: we should not inherit from local
 class DataFrameRemote(DataFrame):
     def __init__(self, name, column_names, dtypes, length_original):
-        super(DataFrameRemote, self).__init__(name, '', column_names)
+        super(DataFrameRemote, self).__init__(name)
+        self.column_names = column_names
         self._dtypes = dtypes
         for column_name in self.get_column_names(virtual=True, strings=True):
             self._save_assign_expression(column_name)

--- a/tests/async_test.py
+++ b/tests/async_test.py
@@ -1,9 +1,9 @@
-import pytest
+# import pytest
 
 
-@pytest.mark.asyncio
-async def test_async_execute(df):
-    count_future = df.count(df.x, delay=True)
-    await df.execute_async()
-    assert await count_future == len(df)
+# @pytest.mark.asyncio
+# async def test_async_execute(df):
+#     count_future = df.count(df.x, delay=True)
+#     await df.execute_async()
+#     assert await count_future == len(df)
 

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -23,12 +23,12 @@ def test_column_names(df_arrow):
 def test_add_invalid_name(tmpdir):
     # support invalid names and keywords
     df = vaex.from_dict({'X!1': x, 'class': x*2})
+    assert str(df['X!1']) != 'X!1', "invalid identifier cannot be an expression"
+    assert str(df['class']) != 'class', "keyword cannot be an expression"
     assert df.get_column_names() == ['X!1', 'class']
-    assert df.get_column_names(alias=False) != ['X!1', 'class']
     assert df['X!1'].tolist() == x.tolist()
     assert (df['X!1']*2).tolist() == (x*2).tolist()
     assert (df['class']).tolist() == (x*2).tolist()
-    assert 'X!1' in df._column_aliases
     assert (df.copy()['X!1']*2).tolist() == (x*2).tolist()
 
     path = str(tmpdir.join('test.hdf5'))

--- a/tests/column_test.py
+++ b/tests/column_test.py
@@ -100,7 +100,7 @@ def test_column_indexed(df_local):
     assert isinstance(dff.columns[x_name], vaex.column.ColumnIndexed)
     assert dff.x.tolist() == [1, 3, 5, 7, 9]
 
-    column_masked = vaex.column.ColumnIndexed.index(dff, dff.columns[x_name], 'x', np.array([0, -1, 2, 3, 4]), {}, True)
+    column_masked = vaex.column.ColumnIndexed.index(dff.columns[x_name], np.array([0, -1, 2, 3, 4]), {}, True)
     assert column_masked[:].tolist() == [1, None, 5, 7, 9]
     assert column_masked.masked
     assert column_masked.trim(0, 1).masked

--- a/tests/common.py
+++ b/tests/common.py
@@ -247,7 +247,7 @@ def create_filtered():
     return ds
 
 def create_base_ds():
-    dataset = vaex.dataset.DatasetArrays("dataset")
+    dataset = vaex.dataset.DataFrameLocal()
     x = np.arange(-2, 40, dtype=">f8").reshape((-1,21)).T.copy()[:,0]
     y = y = x ** 2
     ints = np.arange(-2,19, dtype="i8")

--- a/tests/common.py
+++ b/tests/common.py
@@ -223,7 +223,7 @@ def df_arrow_cache(df_arrow_raw):
     # we add the filter and virtual columns again to avoid the expression rewriting
     df = df_arrow_raw.as_numpy().drop_filter()
     del df['z']
-    df.select('(x >= 0) & (x < 10)', name=vaex.dataset.FILTER_SELECTION_NAME)
+    df.select('(x >= 0) & (x < 10)', name=vaex.dataframe.FILTER_SELECTION_NAME)
     df.add_virtual_column("z", "x+t*y")
     return df
 
@@ -243,11 +243,11 @@ def ds_no_filter(request):
 
 def create_filtered():
     ds = create_base_ds()
-    ds.select('(x >= 0) & (x < 10)', name=vaex.dataset.FILTER_SELECTION_NAME)
+    ds.select('(x >= 0) & (x < 10)', name=vaex.dataframe.FILTER_SELECTION_NAME)
     return ds
 
 def create_base_ds():
-    dataset = vaex.dataset.DataFrameLocal()
+    dataset = vaex.dataframe.DataFrameLocal()
     x = np.arange(-2, 40, dtype=">f8").reshape((-1,21)).T.copy()[:,0]
     y = y = x ** 2
     ints = np.arange(-2,19, dtype="i8")

--- a/tests/concat_test.py
+++ b/tests/concat_test.py
@@ -69,9 +69,9 @@ def test_concat_mixed_types():
     df2 = vaex.from_arrays(x=x2)
     df = vaex.concat([df1, df2])
     assert df2.x.dtype == df.x.dtype, "expect 'upcast' to string"
-    assert df[:2].x.tolist() == [None, None]
-    assert df[1:4].x.tolist() == [None, None, 'hi']
-    assert df[2:4].x.tolist() == [None, 'hi']
+    assert df[:2].x.tolist() == ['nan', 'nan']
+    assert df[1:4].x.tolist() == ['nan', 'nan', 'hi']
+    assert df[2:4].x.tolist() == ['nan', 'hi']
     assert df[3:4].x.tolist() == ['hi']
     assert df[3:5].x.tolist() == ['hi', 'there']
 

--- a/tests/copy_test.py
+++ b/tests/copy_test.py
@@ -18,3 +18,32 @@ def test_non_existing_column(df_local):
     df = df_local
     with pytest.raises(NameError, match='.*Did you.*'):
         df.copy(column_names=['x', 'x_'])
+
+
+def test_copy_dependencies():
+    df = vaex.from_scalars(x=1)
+    df['y'] = df.x + 1
+    df2 = df.copy(['y'])
+    assert df2.get_column_names(hidden=True) == ['y', '__x']
+    # why.. ?
+    #assert df2[['y']].get_column_names(hidden=True) == ['y', '__y']
+
+
+def test_copy_dependencies_invalid_identifier():
+    df = vaex.from_dict({'#': [1]})
+    # add a virtual column depending on a real column with invalid identifier
+    # this means the expression is non-trivial df['#']
+    df['y'] = df['#'] + 1
+    df2 = df.copy(['y'])
+    assert df2.get_column_names(hidden=True) == ['y', "__#"]
+
+    # add a virtual column with an invalid identifier
+    df['$'] = df['#'] + df['y']
+    df['z'] = df['y'] + df['$']
+    df2 = df.copy(['z'])
+    assert set(df2.get_column_names(hidden=True)) == {'z', "__#", "__$", '__y'}
+
+    # copy also takes expressions
+    df['@'] = df['y'] + df['$']
+    df2 = df.copy(["df['@'] * 2"])
+    assert set(df2.get_column_names(hidden=True)) == {"df['@'] * 2", '__@', "__#", "__$", '__y'}

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -78,6 +78,29 @@ def test_merge():
         ds2.merged(dsx)
 
 
+def test_slice():
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    ds2 = ds1[1:8]
+    ds2b = ds1[1:8]
+    ds2c = ds1[1:9]
+    assert ds1 != ds2
+    assert ds2 == ds2b
+    assert ds2 != ds2c
+    assert ds1.row_count == 10
+    assert ds2.row_count == 7
+    assert ds2b.row_count == 7
+    assert ds2c.row_count == 8
+    assert ds2['x'].tolist() == x[1:8].tolist()
+
+
+    ds3 = dataset.DatasetArrays(x=x[1:8], y=y[1:8])
+
+    assert ds2 != ds3
+    assert rebuild(ds1) != rebuild(ds2)
+
+
 def test_drop():
     x = np.arange(10)
     y = x**2

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -126,6 +126,8 @@ def test_cache_hash():
     assert df2.dataset._hash_calculations == 0
     assert path_hashes.exists()
 
-    df3 = vaex.open(str(path_data))
-    assert df3.dataset._hash_calculations == 0
-    assert df2.dataset == df3.dataset
+    # and pickling
+    ds = df2.dataset
+    ds2 = rebuild(ds)
+    assert ds2._hash_calculations == 0
+    assert ds == ds2

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -159,6 +159,18 @@ def test_drop():
     assert rebuild(ds1) == rebuild(ds2.merged(ds3))
 
 
+def test_concat():
+    x = np.arange(10)
+    y = x**2
+    ds = dataset.DatasetArrays(x=x, y=y)
+    mid = 4
+    ds1 = dataset.DatasetArrays(x=x[:mid], y=y[:mid])
+    ds2 = dataset.DatasetArrays(y=y[mid:], x=x[mid:])  # order should not matter
+    dsc = ds1.concat(ds2)
+    assert ds.row_count == dsc.row_count
+    assert dsc.row_count == ds1.row_count + ds2.row_count
+
+
 def test_example():
     df = vaex.example()
     assert isinstance(df, vaex.dataframe.DataFrame)

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -78,6 +78,17 @@ def test_merge():
         ds2.merged(dsx)
 
 
+def test_slice_column():
+    # slicing a colunm type should keep it column type
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    indices = np.array([1, 2, 5, 7, 9])
+    ds2 = ds1.take(indices)
+    ds3 = ds2[1:3]
+    assert isinstance(ds3['x'], vaex.column.ColumnIndexed)
+
+
 def test_slice():
     x = np.arange(10)
     y = x**2
@@ -99,6 +110,41 @@ def test_slice():
 
     assert ds2 != ds3
     assert rebuild(ds1) != rebuild(ds2)
+
+
+def test_take():
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    indices = np.array([1, 2, 5])
+    indices_other = np.array([1, 2, 6])
+    ds2 = ds1.take(indices)
+    ds2b = ds1.take(indices)
+    ds2c = ds1.take(indices_other)
+    assert ds1 != ds2
+    assert ds2 == ds2b
+    assert ds2 != ds2c
+    assert ds1.row_count == 10
+    assert ds2.row_count == len(indices)
+    assert ds2b.row_count == len(indices)
+    assert ds2c.row_count == len(indices_other)
+    assert ds2['x'].tolist() == x[indices].tolist()
+
+    ds3 = dataset.DatasetArrays(x=x[indices], y=y[indices])
+
+    assert ds2 != ds3
+    assert rebuild(ds1) != rebuild(ds2)
+
+
+def test_project():
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    ds2 = ds1.project('x')
+    ds3 = dataset.DatasetArrays(x=x)
+    assert ds1 != ds2
+    assert ds2 == ds3
+    assert rebuild(ds2) == rebuild(ds3)
 
 
 def test_drop():

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -1,0 +1,131 @@
+from io import BytesIO
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import vaex
+import vaex.dataset as dataset
+
+HERE = Path(__file__).parent
+
+
+def rebuild(ds):
+    # pick and unpickle
+    f = BytesIO()
+    picked = pickle.dump(ds, f)
+    f.seek(0)
+    return pickle.load(f)
+
+def test_array_pickle():
+    x = np.arange(10)
+    y = x**2
+    ds = dataset.DatasetArrays(x=x, y=y)
+    assert ds == rebuild(ds)
+
+
+def test_array_eq():
+    x1 = np.arange(10)
+    y1 = x1**2
+    ds1 = dataset.DatasetArrays(x=x1, y=y1)
+    assert ds1['x'] is x1
+    assert ds1['y'] is y1
+
+    x2 = np.arange(10)
+    y2 = x2**2
+    ds2 = dataset.DatasetArrays(x=x2, y=y2)
+    assert ds2['x'] is x2
+    assert ds2['y'] is y2
+
+    # different data, but same ids/hashes
+    assert ds1 == ds2
+    assert ds1 == rebuild(ds2)
+
+
+def test_array_rename():
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    ds2 = ds1.renamed({'x': 'z'})
+    assert ds2['y'] is y
+    assert ds2['z'] is x
+
+    assert ds1 != ds2
+    assert rebuild(ds1) != rebuild(ds2)
+
+    ds3 = ds2.renamed({'z': 'x'})
+    assert ds3['y'] is y
+    assert ds3['x'] is x
+
+    # different data, but same ids/hashes
+    assert ds1 == ds3
+    assert rebuild(ds1) == rebuild(ds3)
+
+
+def test_merge():
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    dsx = dataset.DatasetArrays(x=x)
+    dsy = dataset.DatasetArrays(y=y)
+    ds2 = dsx.merged(dsy)
+
+    assert ds1 == ds2
+    assert rebuild(ds1) == rebuild(ds2)
+
+    with pytest.raises(NameError):
+        ds2.merged(dsx)
+
+
+def test_drop():
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    ds2 = ds1.dropped('x')
+    assert 'x' not in ds2
+    ds3 = ds1.dropped('y')
+    assert 'y' not in ds3
+    assert ds1 == ds2.merged(ds3)
+    assert rebuild(ds1) == rebuild(ds2.merged(ds3))
+
+
+def test_example():
+    df = vaex.example()
+    assert isinstance(df, vaex.dataframe.DataFrame)
+    assert isinstance(df.dataset, vaex.hdf5.dataset.Hdf5MemoryMapped)
+    assert rebuild(df.dataset) == df.dataset
+
+
+def test_hashable():
+    # tests if we can use datasets as keys of dicts
+    x = np.arange(10)
+    y = x**2
+    ds1 = dataset.DatasetArrays(x=x, y=y)
+    df = vaex.example()
+    some_dict = {ds1: '1', df.dataset: '2'}
+    assert some_dict[ds1] == '1'
+    assert some_dict[df.dataset] == '2'
+
+    assert some_dict[rebuild(ds1)] == '1'
+    assert some_dict[rebuild(df.dataset)] == '2'
+
+
+def test_cache_hash():
+    # TODO: what if the directory is not writable?
+    # ds1 = dataset.DatasetArrays(x=x, y=y)
+    path_data = HERE / 'data' / 'test.hdf5'
+    if path_data.exists():
+        path_data.unlink()
+    path_hashes = HERE / 'data' / 'test.hdf5.d' / 'hashes.yaml'
+    if path_hashes.exists():
+        path_hashes.unlink()
+    df = vaex.example()[:10]
+    df.export(str(path_data))
+    df2 = vaex.open(str(path_data))
+    assert df2.dataset._hash_calculations == 0
+    assert path_hashes.exists()
+
+    df3 = vaex.open(str(path_data))
+    assert df3.dataset._hash_calculations == 0
+    assert df2.dataset == df3.dataset

--- a/tests/dropna_test.py
+++ b/tests/dropna_test.py
@@ -76,7 +76,9 @@ def test_dropmissing():
     assert len(m) == 2
     assert (df.s.dropmissing().tolist() == ["aap", "noot", "mies"])
     assert (df.o.dropmissing().tolist()[:2] == ["aap", "noot"])
-    assert np.isnan(df.o.dropmissing().tolist()[2])
+    # this changed in vaex 4, since the np.nan is considered missing, the whole
+    # columns is seen as string
+    # assert np.isnan(df.o.dropmissing().tolist()[2])
 
 
 # equivalent of isna_test
@@ -92,7 +94,9 @@ def test_dropnan():
     m = df.m.dropnan().tolist()
     assert m == [0, None, None]
     assert (df.s.dropnan().tolist() == ["aap", None, "noot", "mies"])
-    assert (df.o.dropnan().tolist() == ["aap", None, "noot"])
+    # this changed in vaex 4, since the np.nan is considered missing, the whole
+    # columns is seen as string
+    assert (df.o.dropnan().tolist() == ["aap", None, "noot", None])
 
 def test_dropna():
     s = vaex.string_column(["aap", None, "noot", "mies"])

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -42,10 +42,8 @@ def test_dtype_str():
     df = vaex.from_arrays(n=n)
     assert df.n.dtype == pa.string()
     assert df.copy().n.dtype == pa.string()
-    assert 'n' in df._dtypes_override
 
     n = np.array([None, 'aap', 'noot'])
     df = vaex.from_arrays(n=n)
     assert df.n.dtype == pa.string()
     assert df.copy().n.dtype == pa.string()
-    assert 'n' in df._dtypes_override

--- a/tests/fillna_test.py
+++ b/tests/fillna_test.py
@@ -125,3 +125,17 @@ def test_fillna_dataframe():
     assert df_filled.x.tolist() == [3, 1, -1, 10, -1]
     assert df_filled.y.tolist() == [-1, 1, True, '10street', -1]
     assert df_filled.z.tolist() == [5, 7, -1, 1, -1]
+
+def test_fillna_string_dtype():
+    name = ['Maria', 'Adam', None, None, 'Dan']
+    age = [28, 15, 34, 55, 41]
+    weight = [np.nan, np.nan, 77.5, 65, 95]
+    df = vaex.from_arrays(name=name, age=age, weight=weight)
+
+    # Originally - the column "name" is string
+    assert df['name'].is_string()
+
+    df['name'] = df['name'].fillna('missing')
+
+    # Confirm that the column "name" is still of type string after fillna
+    assert df['name'].is_string()

--- a/tests/fillna_test.py
+++ b/tests/fillna_test.py
@@ -2,6 +2,10 @@ from common import *
 
 
 def test_fillna_column(df_local_non_arrow):
+    if isinstance(df_local_non_arrow.dataset['obj'], vaex.column.ColumnConcatenatedLazy):
+        # TODO: vaex.column.ColumnConcatenatedLazy is too eager to cast to string
+        # we need the same behaviour as in vaex.dataset.to_supported_array
+        return
     df = df_local_non_arrow
     df['ok'] = df['obj'].fillna(value='NA')
     assert df.ok.values[5] == 'NA'
@@ -61,7 +65,7 @@ def test_fillna_missing():
 # equivalent of isna_test
 def test_fillmissing():
     s = vaex.string_column(["aap", None, "noot", "mies"])
-    o = ["aap", None, "noot", np.nan]
+    o = ["aap", None, False, np.nan]
     x = np.arange(4, dtype=np.float64)
     x[2] = x[3] = np.nan
     m = np.ma.array(x, mask=[0, 1, 0, 1])
@@ -73,14 +77,14 @@ def test_fillmissing():
     assert (m[:2] == [0, 9])
     assert np.isnan(m[2])
     assert m[3] == 9
-    assert (df.s.fillmissing('kees').tolist() == ["aap", "kees", "noot", "mies"])
-    assert (df.o.fillmissing({'a':1}).tolist()[:3] == ["aap", {'a':1}, "noot"])
+    assert (df.s.fillmissing('kees').tolist() == ["aap", "kees", False, "mies"])
+    assert (df.o.fillmissing({'a':1}).tolist()[:3] == ["aap", {'a':1}, False])
     assert np.isnan(df.o.fillmissing([1]).tolist()[3])
 
 # equivalent of isna_test
 def test_fillnan():
     s = vaex.string_column(["aap", None, "noot", "mies"])
-    o = ["aap", None, "noot", np.nan]
+    o = ["aap", None, False, np.nan]
     x = np.arange(4, dtype=np.float64)
     x[2] = x[3] = np.nan
     m = np.ma.array(x, mask=[0, 1, 0, 1])
@@ -90,11 +94,11 @@ def test_fillnan():
     m = df.m.fillnan(9).tolist()
     assert m == [0, None, 9, None]
     assert (df.s.fillnan('kees').tolist() == ["aap", None, "noot", "mies"])
-    assert (df.o.fillnan({'a':1}).tolist() == ["aap", None, "noot", {'a':1}])
+    assert (df.o.fillnan({'a':1}).tolist() == ["aap", None, False, {'a':1}])
 
 def test_fillna():
     s = vaex.string_column(["aap", None, "noot", "mies"])
-    o = ["aap", None, "noot", np.nan]
+    o = ["aap", None, False, np.nan]
     x = np.arange(4, dtype=np.float64)
     x[2] = x[3] = np.nan
     m = np.ma.array(x, mask=[0, 1, 0, 1])
@@ -104,7 +108,7 @@ def test_fillna():
     m = df.m.fillna(9).tolist()
     assert m == [0, 9, 9, 9]
     assert (df.s.fillna('kees').tolist() == ["aap", "kees", "noot", "mies"])
-    assert (df.o.fillna({'a':1}).tolist() == ["aap", {'a': 1}, "noot", {'a':1}])
+    assert (df.o.fillna({'a':1}).tolist() == ["aap", {'a': 1}, False, {'a':1}])
 
 def test_fillna_array():
     x = np.array([1, 2, 3, np.nan])

--- a/tests/graphql_test.py
+++ b/tests/graphql_test.py
@@ -6,11 +6,15 @@ if vaex.utils.devmode:
 
 @pytest.fixture(scope='module')
 def schema(ds_trimmed_cache):
+    ds_trimmed_cache = ds_trimmed_cache.drop('123456')
     return ds_trimmed_cache.graphql.schema()
 
-def test_aggregates(df_local, schema):
-    df = df_local
+@pytest.fixture()
+def df(df_trimmed):
+    return df_trimmed.drop('123456')
 
+
+def test_aggregates(df, schema):
     result = schema.execute("""
     {
         df {
@@ -40,8 +44,7 @@ def test_aggregates(df_local, schema):
     assert result.data['df']['mean']['y'] == df.y.mean()
 
 
-def test_groupby(df_local, schema):
-    df = df_local
+def test_groupby(df, schema):
 
     result = schema.execute("""
     {
@@ -61,8 +64,7 @@ def test_groupby(df_local, schema):
     assert result.data['df']['groupby']['x']['min']['x'] == dfg['xmin'].tolist()
 
 
-def test_row_pagination(df_local, schema):
-    df = df_local
+def test_row_pagination(df, schema):
     def values(row, name):
         return [k[name] for k in row]
     result = schema.execute("""
@@ -106,8 +108,7 @@ def test_row_pagination(df_local, schema):
     assert values(result.data['df']['row'], 'x') == df[3:5].x.tolist()
 
 
-def test_where(df_local, schema):
-    df = df_local
+def test_where(df, schema):
     def values(row, name):
         return [k[name] for k in row]
     result = schema.execute("""
@@ -201,9 +202,8 @@ def test_where(df_local, schema):
     assert values(result.data['df']['row'], 'x') == [4, 5, 6]
 
 
-def test_pandas(df_local, schema):
-    df = df_local
-    df_pandas = df_local.to_pandas_df()
+def test_pandas(df, schema):
+    df_pandas = df.to_pandas_df()
     def values(row, name):
         return [k[name] for k in row]
     result = df_pandas.graphql.execute("""

--- a/tests/internal/filecache_test.py
+++ b/tests/internal/filecache_test.py
@@ -12,7 +12,8 @@ def test_hdf5(tmpdir):
     with open(path, 'rb') as fp:
         fp.seek(0, 2)
         cache = vaex.file.cache.CachedFile(vaex.file.dup(fp), fake_path, str(tmpdir), block_size=2)
-        df = vaex.hdf5.dataset.Hdf5MemoryMapped(cache)
+        ds = vaex.hdf5.dataset.Hdf5MemoryMapped(cache)
+        df = vaex.dataframe.DataFrameLocal(ds)
         assert df.x.tolist() == [1, 2]
         assert df.y.tolist() == [3, 4]
         assert df.s.tolist() == s

--- a/tests/rename_test.py
+++ b/tests/rename_test.py
@@ -81,7 +81,9 @@ def test_rename_aliased():
     df = vaex.from_dict({'1': [1, 2], '#': [2,3]})
     df['x'] = df['1'] + df['#']
     assert df.x.tolist() == [3, 5]
+    assert df['#'].tolist() == [2, 3]
     df.rename('#', '$')
+    assert df['$'].tolist() == [2, 3]
     df['x'] = df['1'] + df['$']
     assert df.x.tolist() == [3, 5]
 
@@ -89,3 +91,11 @@ def test_rename_aliased():
     assert df.x.tolist() == [3, 5]
     df['x'] = df['1'] + df['$']
     assert df.x.tolist() == [5, 8]
+
+
+def test_rename_expression():
+    df = vaex.from_dict({'1': [1, 2], '#': [2,3]})
+    expr = vaex.expression.Expression(df, "df['1']")
+    assert expr.tolist() == [1, 2]
+    expr2 = expr._rename('1', '#')
+    assert expr2.tolist() == [2, 3]

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -24,12 +24,12 @@ def test_format():
     assert df.text.format('pre-%s-post').tolist() == ['pre-%s-post' % k for k in text]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.4 or higher")
 def test_dtype_object_string(tmpdir):
+    # CHANGE: before vaex v4 we worked with dtype object, now we lazily cast to arrow
     x = np.arange(8, 12)
     s = np.array(list(map(str, x)), dtype='O')
     df = vaex.from_arrays(x=x, s=s)
-    assert df.columns['s'].dtype.kind == 'O'
+    assert df.columns['s'].type == pa.string()
     path = str(tmpdir.join('test.arrow'))
     df.export(path)
     df_read = vaex.open(path, as_numpy=False)


### PR DESCRIPTION
Issue #948 exposed a bug in which a column of type `str` gets accidentally converted to `object` after a `fillna` operation. 
This PR should address that.

This happens because, at the moment, we cast everything to numpy array in the processes of filling the N/A entries. If the columns / expression happens to be string, this is never converted back from numpy into the proper string/arrow format, resulting with a dtype `object`. I hope this to be an easy fix for @maartenbreddels.


- [x] Implement a unit test
- [ ] Make the test pass