### PR TITLE
Change default value from `''` to `None` in vaex.ml.sklearn.Predictor

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         submodules: true
     - uses: actions/checkout@v2
-      if: ${{ github.event.pull_request.head.repo.full_name == 'vaexio/vaex' }}
+      if: ${{ (github.event.pull_request.head.repo.full_name == 'vaexio/vaex') && (matrix.os == 'linux-latest') }}
       with:
         repository: vaexio/vaex-enterprise
         token: ${{ secrets.PAT_PULL_ENTERPRISE }}
@@ -80,7 +80,7 @@ jobs:
       run: |
         ./ci/03-install-vaex.sh
     - name: Install vaex-enterprise
-      if: ${{ github.event.pull_request.head.repo.full_name == 'vaexio/vaex' }}
+      if: ${{ (github.event.pull_request.head.repo.full_name == 'vaexio/vaex') && (matrix.os == 'linux-latest') }}
       shell: bash
       run: |
         conda config --set always_yes yes --set changeps1 no
@@ -105,7 +105,7 @@ jobs:
         python -m vaex.ml.spec packages/vaex-ml/vaex/ml/spec_new.json
         diff packages/vaex-ml/vaex/ml/spec_new.json packages/vaex-ml/vaex/ml/spec.json
     - name: Test with pytest (vaex-enterprise)
-      if: ${{ github.event.pull_request.head.repo.full_name == 'vaexio/vaex' }}
+      if: ${{ (github.event.pull_request.head.repo.full_name == 'vaexio/vaex') && (matrix.os == 'linux-latest') }}
       shell: bash
       run: |
         source activate vaex-dev

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -51,7 +51,6 @@ class Predictor(state.HasState):
      1             6.1            3               4.6            1.4         1  1.56469
      2             6.6            2.9             4.6            1.3         1  1.44276
     '''
-    snake_name = 'sklearn_predictor'
     model = traitlets.Any(default_value=None, allow_none=True, help='A scikit-learn estimator.').tag(**serialize_pickle)
     features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
     target = traitlets.Unicode(default_value=None, allow_none=True, help='The name of the target column.')
@@ -73,21 +72,21 @@ class Predictor(state.HasState):
             return self.model.predict_log_proba(X)
 
     def predict(self, df):
-        '''Get an in-memory numpy array with the predictions of the SKLearnPredictor.self
+        '''Get an in-memory numpy array with the predictions of the Predictor.
 
         :param df: A vaex DataFrame, containing the input features.
-        :returns: A in-memory numpy array containing the SKLearnPredictor predictions.
+        :returns: A in-memory numpy array containing the Predictor predictions.
         :rtype: numpy.array
         '''
         return self.transform(df)[self.prediction_name].values
 
     def transform(self, df):
-        '''Transform a DataFrame such that it contains the predictions of the SKLearnPredictor.
+        '''Transform a DataFrame such that it contains the predictions of the Predictor.
         in form of a virtual column.
 
         :param df: A vaex DataFrame.
 
-        :return copy: A shallow copy of the DataFrame that includes the SKLearnPredictor prediction as a virtual column.
+        :return copy: A shallow copy of the DataFrame that includes the Predictor prediction as a virtual column.
         :rtype: DataFrame
         '''
         copy = df.copy()
@@ -97,7 +96,7 @@ class Predictor(state.HasState):
         return copy
 
     def fit(self, df, **kwargs):
-        '''Fit the SKLearnPredictor to the DataFrame.
+        '''Fit the Predictor to the DataFrame.
 
         :param df: A vaex DataFrame containing the features and target on which to train the model.
         '''
@@ -190,10 +189,10 @@ class IncrementalPredictor(state.HasState):
             return self.model.predict_log_proba(X)
 
     def predict(self, df):
-        '''Get an in-memory numpy array with the predictions of the SKLearnPredictor.self
+        '''Get an in-memory numpy array with the predictions of the Predictor
 
         :param df: A vaex DataFrame, containing the input features.
-        :returns: A in-memory numpy array containing the SKLearnPredictor predictions.
+        :returns: A in-memory numpy array containing the Predictor predictions.
         :rtype: numpy.array
         '''
 

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -51,6 +51,7 @@ class Predictor(state.HasState):
      1             6.1            3               4.6            1.4         1  1.56469
      2             6.6            2.9             4.6            1.3         1  1.44276
     '''
+    snake_name = 'sklearn_predictor'
     model = traitlets.Any(default_value=None, allow_none=True, help='A scikit-learn estimator.').tag(**serialize_pickle)
     features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
     target = traitlets.Unicode(default_value=None, allow_none=True, help='The name of the target column.')

--- a/packages/vaex-ml/vaex/ml/sklearn.py
+++ b/packages/vaex-ml/vaex/ml/sklearn.py
@@ -54,7 +54,7 @@ class Predictor(state.HasState):
     snake_name = 'sklearn_predictor'
     model = traitlets.Any(default_value=None, allow_none=True, help='A scikit-learn estimator.').tag(**serialize_pickle)
     features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
-    target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
+    target = traitlets.Unicode(default_value=None, allow_none=True, help='The name of the target column.')
     prediction_name = traitlets.Unicode(default_value='prediction', help='The name of the virtual column housing the predictions.')
     prediction_type = traitlets.Enum(values=['predict', 'predict_proba', 'predict_log_proba'], default_value='predict',
                                      help='Which method to use to get the predictions. \
@@ -103,7 +103,10 @@ class Predictor(state.HasState):
         '''
 
         X = df[self.features].values
-        y = df.evaluate(self.target)
+        if self.target is not None:
+            y = df.evaluate(self.target)
+        else:
+            y = None
         self.model.fit(X=X, y=y, **kwargs)
 
 

--- a/packages/vaex-ml/vaex/ml/spec.json
+++ b/packages/vaex-ml/vaex/ml/spec.json
@@ -655,7 +655,7 @@
                 "type": "Enum"
             },
             {
-                "default": "",
+                "default": null,
                 "has_default": false,
                 "help": "The name of the target column.",
                 "name": "target",


### PR DESCRIPTION
As the title says, this PR changes the default value from `''` to `None` in `vaex.ml.sklearn.Predictor`.

This was motivated by #1004 . While the `vaex.ml.sklearn.Predictor` class is not meant to be used for sklearn classes that are not estimators/predictors (i.e. classes that do not implement the `.predict` method) , which change gives a bit better user experience. 

N.B: This is not a breaking chance. 