### PR TITLE
refactor!: Vaex DType wraps NumPy and Arrow DType in uniform way

### DIFF
--- a/ci/04-run-test-suite.sh
+++ b/ci/04-run-test-suite.sh
@@ -2,4 +2,4 @@
 set -e
 
 source activate vaex-dev
-py.test tests packages/vaex-core/vaex/test/dataset.py::TestDataset --timeout=1000
+py.test tests packages/vaex-core/vaex/datatype_test.py packages/vaex-core/vaex/test/dataset.py::TestDataset --doctest-modules packages/vaex-core/vaex/datatype.py --timeout=1000

--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from .stat import _Statistic
 from vaex import encoding
+from .datatype import DataType
 
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -85,15 +86,15 @@ class AggregatorDescriptorBasic(AggregatorDescriptor):
 
     def _prepare_types(self, df):
         if self.expression == '*':
-            self.dtype_in = np.dtype('int64')
-            self.dtype_out = np.dtype('int64')
+            self.dtype_in = DataType(np.dtype('int64'))
+            self.dtype_out = DataType(np.dtype('int64'))
         else:
             self.dtype_in = df[str(self.expressions[0])].data_type()
             self.dtype_out = self.dtype_in
             if self.short_name == "count":
-                self.dtype_out = np.dtype('int64')
+                self.dtype_out = DataType(np.dtype('int64'))
             if self.short_name in ['sum', 'summoment']:
-                self.dtype_out = vaex.array_types.upcast(self.dtype_in)
+                self.dtype_out = self.dtype_in.upcast()
 
     def add_operations(self, agg_task, **kwargs):
         df = agg_task.df
@@ -132,7 +133,7 @@ class AggregatorDescriptorNUnique(AggregatorDescriptorBasic):
 
     def _create_operation(self, df, grid):
         self.dtype_in = df[str(self.expressions[0])].dtype
-        self.dtype_out = np.dtype('int64')
+        self.dtype_out = DataType(np.dtype('int64'))
         agg_op_type = vaex.utils.find_type_from_dtype(vaex.superagg, self.name + "_", self.dtype_in)
         agg_op = agg_op_type(grid, self.dropmissing, self.dropnan)
         return agg_op

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -250,9 +250,9 @@ class ColumnConcatenatedLazy(Column):
                 self.dtype = pa.string()  # TODO: how do we know it should not be large_string?
             else:
                 # np.datetime64/timedelta64 and find_common_type don't mix very well
-                if all([dtype.type == np.datetime64 for dtype in dtypes]):
+                if all([dtype == 'datetime64' for dtype in dtypes]):
                     self.dtype = dtypes[0]
-                elif all([dtype.type == np.timedelta64 for dtype in dtypes]):
+                elif all([dtype == 'timedelta64' for dtype in dtypes]):
                     self.dtype = dtypes[0]
                 else:
                     if all([dtype == dtypes[0] for dtype in dtypes]):  # find common types doesn't always behave well
@@ -265,7 +265,7 @@ class ColumnConcatenatedLazy(Column):
                             index = np.argmax([df.columns[self.column_name].astype('O').astype('U').dtype.itemsize for df in dfs])
                             self.dtype = dfs[index].columns[self.column_name].astype('O').astype('U').dtype
                     else:
-                        self.dtype = np.find_common_type(dtypes, [])
+                        self.dtype = np.find_common_type([k.numpy for k in dtypes], [])
                     logger.debug("common type for %r is %r", dtypes, self.dtype)
             # make sure all expression are the same type
             self.expressions = [e if vaex.array_types.same_type(e.dtype, self.dtype) else e.astype(self.dtype) for e in expressions]

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -161,7 +161,7 @@ class TaskPartStatistic:
         self.selections = selections
         self.fields = op.fields(weights)
         self.shape_total = (len(self.selections), ) + self.shape + (self.fields,)
-        self.grid = np.zeros(self.shape_total, dtype=self.dtype)
+        self.grid = np.zeros(self.shape_total, dtype=self.dtype.numpy)
         self.op.init(self.grid)
         self.minima = minima
         self.maxima = maxima
@@ -412,9 +412,8 @@ class TaskPartAggregations:
                 grids.append(grid)
             result = np.asarray(grids) if selection_waslist else grids[0]
             if agg_desc.dtype_out != str:
-                dtype_out = vaex.utils.to_native_dtype(agg_desc.dtype_out)
-                dtype_out = vaex.array_types.to_numpy_type(dtype_out)
-                result = result.view(dtype_out)
+                dtype_out = agg_desc.dtype_out.to_native()
+                result = result.view(dtype_out.numpy)
             result = result.copy()
             results.append(result)
         return results

--- a/packages/vaex-core/vaex/datatype.py
+++ b/packages/vaex-core/vaex/datatype.py
@@ -245,10 +245,6 @@ class DataType:
         '''
         return vaex.array_types.is_string_type(self.internal)
 
-    # @property
-    # def is_str(self):
-    #     return self.is_string
-
     def upcast(self):
         '''Cast to the higest data type matching the type
 

--- a/packages/vaex-core/vaex/datatype.py
+++ b/packages/vaex-core/vaex/datatype.py
@@ -1,0 +1,268 @@
+import vaex
+import vaex.array_types
+import numpy as np
+import pyarrow as pa
+
+
+class DataType:
+    """Wraps numpy and arrow data types in a uniform interface
+
+    Examples:
+    >>> import numpy as np
+    >>> import pyarrow as pa
+    >>> type1 = DataType(np.dtype('f8'))
+    >>> type1
+    float64
+    >>> type2 = DataType(np.dtype('>f8'))
+    >>> type2
+    float64
+    >>> type1 in [float, int]
+    True
+
+    """
+    def __init__(self, internal):
+        self.internal = internal
+
+    def to_native(self):
+        '''Removes non-native endianness'''
+        return DataType(vaex.utils.to_native_dtype(self.internal))        
+
+    def __eq__(self, other):
+        if other == str:
+            return self.is_string
+        if other == float:
+            return self.is_float
+        if other == int:
+            return self.is_integer
+        if isinstance(other, str):
+            tester = 'is_' + other
+            if hasattr(self, tester):
+                return getattr(self, tester)
+        if not isinstance(other, DataType):
+            other = DataType(other)
+        return vaex.array_types.same_type(self.internal, other.internal)
+
+    def __repr__(self):
+        '''Standard representation for datatypes
+
+
+        >>> dtype = DataType(pa.float64())
+        >>> dtype.internal
+        DataType(double)
+        >>> dtype
+        float64
+        >>> DataType(pa.float32())
+        float32
+        '''
+
+        internal = self.internal
+        if isinstance(internal, np.dtype):
+            if internal.byteorder == ">":
+                internal = internal.newbyteorder()
+        if self.is_datetime:
+            internal = self.numpy
+
+        repr = str(internal)
+        translate = {
+            'datetime64': 'datetime64[ns]',  # for consistency, always add time unit
+            'double': 'float64',  # this is what arrow does
+            'float': 'float32',  # this is what arrow does
+        }
+        return translate.get(repr, repr)
+
+    @property
+    def name(self):
+        '''Alias of dtype.numpy.name'''
+        return self.numpy.name
+
+    @property
+    def kind(self):
+        return self.numpy.kind
+
+    @property
+    def numpy(self):
+        '''Return the numpy equivalent type
+
+        >>> DataType(pa.float64()).numpy == np.dtype('f8')
+        True
+        '''
+        return vaex.array_types.to_numpy_type(self.internal)
+
+    @property
+    def arrow(self):
+        '''Return the Apache Arrow equivalent type
+
+        >>> DataType(np.dtype('f8')).arrow == pa.float64()
+        True
+        '''
+        return vaex.array_types.to_arrow_type(self.internal)
+
+    @property
+    def is_numeric(self):
+        '''Tests if type is numerical (float, int)
+
+        >>> DataType(np.dtype('f8')).is_numeric
+        True
+        >>> DataType(pa.float32()).is_numeric
+        True
+        '''
+        return self.kind in 'fiu'
+
+    @property
+    def is_primitive(self):
+        '''Tests if type is numerical (float, int, bool)
+
+        >>> DataType(np.dtype('b')).is_primitive
+        True
+        >>> DataType(pa.bool_()).is_primitive
+        True
+        '''
+        return self.kind in 'fiub'
+
+    @property
+    def is_datetime(self):
+        """Tests if dtype is datetime (numpy) or timestamp (arrow)
+
+        Date/Time:
+        >>> date_type = DataType(np.dtype('datetime64'))
+        >>> date_type
+        datetime64[ns]
+        >>> date_type == 'datetime'
+        True
+
+        Using Arrow:
+
+        >>> date_type = DataType(pa.timestamp('ns'))
+        >>> date_type
+        datetime64[ns]
+        >>> date_type == 'datetime'
+        True
+        """
+        return vaex.array_types.to_numpy_type(self.internal).kind in 'M'
+
+    @property
+    def is_timedelta(self):
+        '''Test if timedelta
+
+        >>> dtype = DataType(np.dtype('timedelta64'))
+        >>> dtype
+        timedelta64
+        >>> dtype == 'timedelta'
+        True
+        >>> dtype.is_timedelta
+        True
+        '''
+        return vaex.array_types.to_numpy_type(self.internal).kind in 'm'
+
+    @property
+    def is_float(self):
+        '''Test if a float (float32 or float64)
+
+        >>> dtype = DataType(np.dtype('float32'))
+        >>> dtype
+        float32
+        >>> dtype == 'float'
+        True
+        >>> dtype == float
+        True
+        >>> dtype.is_float
+        True
+
+        Using Arrow:
+        >>> DataType(pa.float32()) == float
+        True
+        '''
+        return vaex.array_types.to_numpy_type(self.internal).kind in 'f'
+
+    @property
+    def is_unsigned(self):
+        '''Test if an (unsigned) integer
+
+        >>> dtype = DataType(np.dtype('uint32'))
+        >>> dtype
+        uint32
+        >>> dtype == 'unsigned'
+        True
+        >>> dtype.is_unsigned
+        True
+
+        Using Arrow:
+        >>> DataType(pa.uint32()).is_unsigned
+        True
+        '''
+        return vaex.array_types.to_numpy_type(self.internal).kind in 'u'
+
+    @property
+    def is_signed(self):
+        '''Test if a (signed) integer
+
+        >>> dtype = DataType(np.dtype('int32'))
+        >>> dtype
+        int32
+        >>> dtype == 'signed'
+        True
+
+        Using Arrow:
+        >>> DataType(pa.int32()).is_signed
+        True
+        '''
+        return vaex.array_types.to_numpy_type(self.internal).kind in 'i'
+
+    @property
+    def is_integer(self):
+        '''Test if an (unsigned or signed) integer
+
+        >>> DataType(np.dtype('uint32')) == 'integer'
+        True
+        >>> DataType(np.dtype('int8')) == int
+        True
+        >>> DataType(np.dtype('int16')).is_integer
+        True
+
+        Using Arrow:
+        >>> DataType(pa.uint32()).is_integer
+        True
+        >>> DataType(pa.int16()) == int
+        True
+
+        '''
+        return vaex.array_types.to_numpy_type(self.internal).kind in 'iu'
+
+    @property
+    def is_string(self):
+        '''Test if an (arrow) string or large_string
+
+        >>> DataType(pa.string()) == str
+        True
+        >>> DataType(pa.large_string()) == str
+        True
+        >>> DataType(pa.large_string()).is_string
+        True
+        >>> DataType(pa.large_string()) == 'string'
+        True
+        '''
+        return vaex.array_types.is_string_type(self.internal)
+
+    # @property
+    # def is_str(self):
+    #     return self.is_string
+
+    def upcast(self):
+        '''Cast to the higest data type matching the type
+
+        >>> DataType(np.dtype('uint32')).upcast()
+        uint64
+        >>> DataType(np.dtype('int8')).upcast()
+        int64
+        >>> DataType(np.dtype('float32')).upcast()
+        float64
+
+        Using Arrow
+        >>> DataType(pa.float32()).upcast()
+        float64
+        '''
+        return DataType(vaex.array_types.upcast(self.internal))
+
+    @property
+    def byteorder(self):
+        return self.numpy.byteorder

--- a/packages/vaex-core/vaex/datatype.py
+++ b/packages/vaex-core/vaex/datatype.py
@@ -138,6 +138,8 @@ class DataType:
         >>> date_type == 'datetime'
         True
         """
+        if self.is_string:
+            return False
         return vaex.array_types.to_numpy_type(self.internal).kind in 'M'
 
     @property

--- a/packages/vaex-core/vaex/datatype_test.py
+++ b/packages/vaex-core/vaex/datatype_test.py
@@ -1,0 +1,27 @@
+import pytest
+import pyarrow as pa
+import numpy as np
+from vaex.datatype import DataType
+
+
+def test_primitive():
+    t1 = DataType(np.dtype('f8'))
+    t2 = DataType(np.dtype('f8'))
+    assert t1 == t2
+    assert t1 == np.dtype('f8')
+    # assert np.dtype('f8') == t2  data type not understood
+
+
+def test_timedelta64():
+    t1 = DataType(np.dtype('timedelta64'))
+    assert t1 == 'timedelta'
+    assert t1 == 'timedelta64'
+    assert t1.is_timedelta
+
+
+@pytest.mark.parametrize('type', [pa.string(), pa.large_string()])
+def test_string(type):
+    t1 = DataType(type)
+    assert t1 == 'string'
+    assert t1 == 'str'
+    assert t1 == str

--- a/packages/vaex-core/vaex/datatype_test.py
+++ b/packages/vaex-core/vaex/datatype_test.py
@@ -23,5 +23,4 @@ def test_timedelta64():
 def test_string(type):
     t1 = DataType(type)
     assert t1 == 'string'
-    assert t1 == 'str'
     assert t1 == str

--- a/packages/vaex-core/vaex/export.py
+++ b/packages/vaex-core/vaex/export.py
@@ -206,7 +206,7 @@ def _export_column(dataset_input, dataset_output, column_name, shuffle, sort, se
                             target_set_item = order_array[i1:i2]
                         else:
                             target_set_item = slice(to_offset, to_offset + no_values)
-                        if dtype.type == np.datetime64:
+                        if dtype.is_datetime:
                             values = values.view(np.int64)
                         if np.ma.isMaskedArray(to_array) and np.ma.isMaskedArray(values):
                             to_array.data[target_set_item] = values.filled(fill_value)

--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -175,10 +175,7 @@ def open_for_arrow(path, mode='rb', fs_options={}, mmap=False):
         else:
             return pa.OSFile(path, mode)
     else:
-        opener = scheme_opener.get(scheme)
-        if not opener:
-            raise ValueError(f'Do not know how to open {path}')
-        return opener(path, mode, fs_options=fs_options).file
+        return open(path, mode=mode, fs_options=fs_options)
 
 
 def dup(file):

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -4,6 +4,7 @@ import numpy as np
 import vaex.promise
 import vaex.encoding
 from .utils import _expand_shape
+from .datatype import DataType
 
 
 logger = logging.getLogger('vaex.tasks')
@@ -238,7 +239,7 @@ class TaskStatistic(Task):
     def encode(self, encoding):
         return {'task': type(self).name, 'expressions': self.expressions,
                 'shape': self.shape, 'selections': self.selections, 'op': encoding.encode('_op', self.op), 'weights': self.weights,
-                'dtype': encoding.encode('dtype', self.dtype), 'minima': self.minima, 'maxima': self.maxima, 'edges': self.edges,
+                'dtype': encoding.encode('dtype', DataType(self.dtype)), 'minima': self.minima, 'maxima': self.maxima, 'edges': self.edges,
                 'selection_waslist': self.selection_waslist}
 
     @classmethod
@@ -256,7 +257,7 @@ class TaskStatistic(Task):
         return cls(df, **spec)
 
     def __init__(self, df, expressions, shape, limits, masked=False, weights=[], weight=None, op=OP_ADD1, selection=None, edges=False,
-                 dtype=np.float64):
+                 dtype=np.dtype('f8')):
         if not isinstance(expressions, (tuple, list)):
             expressions = [expressions]
         # edges include everything outside at index 1 and -1, and nan's at index 0, so we add 3 to each dimension

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -867,14 +867,13 @@ def gen_to_list(fn=None, wrapper=list):
 
 def find_type_from_dtype(namespace, prefix, dtype, transient=True):
     from .array_types import is_string_type
-    if is_string_type(dtype):
+    if dtype == 'string':
         if transient:
             postfix = 'string'
         else:
             postfix = 'string' # view not support atm
     else:
-        import vaex
-        dtype = vaex.array_types.to_numpy_type(dtype)
+        dtype = dtype.numpy
         postfix = str(dtype)
         if postfix == '>f8':
             postfix = 'float64'

--- a/packages/vaex-hdf5/vaex/hdf5/export.py
+++ b/packages/vaex-hdf5/vaex/hdf5/export.py
@@ -194,11 +194,12 @@ def export_hdf5(dataset, path, column_names=None, byteorder="=", shuffle=False, 
                     array.attrs["dlength"] = char_length
                 else:
                     try:
-                        array = h5column_output.require_dataset('data', shape=shape, dtype=dtype.newbyteorder(byteorder))
+                        array = h5column_output.require_dataset('data', shape=shape, dtype=dtype.numpy.newbyteorder(byteorder))
                     except:
                         logging.exception("error creating dataset for %r, with type %r " % (column_name, dtype))
                         del h5columns_output[column_name]
                         column_names.remove(column_name)
+                        continue
                 array[0] = array[0]  # make sure the array really exists
 
                 data = dataset.evaluate(column_name, 0, 1, parallel=False)

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -1,5 +1,5 @@
 from common import *
-
+from vaex.datatype import DataType
 
 def test_dtype_basics(df):
     df['new_virtual_column'] = df.x + 1
@@ -7,7 +7,7 @@ def test_dtype_basics(df):
         if df.is_string(name):
             assert df[name].to_numpy().dtype.kind in 'OSU'
         else:
-            assert vaex.array_types.same_type(vaex.array_types.data_type(df[name].values), df.data_type(df[name]))
+            assert vaex.array_types.same_type(DataType(vaex.array_types.data_type(df[name].values)), df.data_type(df[name]))
 
 
 def test_dtypes(df_local):

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -33,8 +33,7 @@ def test_dtype_object_string(tmpdir):
     path = str(tmpdir.join('test.arrow'))
     df.export(path)
     df_read = vaex.open(path)
-    # the data type of x is different (arrow vs numpy)
-    assert df_read.compare(df) == ([], [], ['x'], [])
+    assert df_read.compare(df) == ([], [], [], [])
 
 
 def test_dtype_unicode_string(tmpdir):
@@ -46,8 +45,7 @@ def test_dtype_unicode_string(tmpdir):
     path = str(tmpdir.join('test.arrow'))
     df.export(path)
     df_read = vaex.open(path)
-    # the data type of x is different (arrow vs numpy)
-    assert df_read.compare(df) == ([], [], ['x'], [])
+    assert df_read.compare(df) == ([], [], [], [])
 
 
 def test_export_arrow_strings_to_hdf5(tmpdir):


### PR DESCRIPTION
See the docstring of datatype.py for usage.
We should decide if we want this or not, and if so, we need to put this also in the docs:

TODO:
 * Add `py.test --doctest-modules packages/vaex-core/vaex/datatype.py` to CI
 * add `packages/vaex-core/vaex/datatype_test.py` to CI
 * Review naming