### PR TITLE
Update os.makedirs to use a exist_ok flag

### DIFF
--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -203,8 +203,7 @@ def get_private_dir(subdir=None, *extra):
     path = os.path.expanduser('~/.vaex')
     if subdir:
         path = os.path.join(path, subdir, *extra)
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path,exist_ok=True)
     return path
 
 


### PR DESCRIPTION
When using vaex with a multiprocessing library, or gunicorn with multiple gunicorn workers, the above condition fails sometimes. ( race condition between workers)

With this change, os.makedirs will fail silently if the directory already exists.


Please find the stacktrace below, this is a random behaviour i have seen.


 ```
 File "/app/dataframe_reader/minio_utils.py", line 19, in <module>
    from vaex_arrow.convert import column_from_arrow_array, vaex_df_from_arrow_table
  File "/usr/local/lib/python3.6/site-packages/vaex_arrow/convert.py", line 4, in <module>
    from vaex.column import ColumnStringArrow
  File "/usr/local/lib/python3.6/site-packages/vaex/__init__.py", line 49, in <module>
    import vaex.datasets
  File "/usr/local/lib/python3.6/site-packages/vaex/datasets.py", line 7, in <module>
    data_dir = vaex.utils.get_private_dir("data")
  File "/usr/local/lib/python3.6/site-packages/vaex/utils.py", line 207, in get_private_dir
    os.makedirs(path)
  File "/usr/local/lib/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/home/admin/.vaex/data'
```