### PR TITLE
Improve vaex.open docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -380,6 +380,9 @@ intersphinx_mapping = {
     's3fs': ('https://s3fs.readthedocs.io/en/latest', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'dask': ('http://docs.dask.org/en/latest/', None),
+    'gcsfs': ('https://gcsfs.readthedocs.io/en/latest/', None),
+    's3fs': ('https://s3fs.readthedocs.io/en/latest/', None),
+    'arrow': ('https://arrow.readthedocs.io/en/stable/', None)
 }
 
 nbsphinx_thumbnails = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -382,7 +382,7 @@ intersphinx_mapping = {
     'dask': ('http://docs.dask.org/en/latest/', None),
     'gcsfs': ('https://gcsfs.readthedocs.io/en/latest/', None),
     's3fs': ('https://s3fs.readthedocs.io/en/latest/', None),
-    'arrow': ('https://arrow.readthedocs.io/en/stable/', None)
+    'pyarrow': ('https://arrow.readthedocs.io/en/stable/', None)
 }
 
 nbsphinx_thumbnails = {

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -101,43 +101,54 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
     >>> df = vaex.open('somedata*.csv', convert='bigdata.hdf5')
 
     :param str or list path: local or absolute path to file, or glob string, or list of paths
-    :param convert: convert files to an hdf5 file for optimization, can also be a path
+    :param convert: Uses `dataframe.export` when convert is a path. If True, ``convert=path+'.hdf5'``
+                    The conversion is skipped if the path already exists.
     :param bool shuffle: shuffle converted DataFrame or not
-    :param bool copy_index: copy index when source is read via pandas
-    :param dict fs_options: coming soon...
+    :param dict fs_options: Extra arguments passed to an optional file system if needed:
+        * Amazon AWS S3
+            * :py.class:`pyarrow.fs.S3FileSystem` - If supported by Arrow.
+            * :py:class:`s3fs.core.S3FileSystem` - Used for globbing and fallback.
+        * Google Cloud Storage
+            * :py:class:`gcsfs.core.GCSFileSystem`
+        In addition you can pass the boolean "cache" option.
     :param args: extra arguments for file readers that need it
     :param kwargs: extra keyword arguments
     :return: return a DataFrame on success, otherwise None
     :rtype: DataFrame
 
-    S3 support:
+    Cloud storage support:
 
-    Vaex supports streaming of hdf5 files from Amazon AWS object storage S3.
-    Files are by default cached in $HOME/.vaex/file-cache/s3 such that successive access
-    is as fast as native disk access. The following url parameters control S3 options:
+    Vaex supports streaming of HDF5 files from Amazon AWS S3 and Google Cloud Storage.
+    Files are by default cached in $HOME/.vaex/file-cache/(s3|gs) such that successive access
+    is as fast as native disk access.
+
+    The following common fs_options are used for S3 access:
 
      * anon: Use anonymous access or not (false by default). (Allowed values are: true,True,1,false,False,0)
-     * use_cache: Use the disk cache or not, only set to false if the data should be accessed once. (Allowed values are: true,True,1,false,False,0)
-     * profile and other arguments are passed to :py:class:`s3fs.core.S3FileSystem`
+     * cache: Use the disk cache or not, only set to false if the data should be accessed once. (Allowed values are: true,True,1,false,False,0)
+     * profile and other arguments are passed to `pyarrow.fs.S3FileSystem` or :py:class:`s3fs.core.S3FileSystem`.
 
-    All arguments can also be passed as kwargs, but then arguments such as `anon` can only be a boolean, not a string.
+    All fs_options can also be encoded in the file path as a query string.
 
     Examples:
 
+    >>> df = vaex.open('s3://vaex/taxi/yellow_taxi_2015_f32s.hdf5', fs_options={'anon': True})
     >>> df = vaex.open('s3://vaex/taxi/yellow_taxi_2015_f32s.hdf5?anon=true')
-    >>> df = vaex.open('s3://vaex/taxi/yellow_taxi_2015_f32s.hdf5', anon=True)  # Note that anon is a boolean, not the string 'true'
-    >>> df = vaex.open('s3://mybucket/path/to/file.hdf5?profile=myprofile')
+    >>> df = vaex.open('s3://mybucket/path/to/file.hdf5', fs_options={'access_key': my_key, 'secret_key': my_secret_key})
+    >>> df = vaex.open(f's3://mybucket/path/to/file.hdf5?access_key={{my_key}}&secret_key={{my_secret_key}}')
+    >>> df = vaex.open('s3://mybucket/path/to/file.hdf5?profile=myproject')
 
-    GCS support:
-    Vaex supports streaming of hdf5 files from Google Cloud Storage.
-    Files are by default cached in $HOME/.vaex/file-cache/gs such that successive access
-    is as fast as native disk access. The following url parameters control GCS options:
+    Google Cloud Storage support:
+
+    The following fs_options are used for GCP access:
+
      * token: Authentication method for GCP. Use 'anon' for annonymous access. See https://gcsfs.readthedocs.io/en/latest/index.html#credentials for more details.
-     * use_cache: Use the disk cache or not, only set to false if the data should be accessed once. (Allowed values are: true,True,1,false,False,0).
+     * cache: Use the disk cache or not, only set to false if the data should be accessed once. (Allowed values are: true,True,1,false,False,0).
      * project and other arguments are passed to :py:class:`gcsfs.core.GCSFileSystem`
 
     Examples:
 
+    >>> df = vaex.open('gs://vaex-data/airlines/us_airline_data_1988_2019.hdf5', fs_options={'token': None})
     >>> df = vaex.open('gs://vaex-data/airlines/us_airline_data_1988_2019.hdf5?token=anon')
     >>> df = vaex.open('gs://vaex-data/testing/xys.hdf5?token=anon&cache=False')
     """

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -198,8 +198,22 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
                     )
                     ds = vaex.dataset.open(path_output, fs_options=fs_options)
                 else:
+<<<<<<< HEAD
                     ds = vaex.dataset.open(path, fs_options=fs_options)
                 df = vaex.from_dataset(ds)
+=======
+                    if ext == '.csv' or naked_path.endswith(".csv.bz2"):  # special support for csv.. should probably approach it a different way
+                        csv_convert = filename_hdf5 if convert else False
+                        df = from_csv(path, convert=csv_convert, **kwargs)
+                    else:
+                        ds = vaex.dataset.open(path, fs_options=fs_options, *args, **kwargs)
+                        if ds is not None:
+                            df = vaex.from_dataset(ds)
+                        if convert and ds is not None:
+                            df = vaex.from_dataset(ds)
+                            df.export_hdf5(filename_hdf5, shuffle=shuffle)
+                            df = vaex.open(filename_hdf5)
+>>>>>>> chore(core): Remove copy_index as a defined kwarg from vaex.open
                 if df is None:
                     if os.path.exists(path):
                         raise IOError('Could not open file: {}, did you install vaex-hdf5? Is the format supported?'.format(path))

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -103,6 +103,8 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
     :param str or list path: local or absolute path to file, or glob string, or list of paths
     :param convert: convert files to an hdf5 file for optimization, can also be a path
     :param bool shuffle: shuffle converted DataFrame or not
+    :param bool copy_index: copy index when source is read via pandas
+    :param dict fs_options: coming soon...
     :param args: extra arguments for file readers that need it
     :param kwargs: extra keyword arguments
     :return: return a DataFrame on success, otherwise None

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -102,7 +102,7 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
 
     :param str or list path: local or absolute path to file, or glob string, or list of paths
     :param convert: Uses `dataframe.export` when convert is a path. If True, ``convert=path+'.hdf5'``
-                    The conversion is skipped if the path already exists.
+                    The conversion is skipped if the input file or conversion argument did not change.
     :param bool shuffle: shuffle converted DataFrame or not
     :param dict fs_options: Extra arguments passed to an optional file system if needed:
         * Amazon AWS S3

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -106,8 +106,12 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
     :param bool shuffle: shuffle converted DataFrame or not
     :param dict fs_options: Extra arguments passed to an optional file system if needed:
         * Amazon AWS S3
-            * :py.class:`pyarrow.fs.S3FileSystem` - If supported by Arrow.
-            * :py:class:`s3fs.core.S3FileSystem` - Used for globbing and fallback.
+            * `anonymous` - access file without authentication (public files)
+            * `access_key` - AWS access key, if not provided will use the standard env vars, or the `~/.aws/credentials` file 
+            * `secret_key` - AWS secret key, similar to `access_key`
+            * `profile` - If multiple profiles are present in `~/.aws/credentials`, pick this one instead of 'default', see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
+            * `region` - AWS Region, e.g. 'us-east-1`, will be determined automatically if not provided.
+            * `endpoint_override` - URL/ip to connect to, instead of AWS, e.g. 'localhost:9000' for minio
         * Google Cloud Storage
             * :py:class:`gcsfs.core.GCSFileSystem`
         In addition you can pass the boolean "cache" option.
@@ -126,13 +130,12 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
 
      * anon: Use anonymous access or not (false by default). (Allowed values are: true,True,1,false,False,0)
      * cache: Use the disk cache or not, only set to false if the data should be accessed once. (Allowed values are: true,True,1,false,False,0)
-     * profile and other arguments are passed to `pyarrow.fs.S3FileSystem` or :py:class:`s3fs.core.S3FileSystem`.
 
     All fs_options can also be encoded in the file path as a query string.
 
     Examples:
 
-    >>> df = vaex.open('s3://vaex/taxi/yellow_taxi_2015_f32s.hdf5', fs_options={'anon': True})
+    >>> df = vaex.open('s3://vaex/taxi/yellow_taxi_2015_f32s.hdf5', fs_options={'anonymous': True})
     >>> df = vaex.open('s3://vaex/taxi/yellow_taxi_2015_f32s.hdf5?anon=true')
     >>> df = vaex.open('s3://mybucket/path/to/file.hdf5', fs_options={'access_key': my_key, 'secret_key': my_secret_key})
     >>> df = vaex.open(f's3://mybucket/path/to/file.hdf5?access_key={{my_key}}&secret_key={{my_secret_key}}')
@@ -209,22 +212,8 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
                     )
                     ds = vaex.dataset.open(path_output, fs_options=fs_options)
                 else:
-<<<<<<< HEAD
                     ds = vaex.dataset.open(path, fs_options=fs_options)
                 df = vaex.from_dataset(ds)
-=======
-                    if ext == '.csv' or naked_path.endswith(".csv.bz2"):  # special support for csv.. should probably approach it a different way
-                        csv_convert = filename_hdf5 if convert else False
-                        df = from_csv(path, convert=csv_convert, **kwargs)
-                    else:
-                        ds = vaex.dataset.open(path, fs_options=fs_options, *args, **kwargs)
-                        if ds is not None:
-                            df = vaex.from_dataset(ds)
-                        if convert and ds is not None:
-                            df = vaex.from_dataset(ds)
-                            df.export_hdf5(filename_hdf5, shuffle=shuffle)
-                            df = vaex.open(filename_hdf5)
->>>>>>> chore(core): Remove copy_index as a defined kwarg from vaex.open
                 if df is None:
                     if os.path.exists(path):
                         raise IOError('Could not open file: {}, did you install vaex-hdf5? Is the format supported?'.format(path))

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -38,6 +38,7 @@ from .column import Column, ColumnIndexed, ColumnSparse, ColumnString, ColumnCon
 from . import array_types
 import vaex.events
 from .datatype import DataType
+from .docstrings import docsubst
 
 # py2/p3 compatibility
 try:
@@ -100,48 +101,6 @@ def get_main_executor():
 
 # we import after function_mapping is defined
 from .expression import Expression
-
-
-_doc_snippets = {}
-_doc_snippets["expression"] = "expression or list of expressions, e.g. df.x, 'x', or ['x, 'y']"
-_doc_snippets["expression_one"] = "expression in the form of a string, e.g. 'x' or 'x+y' or vaex expression object, e.g. df.x or df.x+df.y "
-_doc_snippets["expression_single"] = "if previous argument is not a list, this argument should be given"
-_doc_snippets["binby"] = "List of expressions for constructing a binned grid"
-_doc_snippets["limits"] = """description for the min and max values for the expressions, e.g. 'minmax' (default), '99.7%', [0, 10], or a list of, e.g. [[0, 10], [0, 20], 'minmax']"""
-_doc_snippets["shape"] = """shape for the array where the statistic is calculated on, if only an integer is given, it is used for all dimensions, e.g. shape=128, shape=[128, 256]"""
-_doc_snippets["percentile_limits"] = """description for the min and max values to use for the cumulative histogram, should currently only be 'minmax'"""
-_doc_snippets["percentile_shape"] = """shape for the array where the cumulative histogram is calculated on, integer type"""
-_doc_snippets["selection"] = """Name of selection to use (or True for the 'default'), or all the data (when selection is None or False), or a list of selections"""
-_doc_snippets["selection1"] = """Name of selection to use (or True for the 'default'), or all the data (when selection is None or False)"""
-_doc_snippets["delay"] = """Do not return the result, but a proxy for delayhronous calculations (currently only for internal use)"""
-_doc_snippets["progress"] = """A callable that takes one argument (a floating point value between 0 and 1) indicating the progress, calculations are cancelled when this callable returns False"""
-_doc_snippets["expression_limits"] = _doc_snippets["expression"]
-_doc_snippets["grid"] = """If grid is given, instead if compuation a statistic given by what, use this Nd-numpy array instead, this is often useful when a custom computation/statistic is calculated, but you still want to use the plotting machinery."""
-_doc_snippets["edges"] = """Currently for internal use only (it includes nan's and values outside the limits at borders, nan and 0, smaller than at 1, and larger at -1"""
-
-_doc_snippets["healpix_expression"] = """Expression which maps to a healpix index, for the Gaia catalogue this is for instance 'source_id/34359738368', other catalogues may simply have a healpix column."""
-_doc_snippets["healpix_max_level"] = """The healpix level associated to the healpix_expression, for Gaia this is 12"""
-_doc_snippets["healpix_level"] = """The healpix level to use for the binning, this defines the size of the first dimension of the grid."""
-
-_doc_snippets["return_stat_scalar"] = """Numpy array with the given shape, or a scalar when no binby argument is given, with the statistic"""
-_doc_snippets["return_limits"] = """List in the form [[xmin, xmax], [ymin, ymax], .... ,[zmin, zmax]] or [xmin, xmax] when expression is not a list"""
-_doc_snippets["cov_matrix"] = """List all convariance values as a double list of expressions, or "full" to guess all entries (which gives an error when values are not found), or "auto" to guess, but allow for missing values"""
-_doc_snippets['propagate_uncertainties'] = """If true, will propagate errors for the new virtual columns, see :meth:`propagate_uncertainties` for details"""
-_doc_snippets['note_copy'] = '.. note:: Note that no copy of the underlying data is made, only a view/reference is made.'
-_doc_snippets['note_filter'] = '.. note:: Note that filtering will be ignored (since they may change), you may want to consider running :meth:`extract` first.'
-_doc_snippets['inplace'] = 'Make modifications to self or return a new DataFrame'
-_doc_snippets['return_shallow_copy'] = 'Returns a new DataFrame with a shallow copy/view of the underlying data'
-_doc_snippets['chunk_size'] = 'Return an iterator with cuts of the object in lenght of this size'
-_doc_snippets['chunk_size_export'] = 'Number of rows to be written to disk in a single iteration'
-_doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel'
-_doc_snippets['array_type'] = 'Type of output array, possible values are None/"numpy" (ndarray), "xarray" for a xarray.DataArray, or "list" for a Python list'
-_doc_snippets['ascii'] = 'Transform only ascii characters (usually faster).'
-
-
-def docsubst(f):
-    if f.__doc__:
-        f.__doc__ = f.__doc__.format(**_doc_snippets)
-    return f
 
 
 _functions_statistics_1d = []

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5796,7 +5796,7 @@ class DataFrameLocal(DataFrame):
         :param progress: {progress}
         :param int chunk_size: {chunk_size_export}, if supported.
         :param bool parallel: {evaluate_parallel}
-        :param dict fs_options: Coming soon...
+        :param dict fs_options: {fs_options}
         :return:
         """
         naked_path, options = vaex.file.split_options(path)
@@ -5823,9 +5823,9 @@ class DataFrameLocal(DataFrame):
         :param int chunk_size: {chunk_size_export}
         :param bool parallel: {evaluate_parallel}
         :param bool reduce_large: If True, convert arrow large_string type to string type
-        :param dict fs_options: Coming soon...
         :param bool as_stream: Write as an Arrow stream if true, else a file.
             see also https://arrow.apache.org/docs/format/Columnar.html?highlight=arrow1#ipc-file-format
+        :param dict fs_options: {fs_options}
         :return:
         """
         progressbar = vaex.utils.progressbars(progress)
@@ -5864,7 +5864,7 @@ class DataFrameLocal(DataFrame):
         :param progress: {progress}
         :param int chunk_size: {chunk_size_export}
         :param bool parallel: {evaluate_parallel}
-        :param dict fs_options: Coming soon...
+        :param dict fs_options: {fs_options}
         :param **kwargs: Extra keyword arguments to be passed on to py:data:`pyarrow.parquet.ParquetWriter`.
         :return:
         """
@@ -5900,6 +5900,7 @@ class DataFrameLocal(DataFrame):
         :param int chunk_size: {chunk_size_export}
         :param bool parallel: {evaluate_parallel}
         :param int max_workers: Number of workers/threads to use for writing in parallel
+        :param dict fs_options: {fs_options}
         """
         from .itertools import pmap, pwait, buffer, consume
         path1 = str(path).format(i=0, i1=1, i2=2)

--- a/packages/vaex-core/vaex/docstrings.py
+++ b/packages/vaex-core/vaex/docstrings.py
@@ -38,6 +38,4 @@ _doc_snippets['chunk_size_export'] = 'Number of rows to be written to disk in a 
 _doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel'
 _doc_snippets['array_type'] = 'Type of output array, possible values are None/"numpy" (ndarray), "xarray" for a xarray.DataArray, or "list" for a Python list'
 _doc_snippets['ascii'] = 'Transform only ascii characters (usually faster).'
-
-_doc_snippets['ml_features'] = 'List of features to transform.'
-_doc_snippets['ml_prefix'] = 'Prefix for the names of the transformed features.'
+_doc_snippets['fs_options'] = 'see :func:`vaex.open` e.g. for S3 {"profile": "myproject"}'

--- a/packages/vaex-core/vaex/docstrings.py
+++ b/packages/vaex-core/vaex/docstrings.py
@@ -1,0 +1,43 @@
+def docsubst(f):
+    if f.__doc__:
+        f.__doc__ = f.__doc__.format(**_doc_snippets)
+    return f
+
+
+_doc_snippets = {}
+_doc_snippets["expression"] = "expression or list of expressions, e.g. df.x, 'x', or ['x, 'y']"
+_doc_snippets["expression_one"] = "expression in the form of a string, e.g. 'x' or 'x+y' or vaex expression object, e.g. df.x or df.x+df.y "
+_doc_snippets["expression_single"] = "if previous argument is not a list, this argument should be given"
+_doc_snippets["binby"] = "List of expressions for constructing a binned grid"
+_doc_snippets["limits"] = """description for the min and max values for the expressions, e.g. 'minmax' (default), '99.7%', [0, 10], or a list of, e.g. [[0, 10], [0, 20], 'minmax']"""
+_doc_snippets["shape"] = """shape for the array where the statistic is calculated on, if only an integer is given, it is used for all dimensions, e.g. shape=128, shape=[128, 256]"""
+_doc_snippets["percentile_limits"] = """description for the min and max values to use for the cumulative histogram, should currently only be 'minmax'"""
+_doc_snippets["percentile_shape"] = """shape for the array where the cumulative histogram is calculated on, integer type"""
+_doc_snippets["selection"] = """Name of selection to use (or True for the 'default'), or all the data (when selection is None or False), or a list of selections"""
+_doc_snippets["selection1"] = """Name of selection to use (or True for the 'default'), or all the data (when selection is None or False)"""
+_doc_snippets["delay"] = """Do not return the result, but a proxy for delayhronous calculations (currently only for internal use)"""
+_doc_snippets["progress"] = """A callable that takes one argument (a floating point value between 0 and 1) indicating the progress, calculations are cancelled when this callable returns False"""
+_doc_snippets["expression_limits"] = _doc_snippets["expression"]
+_doc_snippets["grid"] = """If grid is given, instead if compuation a statistic given by what, use this Nd-numpy array instead, this is often useful when a custom computation/statistic is calculated, but you still want to use the plotting machinery."""
+_doc_snippets["edges"] = """Currently for internal use only (it includes nan's and values outside the limits at borders, nan and 0, smaller than at 1, and larger at -1"""
+
+_doc_snippets["healpix_expression"] = """Expression which maps to a healpix index, for the Gaia catalogue this is for instance 'source_id/34359738368', other catalogues may simply have a healpix column."""
+_doc_snippets["healpix_max_level"] = """The healpix level associated to the healpix_expression, for Gaia this is 12"""
+_doc_snippets["healpix_level"] = """The healpix level to use for the binning, this defines the size of the first dimension of the grid."""
+
+_doc_snippets["return_stat_scalar"] = """Numpy array with the given shape, or a scalar when no binby argument is given, with the statistic"""
+_doc_snippets["return_limits"] = """List in the form [[xmin, xmax], [ymin, ymax], .... ,[zmin, zmax]] or [xmin, xmax] when expression is not a list"""
+_doc_snippets["cov_matrix"] = """List all convariance values as a double list of expressions, or "full" to guess all entries (which gives an error when values are not found), or "auto" to guess, but allow for missing values"""
+_doc_snippets['propagate_uncertainties'] = """If true, will propagate errors for the new virtual columns, see :meth:`propagate_uncertainties` for details"""
+_doc_snippets['note_copy'] = '.. note:: Note that no copy of the underlying data is made, only a view/reference is made.'
+_doc_snippets['note_filter'] = '.. note:: Note that filtering will be ignored (since they may change), you may want to consider running :meth:`extract` first.'
+_doc_snippets['inplace'] = 'Make modifications to self or return a new DataFrame'
+_doc_snippets['return_shallow_copy'] = 'Returns a new DataFrame with a shallow copy/view of the underlying data'
+_doc_snippets['chunk_size'] = 'Return an iterator with cuts of the object in lenght of this size'
+_doc_snippets['chunk_size_export'] = 'Number of rows to be written to disk in a single iteration'
+_doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel'
+_doc_snippets['array_type'] = 'Type of output array, possible values are None/"numpy" (ndarray), "xarray" for a xarray.DataArray, or "list" for a Python list'
+_doc_snippets['ascii'] = 'Transform only ascii characters (usually faster).'
+
+_doc_snippets['ml_features'] = 'List of features to transform.'
+_doc_snippets['ml_prefix'] = 'Prefix for the names of the transformed features.'


### PR DESCRIPTION
This PR hope to achieve two things:
 - Improve the docstring of `vaex.open(...)`
 - Refactor a bit how we generate the docstrings for common keywords.
 - Remove `copy_index` from `vaex.open`. This kwarg is not general, but only applies when a csv file is read via `pandas.read_csv`. It can still be passed as part of the `**kwargs` so there is no loss of functionality here, and old code will **not** break.

Checklist
- [x] Put the common kwargs docstrings in a separate dedicated file to be better reused amongst different modules and packages
- [x] Add intersphinx mapping to the docs of s3fs, gcsfs, (py)arrow (groundworks for improving the docs & docstrings)
- [x] Improve the docstrings for `vaex.open`
- [x] Add missing docstring info on the various `df.export_{...}` methods.
- [x] Remove `copy_index` as a defined keyword in `vaex.open`. It can still be passed as part of `**kwargs` so this is not a breaking change. 