### PR TITLE
Fix: property cast dt_strftime to string type

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -290,6 +290,34 @@ def _pandas_dt_fix(x):
         x = x.copy()
     return x
 
+@register_function(scope='dt', as_property=True)
+def dt_date(x):
+    """Return the date part of the datetime value
+
+    :returns: an expression containing the date portion of a datetime value
+
+    Example:
+
+    >>> import vaex
+    >>> import numpy as np
+    >>> date = np.array(['2009-10-12T03:31:00', '2016-02-11T10:17:34', '2015-11-12T11:34:22'], dtype=np.datetime64)
+    >>> df = vaex.from_arrays(date=date)
+    >>> df
+      #  date
+      0  2009-10-12 03:31:00
+      1  2016-02-11 10:17:34
+      2  2015-11-12 11:34:22
+
+    >>> df.date.dt.date
+    Expression = dt_date(date)
+    Length: 3 dtype: datetime64[D] (expression)
+    -------------------------------------------
+    0  2009-10-12
+    1  2016-02-11
+    2  2015-11-12
+    """
+    import pandas as pd
+    return pd.Series(_pandas_dt_fix(x)).dt.date.values.astype(np.datetime64)
 
 @register_function(scope='dt', as_property=True)
 def dt_dayofweek(x):

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -723,7 +723,7 @@ def dt_strftime(x, date_format):
     2  2015-11
     """
     import pandas as pd
-    return pd.Series(_pandas_dt_fix(x)).dt.strftime(date_format).values
+    return pd.Series(_pandas_dt_fix(x)).dt.strftime(date_format).values.astype(str)
 
 @register_function(scope='dt')
 def dt_floor(x, freq, *args):

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -491,7 +491,7 @@ def dt_month_name(x):
     2  November
     """
     import pandas as pd
-    return pd.Series(_pandas_dt_fix(x)).dt.month_name().values.astype(str)
+    return pa.array(pd.Series(_pandas_dt_fix(x)).dt.month_name())
 
 @register_function(scope='dt', as_property=True)
 def dt_quarter(x):
@@ -578,7 +578,7 @@ def dt_day_name(x):
     2  Thursday
     """
     import pandas as pd
-    return pd.Series(_pandas_dt_fix(x)).dt.day_name().values.astype(str)
+    return pa.array(pd.Series(_pandas_dt_fix(x)).dt.day_name())
 
 @register_function(scope='dt', as_property=True)
 def dt_weekofyear(x):
@@ -723,7 +723,7 @@ def dt_strftime(x, date_format):
     2  2015-11
     """
     import pandas as pd
-    return pd.Series(_pandas_dt_fix(x)).dt.strftime(date_format).values.astype(str)
+    return pa.array(pd.Series(_pandas_dt_fix(x)).dt.strftime(date_format))
 
 @register_function(scope='dt')
 def dt_floor(x, freq, *args):

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -28,6 +28,7 @@ def test_datetime_operations():
     assert df.date.dt.dayofyear.tolist() == pandas_df.date.dt.dayofyear.values.tolist()
     assert df.date.dt.dayofweek.tolist() == pandas_df.date.dt.dayofweek.values.tolist()
     assert df.date.dt.floor('H').tolist() == pandas_df.date.dt.floor('H').values.tolist()
+    assert df.date.dt.date.tolist() == pandas_df.date.dt.date.values.tolist()
 
 
 def test_datetime_agg():


### PR DESCRIPTION
Reported by #963 

Checklist:
 - [x] Properly cast `dt_strftime` to string type (earlier pandas objects were being snuck in..)
 - [x] bonus: add `df_date` method (extracts the date part from a datetime column)
 - [x] update unit-tests to account for the changes
 - [x] Review
