### PR TITLE
Enable unique for datetime64 and timedelta64 expressions

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -622,6 +622,8 @@ class DataFrame(object):
                     keys = np.array(keys)
                 else:
                     keys = ordered_set.key_array()
+                    if data_type_item.is_datetime or data_type_item.is_timedelta:
+                        keys = keys.view(data_type_item.numpy)
                     deletes = []
                     if dropmissing and ordered_set.has_null:
                         deletes.append(ordered_set.null_value)

--- a/packages/vaex-core/vaex/datatype.py
+++ b/packages/vaex-core/vaex/datatype.py
@@ -221,6 +221,9 @@ class DataType:
         datetime64[ns]
         >>> date_type == 'datetime'
         True
+        >>> date_type = DataType(pa.large_string())
+        >>> date_type.is_datetime
+        False
         """
         if self.is_arrow:
             return pa.types.is_timestamp(self.internal)
@@ -238,7 +241,12 @@ class DataType:
         True
         >>> dtype.is_timedelta
         True
+        >>> date_type = DataType(pa.large_string())
+        >>> date_type.is_timedelta
+        False
         '''
+        if self.is_string:
+            return False
         return vaex.array_types.to_numpy_type(self.internal).kind in 'm'
 
     @property

--- a/tests/unique_test.py
+++ b/tests/unique_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 from common import small_buffer
 
 import pytest
@@ -102,3 +104,25 @@ def test_unique_categorical(df_factory, future):
         assert df.x.dtype == int
         assert set(df.x.unique()) == {0, 1, 2}
         assert df.x.nunique() == 3
+
+
+def test_unique_datetime_timedelta():
+    x = [1, 2, 3, 1, 1]
+    date = [np.datetime64('2020-01-01'),
+            np.datetime64('2020-01-02'),
+            np.datetime64('2020-01-03'),
+            np.datetime64('2020-01-01'),
+            np.datetime64('2020-01-01')]
+
+    df = vaex.from_arrays(x=x, date=date)
+    df['delta'] = df.date - np.datetime64('2020-01-01')  # for creating a timedelta column
+
+    unique_date = df.unique(expression='date')
+    assert set(unique_date) == {datetime.date(2020, 1, 1),
+                                datetime.date(2020, 1, 2),
+                                datetime.date(2020, 1, 3)}
+
+    unique_delta = df.unique(expression='delta')
+    assert set(unique_delta) == {datetime.timedelta(0),
+                                 datetime.timedelta(days=1),
+                                 datetime.timedelta(days=2)}


### PR DESCRIPTION
This PR enables the `unique` method to be valid for expressions of type `datetime64` and `timedelta64`

 - [x] Implement unit tests
 - [x] Tests pass