### PR TITLE
chore(ci): pytest-asyncio 0.14 breaks tests/process_test test_progress_calls_async

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -18,7 +18,7 @@ py-xgboost
 # pyarrow
 pyqt
 pytest
-pytest-asyncio
+pytest-asyncio <0.14
 python-graphviz
 scikit-learn
 scipy


### PR DESCRIPTION
See https://github.com/vaexio/vaex/issues/976