### PR TITLE
Chore: LightGBM wrapper cleanup

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -5,7 +5,7 @@ geopandas
 graphviz
 h5py
 # libcxx=9.0.0
-lightgbm<3.0.0
+lightgbm
 matplotlib-base
 notebook
 numba

--- a/packages/vaex-ml/vaex/ml/lightgbm.py
+++ b/packages/vaex-ml/vaex/ml/lightgbm.py
@@ -1,19 +1,17 @@
-import ctypes
-import math
-import warnings
+import base64
+import tempfile
+
+import lightgbm
+
+import numpy as np
+
+import traitlets
 
 import vaex
-import lightgbm
-import numpy as np
-import tempfile
-import base64
 import vaex.serialize
-from . import state
-import traitlets
+
 from . import generate
-
-
-lib = lightgbm.basic._LIB
+from . import state
 
 
 @vaex.serialize.register
@@ -62,7 +60,6 @@ class LightGBMModel(state.HasState):
     '''
     snake_name = 'lightgbm_model'
     features = traitlets.List(traitlets.Unicode(), help='List of features to use when fitting the LightGBMModel.')
-    copy = traitlets.Bool(False, help='Copy data or use the modified xgboost library for efficient transfer.')
     target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
     num_boost_round = traitlets.CInt(help='Number of boosting iterations.')
     params = traitlets.Dict(help='parameters to be passed on the to the LightGBM model.')
@@ -87,8 +84,7 @@ class LightGBMModel(state.HasState):
         copy.add_virtual_column(self.prediction_name, expression, unique=False)
         return copy
 
-    def fit(self, df, valid_sets=None, valid_names=None, early_stopping_rounds=None, evals_result=None, verbose_eval=None,
-            copy=False, **kwargs):
+    def fit(self, df, valid_sets=None, valid_names=None, early_stopping_rounds=None, evals_result=None, verbose_eval=None, **kwargs):
         """Fit the LightGBMModel to the DataFrame.
 
         The model will train until the validation score stops improving.
@@ -105,26 +101,14 @@ class LightGBMModel(state.HasState):
         :param dict evals_result: A dictionary storing the evaluation results of all *valid_sets*.
         :param bool verbose_eval: Requires at least one item in *valid_sets*.
             If *verbose_eval* is True then the evaluation metric on the validation set is printed at each boosting stage.
-        :param bool copy: (default, False) If True, make an in memory copy of the data before passing it to LightGBMModel.
         """
 
-        if copy:
-            dtrain = lightgbm.Dataset(df[self.features].values, df.evaluate(self.target))
-            if valid_sets is not None:
-                for i, item in enumerate(valid_sets):
-                    valid_sets[i] = lightgbm.Dataset(item[self.features].values, item[self.target].values)
-            else:
-                valid_sets = ()
+        dtrain = lightgbm.Dataset(df[self.features].values, df.evaluate(self.target))
+        if valid_sets is not None:
+            for i, item in enumerate(valid_sets):
+                valid_sets[i] = lightgbm.Dataset(item[self.features].values, item[self.target].values)
         else:
-            dtrain = VaexDataset(df, self.target, features=self.features)
-            if valid_sets is not None:
-                for i, item in enumerate(valid_sets):
-                    # valid_sets[i] = VaexDataset(item, self.target, features=self.features)
-                    valid_sets[i] = lightgbm.Dataset(item[self.features].values, item[self.target].values)
-                    warnings.warn('''Validation sets do not obey the `copy=False` argument.
-                                  A standard in-memory copy is made for each validation set.''', UserWarning)
-            else:
-                valid_sets = ()
+            valid_sets = ()
 
         self.booster = lightgbm.train(params=self.params,
                                       train_set=dtrain,
@@ -165,69 +149,9 @@ class LightGBMModel(state.HasState):
         self.booster = lightgbm.Booster(model_file=filename)
 
 
-class VaexDataset(lightgbm.Dataset):
-    def __init__(self, df, label=None, features=None, blocksize=100*1000, sample_count=10*100, params={}):
-        super(VaexDataset, self).__init__(None)
-        self.df = df
-        self.features = features or self.df.get_column_names(virtual=True)
-        assert len(set(self.features)) == len(self.features), "using duplicate features"
-        self.blocksize = blocksize
-
-        self.data_references = {}
-
-        self.c_features = (ctypes.c_char_p * len(self.features))()
-        self.c_features[:] = [k.encode() for k in self.features]
-
-        self.handle = ctypes.c_void_p()
-
-        row_count = len(self.df)
-        ncol = len(self.features)
-        num_sample_row = min(sample_count, row_count)
-
-        data_list = [self.df.evaluate(k, i1=0, i2=num_sample_row).astype(np.float64) for k in self.features]
-        data_pointers = [k.ctypes.data_as(ctypes.POINTER(ctypes.c_double)) for k in data_list]
-        sample_data = (ctypes.POINTER(ctypes.c_double) * ncol)(*data_pointers)
-
-        indices = np.arange(num_sample_row, dtype=np.int32)
-        indices_pointers = [indices.ctypes.data_as(ctypes.POINTER(ctypes.c_int)) for k in range(ncol)]
-        sample_indices = (ctypes.POINTER(ctypes.c_int) * ncol)(*indices_pointers)
-        num_per_col = (ctypes.c_int * ncol)(*((num_sample_row,) * ncol))
-        parameters = ctypes.c_char_p(lightgbm.basic.param_dict_to_str(params).encode())
-
-        lightgbm.basic._safe_call(lib.LGBM_DatasetCreateFromSampledColumn(sample_data,
-                                                                          sample_indices,
-                                                                          ctypes.c_uint(ncol),
-                                                                          num_per_col,
-                                                                          ctypes.c_uint(num_sample_row),
-                                                                          ctypes.c_uint(row_count),
-                                                                          parameters,
-                                                                          ctypes.byref(self.handle)))
-
-        blocks = int(math.ceil(row_count / blocksize))
-        dtype = np.float64
-        for i in range(blocks):
-            i1 = i * blocksize
-            i2 = min(row_count, (i+1) * blocksize)
-            data = np.array([df.evaluate(k, i1=i1, i2=i2).astype(dtype) for k in self.features]).T.copy()
-            ctypemap = {np.float64: ctypes.c_double, np.float32: ctypes.c_float}
-            capi_typemap = {np.float64: lightgbm.basic.C_API_DTYPE_FLOAT64, np.float32: lightgbm.basic.C_API_DTYPE_FLOAT32}
-            lightgbm.basic._safe_call(lib.LGBM_DatasetPushRows(self.handle,
-                                                               data.ctypes.data_as(ctypes.POINTER(ctypemap[dtype])),
-                                                               ctypes.c_uint(capi_typemap[dtype]),
-                                                               ctypes.c_uint32(i2-i1),
-                                                               ctypes.c_uint32(ncol),
-                                                               ctypes.c_uint32(i1),
-                                                               ))
-
-        if label is not None:
-            self.label_data = self.df.evaluate(label)
-            self.set_label(self.label_data)
-
-
 if __name__ == "__main__":
     df = vaex.ml.iris()
     features = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width']
-    # ldf = VaexDataset(df, 'class_', features=features)
     ldf = lightgbm.Dataset(np.array(df[features]), df.data.class_)
     param = {'num_leaves': 31, 'num_trees': 100, 'objective': 'softmax', 'num_class': 3}
     num_boost_round = 30

--- a/packages/vaex-ml/vaex/ml/spec.json
+++ b/packages/vaex-ml/vaex/ml/spec.json
@@ -829,13 +829,6 @@
         "snake_name": "lightgbm_model",
         "traits": [
             {
-                "default": false,
-                "has_default": false,
-                "help": "Copy data or use the modified xgboost library for efficient transfer.",
-                "name": "copy",
-                "type": "Bool"
-            },
-            {
                 "default": null,
                 "has_default": true,
                 "help": "List of features to use when fitting the LightGBMModel.",

--- a/tests/ml/lightgbm_test.py
+++ b/tests/ml/lightgbm_test.py
@@ -49,7 +49,7 @@ def test_light_gbm_virtual_columns():
                                              params=params,
                                              features=features,
                                              target='class_')
-    booster.fit(ds_train, copy=False)
+    booster.fit(ds_train)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
@@ -60,8 +60,8 @@ def test_lightgbm():
     features = _ensure_strings_from_expressions(features)
     booster = vaex.ml.lightgbm.LightGBMModel(num_boost_round=10, params=params, features=features, target='class_')
 
-    booster.fit(ds_train, copy=True)    # for coverage
-    class_predict_train = booster.predict(ds_train, copy=True)  # for coverage
+    booster.fit(ds_train)    # for coverage
+    class_predict_train = booster.predict(ds_train)
     class_predict_test = booster.predict(ds_test)
     assert np.all(ds_test.col.class_.values == np.argmax(class_predict_test, axis=1))
 
@@ -101,7 +101,7 @@ def test_lightgbm_numerical_validation():
     lgb_pred = lgb_bst.predict(X)
 
     # Vaex.ml.lightgbm
-    booster = ds.ml.lightgbm_model(target=ds.class_, num_boost_round=3, features=features, params=params, copy=False, transform=False)
+    booster = ds.ml.lightgbm_model(target=ds.class_, num_boost_round=3, features=features, params=params, transform=False)
     vaex_pred = booster.predict(ds)
 
     # Comparing the the predictions of lightgbm vs vaex.ml
@@ -121,14 +121,13 @@ def test_lightgbm_validation_set():
     # instantiate the booster model
     booster = vaex.ml.lightgbm.LightGBMModel(features=features, target='E', num_boost_round=10, params=params_reg)
     # fit the booster - including saving the history of the validation sets
-    with pytest.warns(UserWarning):
-        booster.fit(train, valid_sets=[train, test], valid_names=['train', 'test'],
-                    early_stopping_rounds=2, evals_result=history, copy=False)
+
+    booster.fit(train, valid_sets=[train, test], valid_names=['train', 'test'], early_stopping_rounds=2, evals_result=history)
     assert booster.booster.best_iteration == 10
     assert len(history['train']['l2']) == 10
     assert len(history['test']['l2']) == 10
     booster.fit(train, valid_sets=[train, test], valid_names=['train', 'test'],
-                early_stopping_rounds=2, evals_result=history, copy=True)
+                early_stopping_rounds=2, evals_result=history)
     assert booster.booster.best_iteration == 10
     assert len(history['train']['l2']) == 10
     assert len(history['test']['l2']) == 10


### PR DESCRIPTION
This PR allows safely usage of the lightgbm wrapper through vaex.ml for the latest version(s) of lightgbm (>=3.0.0).

Vaex.ml implemented a special `VaexDataset` class built on top of the `lightgbm.Dataset` class, and allowed for more memory efficient way of passing vaex data to lightgbm. This came at some performance penalty. 

Lightgbm 3.0.0 introduced breaking changes to their Dataset. We do not currently have the capacity to maintain the `VaexDataset`, so it is best to remove it for now. If anybody in the community is willing to pick this up, they are welcome to. 
