### PR TITLE
Feat: Out of core Parquet support using Arrow Dataset scanning

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
         token: ${{ secrets.PAT_PULL_ENTERPRISE }}
         path: vaex-enterprise
     - name: Install conda with Python ${{ matrix.python-version }}
-      uses: s-weigand/setup-conda@master
+      uses: s-weigand/setup-conda@v1
       with:
         python-version: ${{ matrix.python-version }}
         conda-channels: anaconda, conda-forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vaex 4.0.0 (unreleased)
    * Breaking changes:
       * Arrow is now a core dependency, vaex-arrow is deprecated. All methods that return string, will return Arrow arrays [#517](https://github.com/vaexio/vaex/pull/517)
+      * Columns (e.g. df.column['x']) may now return a ColumnProxy, instead of the original data, slice it [:] to get the underlying data (or call .to_numpy()/to_arrow() or try converting it with np.array(..) or pa.array(..)). [#993](https://github.com/vaexio/vaex/pull/993)
 
 ## vaex-arrow (DEPRECATED)
    This is now part of vaex-core.
@@ -20,6 +21,7 @@
       * dropinf (similar to dropna) [#821](https://github.com/vaexio/vaex/pull/821)
       * Support for streaming from Google Cloud Storage. [#898](https://github.com/vaexio/vaex/pull/898)
       * IPython autocomplete support (e.g. `df['hom' (tab)`) [#961](https://github.com/vaexio/vaex/pull/961)
+      * Out of core Parquet support using Arrow Dataset scanning [#993](https://github.com/vaexio/vaex/pull/993)
    * Refactor
       * Use `arrow.compute` for several string functions/kernels. [#885](https://github.com/vaexio/vaex/pull/885)
       * Separate DataFrame and Dataset. [#865](https://github.com/vaexio/vaex/pull/865)

--- a/packages/vaex-astro/vaex/astro/transformations.py
+++ b/packages/vaex-astro/vaex/astro/transformations.py
@@ -249,9 +249,9 @@ class DataFrameAccessorAstro(object):
             df.add_variable('pi', np.pi)
             alpha = "pi/180.*%s" % alpha
             delta = "pi/180.*%s" % delta
-        df.virtual_columns[zname] = "{distance} * (cos({delta}) * cos({delta_gp}) * cos({alpha} - {alpha_gp}) + sin({delta}) * sin({delta_gp}))".format(**locals())
-        df.virtual_columns[xname] = "{distance} * (cos({delta}) * sin({alpha} - {alpha_gp}))".format(**locals())
-        df.virtual_columns[yname] = "{distance} * (sin({delta}) * cos({delta_gp}) - cos({delta}) * sin({delta_gp}) * cos({alpha} - {alpha_gp}))".format(**locals())
+        df.add_virtual_column(zname, "{distance} * (cos({delta}) * cos({delta_gp}) * cos({alpha} - {alpha_gp}) + sin({delta}) * sin({delta_gp}))".format(**locals()))
+        df.add_virtual_column(xname, "{distance} * (cos({delta}) * sin({alpha} - {alpha_gp}))".format(**locals()))
+        df.add_virtual_column(yname, "{distance} * (sin({delta}) * cos({delta_gp}) - cos({delta}) * sin({delta_gp}) * cos({alpha} - {alpha_gp}))".format(**locals()))
         return df
         # self.write_virtual_meta()
 

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -358,6 +358,17 @@ def from_arrow_table(table, as_numpy=True):
     return from_table(table=table, as_numpy=as_numpy)
 
 
+def from_arrow_dataset(arrow_dataset) -> vaex.dataframe.DataFrame:
+    '''Create a DataFrame from an Apache Arrow dataset'''
+    import vaex.arrow.dataset
+    return from_dataset(vaex.arrow.dataset.DatasetArrow(arrow_dataset))
+
+
+def from_dataset(dataset: vaex.dataset.Dataset) -> vaex.dataframe.DataFrame:
+    '''Create a Vaex DataFrame from a Vaex Dataset'''
+    return vaex.dataframe.DataFrameLocal(dataset)
+
+
 def from_scalars(**kwargs):
     """Similar to from_arrays, but convenient for a DataFrame of length 1.
 

--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -10,6 +10,12 @@ supported_array_types = (np.ndarray, ) + supported_arrow_array_types
 string_types = [pa.string(), pa.large_string()]
 
 
+def filter(ar, boolean_mask):
+    if isinstance(ar, supported_arrow_array_types):
+        return ar.filter(pa.array(boolean_mask))
+    else:
+        return ar[boolean_mask]
+
 
 def is_string_type(data_type):
     return not isinstance(data_type, np.dtype) and data_type in string_types

--- a/packages/vaex-core/vaex/arrow/dataset.py
+++ b/packages/vaex-core/vaex/arrow/dataset.py
@@ -1,13 +1,170 @@
 __author__ = 'maartenbreddels'
+import collections
 import logging
 
 import pyarrow as pa
-import pyarrow.parquet as pq
+import pyarrow.dataset
 
 import vaex.dataset
 import vaex.file.other
 from .convert import column_from_arrow_array
 logger = logging.getLogger("vaex.arrow")
+
+
+class DatasetSliced(vaex.dataset.Dataset):
+    def __init__(self, original, start, end):
+        super().__init__()
+        self.original = original
+        self.start = start
+        self.end = end
+        self._row_count = end - start
+        self._columns = {name: vaex.dataset.ColumnProxy(self, col.name, col.dtype) for name, col in self.original._columns.items()}
+        self._ids = {}
+
+    def chunk_iterator(self, columns, chunk_size=None, reverse=False):
+        chunk_size = chunk_size or 1024*1024
+        dict_or_list_of_arrays = collections.defaultdict(list)
+        i1 = i2 = 0
+        for chunk_start, chunk_end, reader in self.original.chunk_iterator(columns, chunk_size=chunk_size):
+            if self.start >= chunk_end:  # we didn't find the beginning yet
+                continue
+            if self.end < chunk_start:  # we are past the end
+                break
+            slice_reader = reader  # default case, if we don't have to slice
+            length = chunk_end - chunk_start  # default length
+            if self.start > chunk_start:
+                # this means we have to cut off a piece of the beginning
+                if self.end < chunk_end:
+                    # AND the end
+                    length = self.end - chunk_start  # without the start cut off
+                    length -= self.start - chunk_start  # correcting for the start cut off
+                    def slice_reader(chunk_start=chunk_start, reader=reader, length=length):
+                        chunks = reader()
+                        chunks = {name: ar.slice(self.start - chunk_start, length) for name, ar in chunks.items()}
+                        for name, ar in chunks.items():
+                            assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
+                        return chunks
+                else:
+                    length -= self.start - chunk_start  # correcting for the start cut off
+                    def slice_reader(chunk_start=chunk_start, reader=reader, length=length):
+                        chunks = reader()
+                        chunks = {name: ar.slice(self.start - chunk_start) for name, ar in chunks.items()}
+                        for name, ar in chunks.items():
+                            assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
+                        return chunks
+            else:
+                if self.end < chunk_end:
+                    # we only need to cut off a piece of the end
+                    length = self.end - chunk_start
+                    def slice_reader(chunk_start=chunk_start, reader=reader, length=length):
+                        chunks = reader()
+                        chunks = {name: ar.slice(0, length) for name, ar in chunks.items()}
+                        for name, ar in chunks.items():
+                            assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
+                        return chunks
+                # else, the defaults apply
+            i2 = i1 + length
+            yield i1, i2, slice_reader
+            i1 = i2
+
+    def hashed(self):
+        raise NotImplementedError
+
+    def close(self):
+        self.original.close()
+
+    def slice(self, start, end):
+        length = end - start
+        start += self.start
+        end = start + length
+        if end > self.original.row_count:
+            raise IndexError(f'Slice end ({end}) if larger than number of rows: {self.original.row_count}')
+        return type(self)(self.original, start, end)
+
+
+class DatasetArrow(vaex.dataset.Dataset):
+    def __init__(self, ds):
+        super().__init__()
+        self._arrow_ds = ds
+        row_count = 0
+        for fragment in self._arrow_ds.get_fragments():
+            fragment.ensure_complete_metadata()
+            for rg in fragment.row_groups:
+                row_count += rg.num_rows
+        self._row_count = row_count
+        self._columns = {name: vaex.dataset.ColumnProxy(self, name, type) for name, type in
+                          zip(self._arrow_ds.schema.names, self._arrow_ds.schema.types)}
+        self._ids = {}
+
+    def hashed(self):
+        raise NotImplementedError
+
+    def slice(self, start, end):
+        # TODO: we can be smarter here, and trim off some fragments
+        if start == 0 and end == self.row_count:
+            return self
+        return DatasetSliced(self, start=start, end=end)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            assert item.step in [1, None]
+            return DatasetSliced(self, item.start or 0, item.stop or self.row_count)
+        return self._columns[item]
+
+    def close(self):
+        # no need to close it, it seem
+        pass
+
+    def chunk_iterator(self, columns, chunk_size=None, reverse=False):
+        chunk_size = chunk_size or 1024*1024
+        i1 = 0
+        # Instead of looping over all fragments, they might be too big, so...
+        for fragment_large in self._arrow_ds.get_fragments():
+            fragment_large_rows = sum([rg.num_rows for rg in fragment_large.row_groups])
+            # then we split them up
+            if fragment_large_rows > chunk_size:
+                fragments = fragment_large.split_by_row_group()
+            else:
+                # or not
+                fragments = [fragment_large]
+            # now we collect fragments, until we hit the chunk_size
+            rows_planned = 0
+            fragments_planned = []
+            for fragment in fragments:
+                fragment_rows = sum([rg.num_rows for rg in fragment.row_groups])
+                # if adding the current fragment would make the chunk too large
+                # and we already have some fragments
+                if rows_planned + fragment_rows > chunk_size and rows_planned > 0:
+                    i2 = i1 + rows_planned
+                    yield i1, i2, self._make_reader(fragments_planned, chunk_size, columns, rows_planned)
+                    i1 = i2
+                    rows_planned = 0
+                    fragments_planned = []
+                fragments_planned.append(fragment)
+                rows_planned += fragment_rows
+            if rows_planned:
+                i2 = i1 + rows_planned
+                yield i1, i2, self._make_reader(fragments_planned, chunk_size, columns, rows_planned)
+                i1 = i2
+                rows_planned = 0
+                fragments_planned = []
+
+    def _make_reader(self, fragments, chunk_size, columns, rows_planned):
+        def reader():
+            record_batches = []
+            for fragment in fragments:
+                for scan_task in fragment.scan(batch_size=chunk_size, use_threads=False, columns=columns):
+                    for record_batch in scan_task.execute():
+                        record_batches.append((record_batch))
+            dict_or_list_of_arrays = collections.defaultdict(list)
+            for rb in record_batches:
+                for name, array in zip(rb.schema.names, rb.columns):
+                    dict_or_list_of_arrays[name].append(array)
+            chunks = {name: pa.chunked_array(arrays) for name, arrays in dict_or_list_of_arrays.items()}
+            for name, chunk in chunks.items():
+                assert len(chunk) == rows_planned, f'Oops, got a chunk ({name}) of length {len(chunk)} while it is expected to be of length {rows_planned}'
+            return chunks
+        return reader
 
 
 def from_table(table, as_numpy=True):
@@ -36,8 +193,9 @@ def open(filename, as_numpy=True):
 
 
 def open_parquet(filename, as_numpy=True):
-    table = pq.read_table(filename)
-    return from_table(table, as_numpy=as_numpy)
+    arrow_ds = pyarrow.dataset.dataset(filename)
+    ds = DatasetArrow(arrow_ds)
+    return vaex.from_dataset(ds)
 
 # vaex.file.other.dataset_type_map["arrow"] = DatasetArrow
 # vaex.file.other.dataset_type_map["parquet"] = DatasetParquet

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -75,6 +75,9 @@ class ColumnSparse(Column):
     def __len__(self):
         return self.shape[0]
 
+    def trim(self, i1, i2):
+        return ColumnSparse(self.matrix[i1:i2], column_index=self.column_index)
+
     def __getitem__(self, slice):
         # not sure if this is the fastest
         return self.matrix[slice, self.column_index].A[:,0]

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -219,9 +219,10 @@ class ColumnIndexed(Column):
 
 
 class ColumnConcatenatedLazy(Column):
-    def __init__(self, expressions, dtype=None):
+    def __init__(self, expressions, dtype=None, shape=None, fill_value=None):
         self.is_masked = any([e.is_masked for e in expressions])
-        if self.is_masked:
+        self.fill_value = fill_value
+        if self.is_masked and fill_value is None:
             for expression in expressions:
                 if expression.is_masked:
                     try:
@@ -265,13 +266,15 @@ class ColumnConcatenatedLazy(Column):
             # if dtype is given, we assume every expression/column is the same dtype
             self.dtype = dtype
             self.expressions = expressions[:]
-        self.shape = (len(self), ) + self.expressions[0][0:1].to_numpy().shape[1:]
-
-        for i in range(1, len(self.expressions)):
-            expression = self.expressions[i]
-            shape_i = (len(self), ) + expressions[i][0:1].to_numpy().shape[1:]
-            if self.shape != shape_i:
-                raise ValueError("shape of of expression %s, array index 0, is %r and is incompatible with the shape of the same column of array index %d, %r" % (self.expressions[0], self.shape, i, shape_i))
+        if shape is not None:
+            self.shape = (len(self),) + shape
+        else:
+            self.shape = (len(self), ) + self.expressions[0][0:1].to_numpy().shape[1:]
+            for i in range(1, len(self.expressions)):
+                expression = self.expressions[i]
+                shape_i = (len(self), ) + expressions[i][0:1].to_numpy().shape[1:]
+                if self.shape != shape_i:
+                    raise ValueError("shape of of expression %s, array index 0, is %r and is incompatible with the shape of the same column of array index %d, %r" % (self.expressions[0], self.shape, i, shape_i))
 
     def to_arrow(self, type=None):
         values = [e.values for e in self.expressions]
@@ -323,7 +326,7 @@ class ColumnConcatenatedLazy(Column):
             # otherwise we only need a slice of the first
             expressions = [self.expressions[i][start-offset:stop-offset]]
 
-        return ColumnConcatenatedLazy(expressions, self.dtype)
+        return ColumnConcatenatedLazy(expressions, self.dtype, self.shape[1:], fill_value=self.fill_value)
 
     def __arrow_array__(self, type=None):
         return pa.array(self[:], type=type)

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -332,7 +332,12 @@ class TaskPartAggregations:
                     x = x.view('uint64')
             return x
 
+        N = i2 - i1
+        if filter_mask is not None:
+            N = filter_mask.astype(np.uint8).sum()
         blocks = [array_types.to_numpy(block, strict=False) for block in blocks]
+        for block in blocks:
+            assert len(block) == N, f'Oops, got a block of length {len(block)} while it is expected to be of length {N} (at {i1}-{i2}, filter={filter_mask is not None})'
         block_map = {expr: block for expr, block in zip(self.expressions, blocks)}
         # we need to make sure we keep some objects alive, since the c++ side does not incref
         # on set_data and set_data_mask
@@ -388,9 +393,6 @@ class TaskPartAggregations:
                 if selection_mask is not None:
                     agg.set_data_mask(selection_mask)
                     references.extend([selection_mask])
-        N = i2 - i1
-        if filter_mask is not None:
-            N = filter_mask.astype(np.uint8).sum()
         grid.bin(all_aggregators, N)
         self.has_values = True
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4911,8 +4911,7 @@ class DataFrameLocal(DataFrame):
         for column_name in self.column_names:
             self._initialize_column(column_name)
         if len(self.dataset):
-            ar = self.dataset[list(self.dataset.keys())[0]]
-            self._length = len(ar)
+            self._length = self.dataset.row_count
             if self._length_unfiltered is None:
                 self._length_unfiltered = self._length
                 self._length_original = self._length

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4942,12 +4942,16 @@ class DataFrameLocal(DataFrame):
         return df
 
     def _readonly(self, inplace=False):
-        # make arrays read only if possib;e
+        # make arrays read only if possible
         df = self if inplace else self.copy()
+        assert isinstance(self.dataset, vaex.dataset.DatasetArrays)
+        columns = {}
         for key, ar in self.columns.items():
+            columns[key] = ar
             if isinstance(ar, np.ndarray):
-                df.columns[key] = ar = ar.view() # make new object so we don't modify others
+                columns[key] = ar = ar.view() # make new object so we don't modify others
                 ar.flags['WRITEABLE'] = False
+        df._dataset = vaex.dataset.DatasetArrays(columns)
         return df
 
     @docsubst

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4926,12 +4926,13 @@ class DataFrameLocal(DataFrame):
 
     @dataset.setter
     def dataset(self, dataset):
+        if self._dataset.row_count != dataset.row_count:
+            self._length_original = dataset.row_count
+            self._length_unfiltered = self._length_original
+            self._cached_filtered_length = None
+            self._index_start = 0
+            self._index_end = self._length_original
         self._dataset = dataset
-        self._length_original = dataset.row_count
-        self._length_unfiltered = self._length_original
-        self._cached_filtered_length = None
-        self._index_start = 0
-        self._index_end = self._length_original
         self._invalidate_selection_cache()
 
     def hashed(self) -> DataFrame:

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4641,7 +4641,7 @@ class DataFrame(object):
             return df.trim()
 
     def __delitem__(self, item):
-        '''Alias op df.drop(item, inplace=True)'''
+        '''Alias of df.drop(item, inplace=True)'''
         if item in self.columns:
             name = item
             if name in self._depending_columns(columns_exclude=[name]):
@@ -5075,7 +5075,7 @@ class DataFrameLocal(DataFrame):
 
         datas = Datas()
         for name, array in self.columns.items():
-            setattr(datas, name, array)
+            setattr(datas, name, array[:])
         return datas
 
     def copy(self, column_names=None):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3350,7 +3350,7 @@ class DataFrame(object):
             # we only have to do this locally
             # if we don't do this locally, we still store this info
             # in self._renamed_columns, so it will happen at the server
-            self.columns[new] = self.columns.pop(old)
+            self.dataset = self.dataset.renamed({old: new})
         if rename_meta_data:
             for d in [self.ucds, self.units, self.descriptions]:
                 if old in d:

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5066,8 +5066,88 @@ class DataFrameLocal(DataFrame):
             setattr(datas, name, array)
         return datas
 
-    def copy(self, column_names=None, virtual=True):
-        df = DataFrameLocal()
+    def copy(self, column_names=None):
+        copy_all = column_names is None
+        if copy_all:  # fast path
+            df = vaex.from_dataset(self.dataset)
+            df.column_names = list(self.column_names)
+            df.virtual_columns = self.virtual_columns.copy()
+            virtuals = set(df.virtual_columns)
+            for name in df.column_names:
+                if name in virtuals:
+                    df._virtual_expressions[name] = Expression(df, df.virtual_columns[name])
+                df._initialize_column(name)
+            hide = set()
+        else:
+
+            all_column_names = self.get_column_names(hidden=True)
+            if column_names is None:
+                column_names = all_column_names.copy()
+            else:
+                for name in column_names:
+                    self.validate_expression(name)
+
+            # the columns that we require for a copy (superset of column_names)
+            required = set()
+            # expression like 'x/2' that are not (virtual) columns
+            expression_columns = set()
+
+            def track(name):
+                if name in self.dataset:
+                    required.add(name)
+                else:
+                    if name in self.variables:
+                        return  # we don't track variables, we copy all
+                    elif name in self.virtual_columns:
+                        required.add(name)
+                        expr = self._virtual_expressions[name]
+                    else:
+                        # this might be an expression, create a valid name
+                        expression_columns.add(name)
+                        expr = self[name]
+                    deps = set([key for key, value in expr.ast_names.items()])
+                    deps -= {'df'}
+                    deps |= set([key for key, value in expr._ast_slices.items()])
+                    # the columns we didn't know we required yet
+                    missing = deps - required
+                    required.update(deps)
+                    for name in missing:
+                        track(name)
+
+            for name in column_names:
+                track(name)
+
+            # track all selection dependencies, this includes the filters
+            for key, value in self.selection_histories.items():
+                selection = self.get_selection(key)
+                if selection:
+                    for name in selection._depending_columns(self):
+                        track(name)
+
+            # first create the DataFrame with real data (dataset)
+            dataset_columns = {k for k in required if k in self.dataset}
+            dataset = self.dataset.project(*dataset_columns)
+            df = vaex.from_dataset(dataset)
+
+            # and reconstruct the rest (virtual columns and variables)
+            other = {k for k in required if k not in self.dataset}
+            for name in other:
+                if name in self.virtual_columns:
+                    valid_name = vaex.utils.find_valid_name(name)
+                    df.add_virtual_column(valid_name, self.virtual_columns[name])
+                elif name in self.variables:
+                    # no need to do this, since we copy all variables
+                    # df.variables[name] = self.variables[name]
+                    pass
+                else:
+                    raise RuntimeError(f'Oops {name} is not a virtual column or variable??')
+
+            # and extra expressions like 'x/2'
+            for expr in expression_columns:
+                df.add_virtual_column(expr, expr)
+            hide = required - set(column_names) - set(self.variables)
+
+        # restore some metadata
         df._length_unfiltered = self._length_unfiltered
         df._length_original = self._length_original
         df._cached_filtered_length = self._cached_filtered_length
@@ -5078,10 +5158,6 @@ class DataFrameLocal(DataFrame):
         df.units.update(self.units)
         df.variables.update(self.variables)  # we add all, could maybe only copy used
         df._categories.update(self._categories)
-        copy_all = column_names is None
-        all_column_names = self.get_column_names(hidden=True)
-        if column_names is None:
-            column_names = all_column_names.copy()
 
         # put in the selections (thus filters) in place
         # so drop moves instead of really dropping it
@@ -5110,87 +5186,13 @@ class DataFrameLocal(DataFrame):
                 df._selection_mask_caches[key] = collections.defaultdict(dict)
                 df._selection_mask_caches[key].update(self._selection_mask_caches[key])
 
-        if copy_all:  # fast path
-            # this is ok, we don't have to reset caches and all, since we do this in copy
-            df._dataset = self.dataset
-            df.column_names = list(self.column_names)
-            df.virtual_columns = self.virtual_columns.copy()
-            for name in all_column_names:
-                df._initialize_column(name)
-            for name, expression in df.virtual_columns.items():
-                df._virtual_expressions[name] = Expression(df, expression)
-        else:
-            # print("-----", column_names)
-            depending = set()
-            added = set()
-            for name in column_names:
-                # print("add", name)
-                added.add(name)
-                if name in self.columns:
-                    column = self.columns[name]
-                    df.add_column(name, column)
-                    if isinstance(column, ColumnSparse):
-                        df._sparse_matrices[name] = self._sparse_matrices[name]
-                elif name in self.virtual_columns:
-                    if virtual:  # TODO: check if the ast is cached
-                        df.add_virtual_column(name, self.virtual_columns[name])
-                        deps = [key for key, value in df._virtual_expressions[name].ast_names.items()]
-                        deps += [key for key, value in df._virtual_expressions[name]._ast_slices.items()]
-                        # print("add virtual", name, df._virtual_expressions[name].expression, deps)
-                        depending.update(deps)
-                else:
-                    # this might be an expression, create a valid name
-                    valid_name = vaex.utils.find_valid_name(name)
-                    self.validate_expression(name)
-                    # add the expression
-                    df[valid_name] = df._expr(name)
-                    # then get the dependencies
-                    deps = [key for key, value in df._virtual_expressions[valid_name].ast_names.items()]
-                    deps += [key for key, value in df._virtual_expressions[name]._ast_slices.items()]
-                    depending.update(deps)
-                # print(depending, "after add")
-            # depending |= column_names
-            # print(depending)
-            # print(depending, "before filter")
-            if self.filtered:
-                selection = self.get_selection(FILTER_SELECTION_NAME)
-                depending |= selection._depending_columns(self)
-            depending.difference_update(added)  # remove already added
-            # print(depending, "after filter")
-            # return depending_columns
 
-            hide = []
-
-            while depending:
-                new_depending = set()
-                for name in depending:
-                    added.add(name)
-                    if name in self.columns:
-                        # print("add column", name)
-                        df.add_column(name, self.columns[name])
-                        # print("and hide it")
-                        # df._hide_column(name)
-                        hide.append(name)
-                    elif name in self.virtual_columns:
-                        if virtual:  # TODO: check if the ast is cached
-                            df.add_virtual_column(name, self.virtual_columns[name])
-                            deps = [key for key, value in self._virtual_expressions[name].ast_names.items()]
-                            deps += [key for key, value in df._virtual_expressions[name]._ast_slices.items()]
-                            new_depending.update(deps)
-                        # df._hide_column(name)
-                        hide.append(name)
-                    elif name in self.variables:
-                        # if must be a variables?
-                        # TODO: what if the variable depends on other variables
-                        # we already add all variables
-                        # df.add_variable(name, self.variables[name])
-                        pass
-
-                # print("new_depending", new_depending)
-                new_depending.difference_update(added)
-                depending = new_depending
-            for name in hide:
-                df._hide_column(name)
+        for name in hide:
+            df._hide_column(name)
+        if column_names is not None:
+            # make the the column order is as requested by the column_names argument
+            extra = set(df.column_names) - set(column_names)
+            df.column_names = list(column_names) + list(extra)
 
         df.copy_metadata(self)
         return df

--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -352,6 +352,14 @@ class ExpressionString(ast.NodeVisitor):
     def visit_NameConstant(self, node):
         return repr(node.value)
 
+    def visit_Dict(self, node):
+        parts = []
+        for key, value in zip(node.keys, node.values):
+            key = self.visit(key)
+            value = self.visit(value)
+            parts.append(f'{key}: {value}')
+        return '{' + ' '.join(parts) + '}'
+
     def visit_Call(self, node):
         args = [self.visit(k) for k in node.args]
         keywords = []

--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -127,6 +127,14 @@ def validate_expression(expr, variable_set, function_set=[], names=None):
         validate_expression(expr.value, variable_set, function_set, names)
     elif isinstance(expr, ast_Constant):
         pass  # like True and False
+    elif isinstance(expr, _ast.List):
+        for el in expr.elts:
+            validate_expression(el, variable_set, function_set, names)
+    elif isinstance(expr, _ast.Dict):
+        for key in expr.keys:
+            validate_expression(key, variable_set, function_set, names)
+        for value in expr.values:
+            validate_expression(value, variable_set, function_set, names)
     elif isinstance(expr, _ast.Subscript):
         validate_expression(expr.value, variable_set, function_set, names)
         if isinstance(expr.slice.value, ast_Num):

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2300,7 +2300,7 @@ def _astype(x, dtype):
     # we rely on numpy for astype conversions (TODO: possible performance hit?)
     if isinstance(x, vaex.column.ColumnString):
         x = x.to_numpy()
-    if isinstance(x, pa.Array):
+    if isinstance(x, vaex.array_types.supported_arrow_array_types):
         x = x.to_pandas().values
     y = x.astype(dtype if dtype not in ['string', 'large_string'] else 'str')
     if vaex.column._is_stringy(y):

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -18,7 +18,7 @@ def test_sum(df, ds_trimmed):
 
     df.select("x < 5")
     # convert to float
-    x = ds_trimmed.columns["x"]
+    x = ds_trimmed.x.to_numpy()
     y = ds_trimmed.data.y
     x_with_nan = x * 1
     x_with_nan[0] = np.nan

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,18 +6,26 @@ try:
 except:
     pass
 
+import os
+import sys
+from pathlib import Path
+
 import pytest
+import numpy as np
+import contextlib
+import pyarrow as pa
+import pyarrow.parquet
+
 import vaex
 import vaex.server.service
 import vaex.server.tornado_server
 import vaex.server.dummy
-import numpy as np
-import contextlib
-import pyarrow as pa
 
-import sys
+
+
 test_port = 3911 + sys.version_info[0] * 10 + sys.version_info[1]
 scheme = 'ws'
+HERE = Path(__file__).parent
 
 
 class CallbackCounter(object):
@@ -233,7 +241,7 @@ def df_arrow_raw(df_filtered):
     df = df_filtered.copy()
     df.drop('obj', inplace=True)
     df.drop('timedelta', inplace=True)
-    columns = {k: vaex.array_types.to_arrow(v, convert_to_native=True) for k, v in df.columns.items()}
+    columns = {k: vaex.array_types.to_arrow(v[:], convert_to_native=True) for k, v in df.columns.items()}
     dataset = vaex.dataset.DatasetArrays(columns)
     df.dataset = dataset
     return df

--- a/tests/common.py
+++ b/tests/common.py
@@ -249,8 +249,8 @@ def create_filtered():
     return ds
 
 def create_base_ds():
-    dataset = vaex.dataframe.DataFrameLocal()
     x = np.arange(-2, 40, dtype=">f8").reshape((-1,21)).T.copy()[:,0]
+    columns = {'x': x}
     y = y = x ** 2
     ints = np.arange(-2,19, dtype="i8")
     ints[0] = 2**62+1
@@ -259,8 +259,8 @@ def create_base_ds():
     ints[0+10] = 2**62+1
     ints[1+10] = -2**62+1
     ints[2+10] = -2**62-1
-    dataset.add_column("x", x)
-    dataset.add_column("y", y)
+    columns["x"] = x
+    columns["y"] = y
     # m = x.copy()
     m = np.arange(-2, 40, dtype=">f8").reshape((-1,21)).T.copy()[:,0]
     ma_value = 77777
@@ -280,25 +280,25 @@ def create_base_ds():
     nm = np.ma.array(nm, mask=nm==ma_value)
 
     mi = np.ma.array(m.data.astype(np.int64), mask=m.data==ma_value, fill_value=88888)
-    dataset.add_column("m", m)
-    dataset.add_column('n', n)
-    dataset.add_column('nm', nm)
-    dataset.add_column("mi", mi)
-    dataset.add_column("ints", ints)
+    columns["m"] = m
+    columns['n'] = n
+    columns['nm'] = nm
+    columns["mi"] = mi
+    columns["ints"] = ints
 
     name = np.array(list(map(lambda x: str(x) + "bla" + ('_' * int(x)), x)), dtype='U') #, dtype=np.string_)
-    dataset.add_column("name", np.array(name))
-    dataset.add_column("name_arrow", vaex.string_column(name))
+    columns["name"] = np.array(name)
+    columns["name_arrow"] = vaex.string_column(name)
 
     obj_data = np.array(['train', 'false' , True, 1, 30., np.nan, 'something', 'something a bit longer resembling a sentence?!', -10000, 'this should be masked'], dtype='object')
     obj_mask = np.array([False] * 9 + [True])
     obj = nm.copy().astype('object')
     obj[2:12] = np.ma.MaskedArray(data=obj_data, mask=obj_mask, dtype='object')
-    dataset.add_column("obj", obj, dtype=np.dtype('O'))
+    columns["obj"] = obj #, dtype=np.dtype('O')
 
     booleans = np.ones(21, dtype=np.bool)
     booleans[[4, 6, 8, 14, 16, 19]] = False
-    dataset.add_column("bool", booleans)
+    columns["bool"] = booleans
 
     datetime = np.array(['2016-02-29T22:02:02.32', '2013-01-17T01:02:03.32', '2017-11-11T08:15:15.00',
                          '1995-04-01T05:55:55.55', '2000-01-01T00:00:00.00', '2019-03-05T09:12:13.51',
@@ -309,11 +309,11 @@ def create_base_ds():
                          '1997-09-04T20:31:00.11', '2004-02-24T04:00:00.00', '2000-06-15T12:30:30.00',
                          ],dtype=np.datetime64)
     timedelta = datetime - np.datetime64('1996-05-17T16:45:00.00')
-    dataset.add_column("datetime", datetime)
-    dataset.add_column("timedelta", timedelta)
-    dataset.add_column("123456", x)  # a column that will have an alias
+    columns["datetime"] = datetime
+    columns["timedelta"] = timedelta
+    columns["123456"] = x  # a column that will have an alias
 
-    dataset.add_virtual_column("z", "x+t*y")
-    dataset.set_variable("t", 1.)
-
-    return dataset._readonly()
+    df = vaex.from_arrays(**columns)
+    df.add_virtual_column("z", "x+t*y")
+    df.set_variable("t", 1.)
+    return df._readonly()

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -69,6 +69,8 @@ def test_array_rename():
     assert ds2['y'] is y
     assert ds2['z'] is x
 
+    assert 'z' in list(ds2.chunk_iterator(['z']))[0][-1]()
+
     assert ds1 != ds2
     assert rebuild(ds1) != rebuild(ds2)
 
@@ -240,3 +242,27 @@ def test_cache_hash():
     ds3 = df3.dataset
     assert ds3._hash_calculations == 0
     assert ds3 == ds2
+
+
+def test_chunk_iterator():
+    x = np.arange(10)
+    y = x**2
+    ds = dataset.DatasetArrays(x=x, y=y)
+    chunk_it = ds.chunk_iterator(['y'], chunk_size=4)
+    i1, i2, reader = next(chunk_it)
+    chunk0 = reader()
+    assert chunk0['y'].tolist() == y[0:4].tolist()
+    assert i1 == 0
+    assert i2 == 4
+
+    i1, i2, reader = next(chunk_it)
+    chunk1 = reader()
+    assert chunk1['y'].tolist() == y[4:8].tolist()
+    assert i1 == 4
+    assert i2 == 8
+
+    i1, i2, reader = next(chunk_it)
+    chunk2 = reader()
+    assert chunk2['y'].tolist() == y[8:].tolist()
+    assert i1 == 8
+    assert i2 == 10

--- a/tests/drop_test.py
+++ b/tests/drop_test.py
@@ -39,7 +39,7 @@ def test_drop_autocomplete(ds_local):
     ds['drop'] = ds.m
     ds['columns'] = ds.m
 
-    del ds['x']
+    ds.drop('x', inplace=True)
     assert not hasattr(ds, 'x')
 
     ds.drop('y', inplace=True)

--- a/tests/expression_variables_test.py
+++ b/tests/expression_variables_test.py
@@ -15,3 +15,21 @@ def test_expression_expand():
     assert ds.t.variables() == {'s', 'r', 'x', 'y'}
     ds['u'] = np.arctan(ds.t)
     assert ds.u.variables() == {'t', 's', 'r', 'x', 'y'}
+
+
+def test_non_identifiers():
+    df = vaex.from_dict({'x': [1], 'y': [2], '#':[1]})
+    df['z'] = df['#'] + 1
+    assert df['z'].variables() == {'#'}
+    assert df._virtual_expressions['z'].variables() == {'#'}
+
+    df['1'] = df.x * df.y
+    df['2'] = df['1'] + df.x
+    assert df['1'].variables(ourself=True) == {'x', 'y', '1'}
+    assert df['1'].variables() == {'x', 'y'}
+    assert df['2'].variables(ourself=True) == {'x', 'y', '2', '1'}
+    assert df['2'].variables(include_virtual=False) == {'x', 'y'}
+
+    df['valid'] = df['2']
+    assert df['valid'].variables(ourself=True) == {'x', 'y', '2', '1', 'valid'}
+    assert df['valid'].variables(include_virtual=False) == {'x', 'y'}

--- a/tests/expresso_test.py
+++ b/tests/expresso_test.py
@@ -57,12 +57,14 @@ def test_lists():
     assert node is not None
 
     expr = "searchsorted(['9E', 'AA', 'AQ', 'AS', 'B6', 'CO', 'DL', 'EV', 'F9', 'FL', 'HA', 'MQ', 'NW', 'OH', 'OO', 'UA', 'US', 'WN', 'XE', 'YV'], UniqueCarrier)"
+    validate_expression(expr, {'UniqueCarrier'}, {'searchsorted'})
     expr_translate = translate(expr, lambda x: None)
     print(node)
     assert expr == expr_translate
 
 def test_dicts():
     expr = "fillmissing(o, {'a': 1})"
+    validate_expression(expr, {'o'}, {'fillmissing'})
     node = parse_expression(expr)
     assert node is not None
     expr_translate = translate(expr, lambda x: None)

--- a/tests/expresso_test.py
+++ b/tests/expresso_test.py
@@ -61,6 +61,13 @@ def test_lists():
     print(node)
     assert expr == expr_translate
 
+def test_dicts():
+    expr = "fillmissing(o, {'a': 1})"
+    node = parse_expression(expr)
+    assert node is not None
+    expr_translate = translate(expr, lambda x: None)
+    print(node)
+    assert expr == expr_translate
 
 def test_validate():
     validate_expression('x + 1', {'x'})

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -41,14 +41,14 @@ df_e = vaex.from_arrays(a=np.array(['X', 'Y', 'Z']),
 def test_no_on():
     # just adds the columns
     df = df_a.join(df_b, rsuffix='_r')
-    assert df.columns['b'] is df_b.columns['b']
+    assert df.dataset.right._columns['b'] is df_b.dataset._columns['b']
 
 
 def test_join_masked():
     df = df_a.join(other=df_b, left_on='m', right_on='m', rsuffix='_r')
     assert df.evaluate('m').tolist() == [1, None, 3]
     assert df.evaluate('m_r').tolist() == [1, None, None]
-    assert df.columns['m_r'].indices.dtype == np.int8
+    assert df.dataset.right._columns['m_r'].indices.dtype == np.int8
 
 
 def test_join_nomatch():
@@ -301,7 +301,7 @@ def test_with_masked_no_short_circuit():
     df_right = vaex.from_arrays(i=np.arange(9), j=np.arange(9))
     with small_buffer(df, size=1):
         dfj = df.join(other=df_right, on='i')
-    assert dfj.columns['j'].masked
-    assert dfj[:10].columns['j'].masked
+    assert dfj.dataset.right._columns['j'].masked
+    assert dfj[:10].dataset.right._columns['j'].masked
     assert dfj['j'][:10].tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, None]
     dfj['j'].tolist()  # make sure we can evaluate the whole column

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -11,9 +11,9 @@ def test_slice_expression(df):
 
 
 def test_slice_against_numpy(df):
-    assert df.x[:2].tolist() == df.x.values[:2].tolist()
-    assert df.x[2:6].tolist() == df.x.values[2:6].tolist()
-    assert df.x[-3:].tolist() == df.x.values[-3:].tolist()
+    assert df.x[:2].tolist() == df.x.to_numpy()[:2].tolist()
+    assert df.x[2:6].tolist() == df.x.to_numpy()[2:6].tolist()
+    assert df.x[-3:].tolist() == df.x.to_numpy()[-3:].tolist()
     # we don't support non 1 steps
     # assert df.x[::-3].tolist() == df.x.values[::-3].tolist()
 
@@ -72,5 +72,5 @@ def test_slice_beyond_end(df):
 
 def test_slice_negative(df):
     df2 = df[:-1]
-    assert df2.x.tolist() == df.x.values[:-1].tolist()
+    assert df2.x.tolist() == df.x.to_numpy()[:-1].tolist()
     assert len(df2) == len(df)-1


### PR DESCRIPTION
This PR includes all refactors such that we can leverage Arrows Dataset API. This allows out of core dataframe backed by a parquet file. In principle goodies such as s3 support should work, but I haven't tried it yet.
Demo:
![image](https://user-images.githubusercontent.com/1765949/94953621-24b99d00-04e8-11eb-9b92-0375537288c2.png)

I think it's a bit on the slow side, for e.g. a single column, compared to sub 100ms for a memory mapped hdf5 or arrow file. But for slow storage/network this will speed up things quite a bit.