### PR TITLE
fix(core): allow unicode variable names in expressions, fixes #949

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
       * Trimming concatenated columns. [#860](https://github.com/vaexio/vaex/pull/860)
       * percentile_approx works for 0 and 100 percentile. [#818](https://github.com/vaexio/vaex/pull/818)
       * Expression containing kwarg=True were treated as invalid. [#861](hhttps://github.com/vaexio/vaex/pull/861)
+      * Unicode column names fully supported [#974](https://github.com/vaexio/vaex/issues/974)
    * Features
       * Datetime floor method [#843](https://github.com/vaexio/vaex/pull/843)
       * dropinf (similar to dropna) [#821](https://github.com/vaexio/vaex/pull/821)

--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -97,7 +97,6 @@ def validate_expression(expr, variable_set, function_set=[], names=None):
         else:
             raise ValueError("Unary operator not allowed: %r" % expr.op)
     elif isinstance(expr, _ast.Name):
-        validate_id(expr.id)
         if expr.id not in variable_set:
             matches = difflib.get_close_matches(expr.id, list(variable_set))
             msg = "Column or variable %r does not exist." % expr.id
@@ -612,9 +611,3 @@ def node_to_string(node, pretty=False):
 def validate_func(name, function_set):
     if name.id not in function_set:
         raise NameError("function %r is not defined" % name.id)
-
-
-def validate_id(id):
-    for char in id:
-        if char not in valid_id_characters:
-            raise ValueError("invalid character %r in id %r" % (char, id))

--- a/tests/expresso_test.py
+++ b/tests/expresso_test.py
@@ -65,3 +65,6 @@ def test_lists():
 def test_validate():
     validate_expression('x + 1', {'x'})
     validate_expression('x == "1"', {'x'})
+
+def test_unicode():
+    validate_expression('实体 + 1', {'实体'})


### PR DESCRIPTION
This was a too strict test, since we allow Unicode column names