### PR TITLE
refactor: dataset API returns chunks instead of callable (3x faster parquet reading 🔥)

### DIFF
--- a/packages/vaex-core/vaex/arrow/dataset.py
+++ b/packages/vaex-core/vaex/arrow/dataset.py
@@ -109,7 +109,10 @@ class DatasetArrow(vaex.dataset.Dataset):
                 chunk_start = offset
                 chunk_end = offset + rows
 
+                length = chunk_end - chunk_start  # default length
+
                 if start >= chunk_end:  # we didn't find the beginning yet
+                    offset += length
                     continue
                 if end < chunk_start:  # we are past the end
                     # assert False
@@ -119,7 +122,6 @@ class DatasetArrow(vaex.dataset.Dataset):
                     chunks = dict(zip(table.column_names, table.columns))
                     return chunks
 
-                length = chunk_end - chunk_start  # default length
                 if start > chunk_start:
                     # this means we have to cut off a piece of the beginning
                     if end < chunk_end:

--- a/packages/vaex-core/vaex/arrow/dataset.py
+++ b/packages/vaex-core/vaex/arrow/dataset.py
@@ -1,14 +1,31 @@
 __author__ = 'maartenbreddels'
 import collections
+import concurrent.futures
 import logging
+import multiprocessing
+import os
 
 import pyarrow as pa
 import pyarrow.dataset
 
 import vaex.dataset
 import vaex.file.other
-from .convert import column_from_arrow_array
-logger = logging.getLogger("vaex.arrow")
+
+
+logger = logging.getLogger("vaex.arrow.dataset")
+
+thread_count_default_io = os.environ.get('VAEX_NUM_THREADS_IO', multiprocessing.cpu_count() * 2 + 1)
+thread_count_default_io = int(thread_count_default_io)
+main_io_pool = None
+
+logger = logging.getLogger("vaex.multithreading")
+
+
+def get_main_io_pool():
+    global main_io_pool
+    if main_io_pool is None:
+        main_io_pool = concurrent.futures.ThreadPoolExecutor(max_workers=thread_count_default_io)
+    return main_io_pool
 
 
 class DatasetSliced(vaex.dataset.Dataset):
@@ -22,50 +39,7 @@ class DatasetSliced(vaex.dataset.Dataset):
         self._ids = {}
 
     def chunk_iterator(self, columns, chunk_size=None, reverse=False):
-        chunk_size = chunk_size or 1024*1024
-        dict_or_list_of_arrays = collections.defaultdict(list)
-        i1 = i2 = 0
-        for chunk_start, chunk_end, reader in self.original.chunk_iterator(columns, chunk_size=chunk_size):
-            if self.start >= chunk_end:  # we didn't find the beginning yet
-                continue
-            if self.end < chunk_start:  # we are past the end
-                break
-            slice_reader = reader  # default case, if we don't have to slice
-            length = chunk_end - chunk_start  # default length
-            if self.start > chunk_start:
-                # this means we have to cut off a piece of the beginning
-                if self.end < chunk_end:
-                    # AND the end
-                    length = self.end - chunk_start  # without the start cut off
-                    length -= self.start - chunk_start  # correcting for the start cut off
-                    def slice_reader(chunk_start=chunk_start, reader=reader, length=length):
-                        chunks = reader()
-                        chunks = {name: ar.slice(self.start - chunk_start, length) for name, ar in chunks.items()}
-                        for name, ar in chunks.items():
-                            assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
-                        return chunks
-                else:
-                    length -= self.start - chunk_start  # correcting for the start cut off
-                    def slice_reader(chunk_start=chunk_start, reader=reader, length=length):
-                        chunks = reader()
-                        chunks = {name: ar.slice(self.start - chunk_start) for name, ar in chunks.items()}
-                        for name, ar in chunks.items():
-                            assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
-                        return chunks
-            else:
-                if self.end < chunk_end:
-                    # we only need to cut off a piece of the end
-                    length = self.end - chunk_start
-                    def slice_reader(chunk_start=chunk_start, reader=reader, length=length):
-                        chunks = reader()
-                        chunks = {name: ar.slice(0, length) for name, ar in chunks.items()}
-                        for name, ar in chunks.items():
-                            assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
-                        return chunks
-                # else, the defaults apply
-            i2 = i1 + length
-            yield i1, i2, slice_reader
-            i1 = i2
+        yield from self.original.chunk_iterator(columns, chunk_size=chunk_size, reverse=reverse, start=self.start, end=self.end)
 
     def hashed(self):
         raise NotImplementedError
@@ -88,7 +62,8 @@ class DatasetArrow(vaex.dataset.Dataset):
         self._arrow_ds = ds
         row_count = 0
         for fragment in self._arrow_ds.get_fragments():
-            fragment.ensure_complete_metadata()
+            if hasattr(fragment, "ensure_complete_metadata"):
+                fragment.ensure_complete_metadata()
             for rg in fragment.row_groups:
                 row_count += rg.num_rows
         self._row_count = row_count
@@ -115,56 +90,145 @@ class DatasetArrow(vaex.dataset.Dataset):
         # no need to close it, it seem
         pass
 
-    def chunk_iterator(self, columns, chunk_size=None, reverse=False):
-        chunk_size = chunk_size or 1024*1024
-        i1 = 0
-        # Instead of looping over all fragments, they might be too big, so...
+    def _chunk_producer(self, columns, chunk_size=None, reverse=False, start=0, end=None):
+        pool = get_main_io_pool()
+        offset = 0
         for fragment_large in self._arrow_ds.get_fragments():
             fragment_large_rows = sum([rg.num_rows for rg in fragment_large.row_groups])
-            # then we split them up
-            if fragment_large_rows > chunk_size:
-                fragments = fragment_large.split_by_row_group()
-            else:
-                # or not
-                fragments = [fragment_large]
-            # now we collect fragments, until we hit the chunk_size
-            rows_planned = 0
-            fragments_planned = []
+            # when do we want to split up? File size? max chunk size?
+            # if fragment_large_rows > chunk_size:
+            #     fragments = fragment_large.split_by_row_group()
+            # else:
+            #     # or not
+            #     fragments = [fragment_large]
+            import pyarrow.parquet
+            fragments = [fragment_large]
             for fragment in fragments:
-                fragment_rows = sum([rg.num_rows for rg in fragment.row_groups])
-                # if adding the current fragment would make the chunk too large
-                # and we already have some fragments
-                if rows_planned + fragment_rows > chunk_size and rows_planned > 0:
-                    i2 = i1 + rows_planned
-                    yield i1, i2, self._make_reader(fragments_planned, chunk_size, columns, rows_planned)
-                    i1 = i2
-                    rows_planned = 0
-                    fragments_planned = []
-                fragments_planned.append(fragment)
-                rows_planned += fragment_rows
-            if rows_planned:
-                i2 = i1 + rows_planned
-                yield i1, i2, self._make_reader(fragments_planned, chunk_size, columns, rows_planned)
-                i1 = i2
-                rows_planned = 0
-                fragments_planned = []
+                rows = sum([rg.num_rows for rg in fragment.row_groups])
+                chunk_start = offset
+                chunk_end = offset + rows
 
-    def _make_reader(self, fragments, chunk_size, columns, rows_planned):
-        def reader():
-            record_batches = []
-            for fragment in fragments:
-                for scan_task in fragment.scan(batch_size=chunk_size, use_threads=False, columns=columns):
-                    for record_batch in scan_task.execute():
-                        record_batches.append((record_batch))
-            dict_or_list_of_arrays = collections.defaultdict(list)
-            for rb in record_batches:
-                for name, array in zip(rb.schema.names, rb.columns):
-                    dict_or_list_of_arrays[name].append(array)
-            chunks = {name: pa.chunked_array(arrays) for name, arrays in dict_or_list_of_arrays.items()}
-            for name, chunk in chunks.items():
-                assert len(chunk) == rows_planned, f'Oops, got a chunk ({name}) of length {len(chunk)} while it is expected to be of length {rows_planned}'
-            return chunks
-        return reader
+                if start >= chunk_end:  # we didn't find the beginning yet
+                    continue
+                if end < chunk_start:  # we are past the end
+                    # assert False
+                    break
+                def reader(fragment=fragment):
+                    table = fragment.to_table(columns=columns, use_threads=False)
+                    chunks = dict(zip(table.column_names, table.columns))
+                    return chunks
+
+                length = chunk_end - chunk_start  # default length
+                if start > chunk_start:
+                    # this means we have to cut off a piece of the beginning
+                    if end < chunk_end:
+                        # AND the end
+                        length = end - chunk_start  # without the start cut off
+                        length -= start - chunk_start  # correcting for the start cut off
+                        def slicer(chunk_start=chunk_start, reader=reader, length=length):
+                            chunks = reader()
+                            chunks = {name: ar.slice(start - chunk_start, length) for name, ar in chunks.items()}
+                            for name, ar in chunks.items():
+                                assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
+                            return chunks
+                        reader = slicer
+                    else:
+                        length -= start - chunk_start  # correcting for the start cut off
+                        def slicer(chunk_start=chunk_start, reader=reader, length=length):
+                            chunks = reader()
+                            chunks = {name: ar.slice(start - chunk_start) for name, ar in chunks.items()}
+                            for name, ar in chunks.items():
+                                assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
+                            return chunks
+                        reader = slicer
+                else:
+                    if end < chunk_end:
+                        # we only need to cut off a piece of the end
+                        length = end - chunk_start
+                        def slicer(chunk_start=chunk_start, reader=reader, length=length):
+                            chunks = reader()
+                            chunks = {name: ar.slice(0, length) for name, ar in chunks.items()}
+                            for name, ar in chunks.items():
+                                assert len(ar) == length, f'Oops, array was expected to be of length {length} but was {len(ar)}'
+                            return chunks
+                        reader = slicer
+                offset += length
+                yield pool.submit(reader)
+
+    def chunk_iterator(self, columns, chunk_size=None, reverse=False, start=0, end=None):
+        chunk_size = chunk_size or 1024*1024
+        i1 = 0
+        lenghts = set()
+        cuts = 0
+        chunks_ready_list = []
+        i1 = i2 = 0
+        def get(chunks_ready_list):
+            nonlocal cuts
+            current_row_count = 0
+            chunks_current_list = []
+            while current_row_count < chunk_size and chunks_ready_list:
+                chunks_current = chunks_ready_list.pop(0)
+                chunk = list(chunks_current.values())[0]
+                # chunks too large, split, and put back a part
+                if current_row_count + len(chunk) > chunk_size:
+                    strict = True
+                    if strict:
+                        needed_length = chunk_size - current_row_count
+                        current_row_count += needed_length
+                        assert current_row_count == chunk_size
+                        if needed_length not in lenghts:
+                            lenghts.add(needed_length)
+                        cuts += 1
+
+                        chunks_head = {name: chunk.slice(0, needed_length) for name, chunk in chunks_current.items()}
+                        chunks_current_list.append(chunks_head)
+                        chunks_extra = {name: chunk.slice(needed_length) for name, chunk in chunks_current.items()}
+                        chunks_ready_list.insert(0, chunks_extra)  # put back the extra in front
+                    else:
+                        current_row_count += len(chunk)
+                        chunks_current_list.append(chunks_current)
+                else:
+                    current_row_count += len(chunk)
+                    chunks_current_list.append(chunks_current)
+            return chunks_current_list, current_row_count
+
+        for chunks_future in read_ahead(self._chunk_producer(columns, chunk_size, start=start, end=end or self._row_count), thread_count_default_io+3):
+            chunks = chunks_future.result()
+            chunks_ready_list.append(chunks)
+            total_row_count = sum([len(list(k.values())[0]) for k in chunks_ready_list])
+            if total_row_count > chunk_size:
+                chunks_current_list, current_row_count = get(chunks_ready_list)
+                i2 += current_row_count
+                yield i1, i2, _concat(chunks_current_list)
+                i1 = i2
+
+        while chunks_ready_list:
+            chunks_current_list, current_row_count = get(chunks_ready_list)
+            i2 += current_row_count
+            yield i1, i2, _concat(chunks_current_list)
+            i1 = i2
+
+
+def read_ahead(i, n=1):
+    values = []
+    try:
+        for _ in range(n-1):
+            values.append(next(i))
+        while True:
+            values.append(next(i))
+            yield values.pop(0)
+    except StopIteration:
+        pass
+    yield from values
+
+
+def _concat(list_of_chunks):
+    dict_of_list_of_arrays = collections.defaultdict(list)
+    for chunks in list_of_chunks:
+        for name, array in chunks.items():
+            dict_of_list_of_arrays[name].extend(array.chunks)
+    chunks = {name: pa.chunked_array(arrays) for name, arrays in dict_of_list_of_arrays.items()}
+    return chunks
 
 
 def from_table(table, as_numpy=False):

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -202,13 +202,12 @@ class ExecutorLocal(Executor):
         finally:
             self.local.executing = False
 
-    def process_part(self, thread_index, i1, i2, chunk_reader, run):
+    def process_part(self, thread_index, i1, i2, chunks, run):
         if not run.cancelled:
             if thread_index >= len(run.block_scopes):
                 raise ValueError(f'thread_index={thread_index} while only having {len(run.block_scopes)} blocks')
             block_scope = run.block_scopes[thread_index]
             block_scope.move(i1, i2)
-            chunks = chunk_reader()
             df = run.df
             N = i2 - i1
             for name, chunk in chunks.items():

--- a/packages/vaex-core/vaex/itertools.py
+++ b/packages/vaex-core/vaex/itertools.py
@@ -1,0 +1,11 @@
+def buffer(i, n=1):
+    values = []
+    try:
+        for _ in range(n-1):
+            values.append(next(i))
+        while True:
+            values.append(next(i))
+            yield values.pop(0)
+    except StopIteration:
+        pass
+    yield from values

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -69,7 +69,7 @@ def test_array_rename():
     assert ds2['y'] is y
     assert ds2['z'] is x
 
-    assert 'z' in list(ds2.chunk_iterator(['z']))[0][-1]()
+    assert 'z' in list(ds2.chunk_iterator(['z']))[0][-1]
 
     assert ds1 != ds2
     assert rebuild(ds1) != rebuild(ds2)
@@ -249,20 +249,17 @@ def test_chunk_iterator():
     y = x**2
     ds = dataset.DatasetArrays(x=x, y=y)
     chunk_it = ds.chunk_iterator(['y'], chunk_size=4)
-    i1, i2, reader = next(chunk_it)
-    chunk0 = reader()
+    i1, i2, chunk0 = next(chunk_it)
     assert chunk0['y'].tolist() == y[0:4].tolist()
     assert i1 == 0
     assert i2 == 4
 
-    i1, i2, reader = next(chunk_it)
-    chunk1 = reader()
+    i1, i2, chunk1 = next(chunk_it)
     assert chunk1['y'].tolist() == y[4:8].tolist()
     assert i1 == 4
     assert i2 == 8
 
-    i1, i2, reader = next(chunk_it)
-    chunk2 = reader()
+    i1, i2, chunk2 = next(chunk_it)
     assert chunk2['y'].tolist() == y[8:].tolist()
     assert i1 == 8
     assert i2 == 10


### PR DESCRIPTION
This makes it easier to implement streaming input, and with
this new implementation the parquet reading is about 3x faster.

Compared to https://github.com/vaexio/vaex/pull/993 where it took 3 seconds to go over a single columns, it is now subsecond.