### PR TITLE
Fix deletion of chunk files on csv->hdf5 conversion

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -575,7 +575,7 @@ def _from_csv_convert_and_read(filename_or_buffer, copy_index, maybe_convert_pat
         logger.info('deleting %d chunk files' % len(converted_paths))
         for df, df_path in zip(dfs, converted_paths):
             try:
-                df.close()
+                df.close_files()
                 os.remove(df_path)
             except Exception as e:
                 logger.error('Could not close or delete intermediate hdf5 file %s used to convert %s to hdf5: %s' % (

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -575,7 +575,7 @@ def _from_csv_convert_and_read(filename_or_buffer, copy_index, maybe_convert_pat
         logger.info('deleting %d chunk files' % len(converted_paths))
         for df, df_path in zip(dfs, converted_paths):
             try:
-                df.close_files()
+                df.close()
                 os.remove(df_path)
             except Exception as e:
                 logger.error('Could not close or delete intermediate hdf5 file %s used to convert %s to hdf5: %s' % (

--- a/packages/vaex-core/vaex/dataset_mmap.py
+++ b/packages/vaex-core/vaex/dataset_mmap.py
@@ -84,13 +84,10 @@ class DatasetMemoryMapped(vaex.dataset.DatasetFile):
         return self.mapping_map[path]
 
     def close(self):
+        for name, memmap in self.mapping_map.items():
+            memmap.close()
         for name, file in self.file_map.items():
             file.close()
-        # on osx and linux this will give random bus errors (osx) or segfaults (linux)
-        # on win32 however, we'll run out of file handles
-        if vaex.utils.osname not in ["osx", "linux"]:
-            for name, memmap in self.mapping_map.items():
-                memmap.close()
 
     def _map_array(self, offset=None, length=None, dtype=np.float64, path=None):
         if path is None:


### PR DESCRIPTION
Use `df.close_files()` instead of `df.close()` to ensure the file lock on hdf5 chunks gets released and hence can be deleted.