### PR TITLE
Feature: adding ipython tab-completion

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -241,6 +241,9 @@ class DataFrame(object):
         else:
             return object.__getattribute__(self, name)
 
+    def _ipython_key_completions_(self):
+        return self.get_column_names()
+
     @property
     def func(self):
         class Functions(object):

--- a/tests/ipython_test.py
+++ b/tests/ipython_test.py
@@ -1,0 +1,13 @@
+import vaex
+
+
+def test_ipython_autocompletion(ds_local):
+    df = vaex.from_dict({'First name': ['Reggie', 'Tamika'],
+                         'Last name': ['Miller', 'Catchings'],
+                         '$amount': [10, 20]})
+
+    completions = df._ipython_key_completions_()
+    assert 'First name' in completions
+    assert 'Last name' in completions
+    assert '$amount' in completions
+    assert 'Team' not in completions


### PR DESCRIPTION
Adding tab competion when accessing columns using the dictionary syntax.

example:
`df['hom' (tab)]` -> `df['home_dest']`

- [ ] Review