### PR TITLE
Fix: groupby aggregators return incorrect output for certain selections

### DIFF
--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -71,7 +71,7 @@ class AggregatorDescriptorBasic(AggregatorDescriptor):
             spec['expression'] = self.expression
         else:
             spec['expression'] = [str(k) for k in self.expressions]
-        if self.selection:
+        if self.selection is not None:
             spec['selection'] = self.selection
         if self.edges:
             spec['edges'] = True

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -355,7 +355,7 @@ class TaskPartAggregations:
                 agg = aggregation2d[selection_index]
                 all_aggregators.append(agg)
                 selection_mask = None
-                if selection:
+                if not (selection is None or selection is False):
                     selection_mask = self.df.evaluate_selection_mask(selection, i1=i1, i2=i2, cache=True)  # TODO
                     # TODO: we probably want a way to avoid a to numpy conversion?
                     selection_mask = np.asarray(selection_mask)

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -170,7 +170,8 @@ class GroupByBase(object):
             grids[column_name] = values
             if isinstance(aggregate, vaex.agg.AggregatorDescriptorBasic)\
                 and aggregate.name == 'AggCount'\
-                and aggregate.expression == "*":
+                and aggregate.expression == "*"\
+                and (aggregate.selection is None or aggregate.selection is False):
                 self.counts = values
 
         for item in actions:

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -357,6 +357,37 @@ def test_agg_selections():
     assert df_grouped['z_mean_selected'].tolist() == [1, 4, 6.5]
     assert df_grouped['w_nuniqe_selected'].tolist() == [2, 1, 2]
 
+def test_agg_selections_equal():
+    x = np.array([0, 0, 0, 1, 1, 2, 2])
+    y = np.array([1, 3, 5, 1, 7, 1, -1])
+    z = np.array([0, 2, 3, 4, 5, 6, 7])
+    w = np.array(['dog', 'cat', 'mouse', 'dog', 'dog', 'mouse', 'cat'])
+
+    df = vaex.from_arrays(x=x, y=y, z=z, w=w)
+
+
+    df_grouped = df.groupby(df.x).agg({'counts': vaex.agg.count(),
+                                      'sel_counts': vaex.agg.count(selection=df.y==1.)
+                                      })
+    assert df_grouped['counts'].tolist() == [3, 2, 2]
+    assert df_grouped['sel_counts'].tolist() == [1, 1, 1]
+
+def test_agg_selection_nodata():
+    x = np.array([0, 0, 0, 1, 1, 2, 2])
+    y = np.array([1, 3, 5, 1, 7, 1, -1])
+    z = np.array([0, 2, 3, 4, 5, 6, 7])
+    w = np.array(['dog', 'cat', 'mouse', 'dog', 'dog', 'mouse', 'cat'])
+
+    df = vaex.from_arrays(x=x, y=y, z=z, w=w)
+
+    df_grouped = df.groupby(df.x).agg({'counts': vaex.agg.count(),
+                                      'dog_counts': vaex.agg.count(selection=df.w == 'dog')
+                                      })
+
+    assert len(df_grouped) == 3
+    assert df_grouped['counts'].tolist() == [3, 2, 2]
+    assert df_grouped['dog_counts'].tolist() == [1, 2, 0]
+
 def test_upcast():
     df = vaex.from_arrays(b=[False, True, True], i8=np.array([120, 121, 122], dtype=np.int8),
         f4=np.array([1, 1e-13, 1], dtype=np.float32))


### PR DESCRIPTION
This PR fixes some issues with the groupby aggregators, when the `selection` kwarg is used.

Case 1:
the selection is ignored when the `==` operator is used with a float or int. Ex.  `vaex.agg.count(selection=df.x == 1)`. This will give the same result as if `selection=None`.

Case 2:
If a selection of an aggregation is such that no data is left, the entire row (group) is removed from the resulting grouped DataFrame (see unit-test for details). 

AC:
- [x] Make unit-tests that expose the issues
- [ ] Make tests pass

