### PR TITLE
fix: dispatching computations to numpy was missing null/missing support

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -19,6 +19,7 @@ python-annoy
 pyqt
 pytest
 pytest-asyncio <0.14
+pytest-mpl
 pytest-timeout
 python-graphviz
 scikit-learn

--- a/packages/vaex-core/vaex/arrow/numpy_dispatch.py
+++ b/packages/vaex-core/vaex/arrow/numpy_dispatch.py
@@ -1,19 +1,73 @@
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
 import vaex
 from ..expression import _binary_ops, _unary_ops, reversable
 
+
+def combine_missing(a, b):
+    assert a.offset == 0
+    if a.null_count > 0 or b.null_count > 0:
+        # not optimal
+        nulls = pc.invert(pc.or_(a.is_null(), b.is_null()))
+        assert nulls.offset == 0
+        nulls_buffer = nulls.buffers()[1]
+        # this is not the case: no reason why it should be (TODO: open arrow issue)
+        # assert nulls.buffers()[0] is None
+    else:
+        nulls_buffer = None
+    buffers = a.buffers()
+    return pa.Array.from_buffers(a.type, len(a), [nulls_buffer, buffers[1]])
+
 class NumpyDispatch:
-    def __init__(self, arrow_array):
-        self.arrow_array = arrow_array
-        self._numpy_array = None
+    def __init__(self, ar):
+        self._array = ar
+        if isinstance(ar, vaex.column.ColumnStringArrow):
+            ar = pa.array(ar)
+        if isinstance(ar, np.ndarray):
+            self._numpy_array = ar
+            self._arrow_array = None
+        elif isinstance(ar, vaex.array_types.supported_arrow_array_types):
+            self._numpy_array = None
+            self._arrow_array = ar
+        else:
+            raise TypeError(f'Only support numpy and arrow, not {type(ar)}')
+
+    def add_missing(self, ar):
+        if isinstance(ar, np.ndarray):
+            # if we are an arrow array, we upgrade ar to one
+            if isinstance(self._array, vaex.array_types.supported_arrow_array_types):
+                ar = vaex.array_types.to_arrow(ar)
+                ar = combine_missing(ar, self._array)
+            # else: both numpy, handled by numpy
+        else:
+            if isinstance(self._array, vaex.array_types.supported_arrow_array_types):
+                ar = combine_missing(ar, self._array)
+            # else: was numpy, handled by numpy
+        return ar
+
 
     @property
     def numpy_array(self):
-        # convert lazily, since not all arrow arrays (e.g. lists) can be converted
         if self._numpy_array is None:
-            self._numpy_array = vaex.array_types.to_numpy(self.arrow_array)
+            import vaex.arrow.convert
+            arrow_array = self._arrow_array
+            arrow_array = vaex.arrow.convert.ensure_not_chunked(arrow_array)
+            buffers = arrow_array.buffers()
+            # for math, we don't care about the nulls
+            if buffers[0] is not None:
+                buffers[0] = None
+                arrow_array = pa.Array.from_buffers(arrow_array.type, len(arrow_array), buffers, offset=arrow_array.offset)
+            self._numpy_array = vaex.array_types.to_numpy(arrow_array)
         return self._numpy_array
+
+    @property
+    def arrow_array(self):
+        if self._arrow_array is None:
+            # convert lazily, since not all arrow arrays (e.g. lists) can be converted
+            if self._arrow_array is None:
+                self._arrow_array = vaex.array_types.to_arrow(self._numpy_array)
+        return self._arrow_array
 
     def __eq__(self, rhs):
         if vaex.array_types.is_string(self.arrow_array):
@@ -28,11 +82,18 @@ class NumpyDispatch:
 for op in _binary_ops:
     def closure(op=op):
         def operator(a, b):
+            a_data = a
+            b_data = b
             if isinstance(a, NumpyDispatch):
-                a = a.numpy_array
+                a_data = a.numpy_array
             if isinstance(b, NumpyDispatch):
-                b = b.numpy_array
-            return NumpyDispatch(pa.array(op['op'](a, b)))
+                b_data = b.numpy_array
+            result_data = op['op'](a_data, b_data)
+            if isinstance(a, NumpyDispatch):
+                result_data = a.add_missing(result_data)
+            if isinstance(b, NumpyDispatch):
+                result_data = b.add_missing(result_data)
+            return NumpyDispatch(result_data)
         return operator
     method_name = '__%s__' % op['name']
     if op['name'] != "eq":
@@ -41,7 +102,18 @@ for op in _binary_ops:
     if op['name'] in reversable:
         def closure(op=op):
             def operator(b, a):
-                return NumpyDispatch(pa.array(op['op'](a, b.numpy_array)))
+                a_data = a
+                b_data = b
+                if isinstance(a, NumpyDispatch):
+                    a_data = a.numpy_array
+                if isinstance(b, NumpyDispatch):
+                    b_data = b.numpy_array
+                result_data = op['op'](a_data, b_data)
+                if isinstance(a, NumpyDispatch):
+                    result_data = a.add_missing(result_data)
+                if isinstance(b, NumpyDispatch):
+                    result_data = b.add_missing(result_data)
+                return NumpyDispatch(result_data)
             return operator
         method_name = '__r%s__' % op['name']
         setattr(NumpyDispatch, method_name, closure())
@@ -50,19 +122,27 @@ for op in _binary_ops:
 for op in _unary_ops:
     def closure(op=op):
         def operator(a):
-            a = a.numpy_array
-            return NumpyDispatch(pa.array(op['op'](a)))
+            a_data = a.numpy_array
+            result_data = op['op'](a_data)
+            if isinstance(a, NumpyDispatch):
+                result_data = a.add_missing(result_data)
+            return NumpyDispatch(result_data)
         return operator
     method_name = '__%s__' % op['name']
     setattr(NumpyDispatch, method_name, closure())
 
 
+def wrap(value):
+    if not isinstance(value, NumpyDispatch): # and not isinstance(value, np.ndarray):
+        if isinstance(value, vaex.array_types.supported_array_types + (vaex.column.ColumnStringArrow,)):
+            return NumpyDispatch(value)
+    # for performance reasons we don't visit lists and dicts
+    return value
+
 
 def unwrap(value):
     if isinstance(value, NumpyDispatch):
-        # import pdb
-        # pdb.set_trace()
-        return value.arrow_array
+        return value._array
     # for performance reasons we don't visit lists and dicts
     return value
 
@@ -70,7 +150,8 @@ def unwrap(value):
 def autowrapper(f):
     '''Takes a function f, and will unwrap all its arguments and wrap the return value'''
     def wrapper(*args, **kwargs):
-        args = map(unwrap, args)
+        args_original = args
+        args = list(map(unwrap, args))
         kwargs = {k: unwrap(v) for k, v, in kwargs.items()}
         result = f(*args, **kwargs)
         if isinstance(result, vaex.array_types.supported_arrow_array_types):

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -219,11 +219,7 @@ class ExecutorLocal(Executor):
                 chunks = {k:vaex.array_types.filter(v, filter_mask) for k, v, in chunks.items()}
             else:
                 filter_mask = None
-            def wrap(ar):
-                if isinstance(ar, vaex.array_types.supported_arrow_array_types):
-                    ar = vaex.arrow.numpy_dispatch.NumpyDispatch(ar)
-                return ar
-            chunks = {name: wrap(ar) for name, ar in chunks.items()}
+            chunks = {name: vaex.arrow.numpy_dispatch.wrap(ar) for name, ar in chunks.items()}
             block_scope.values.update(chunks)
             block_scope.mask = filter_mask
             block_dict = {expression: block_scope.evaluate(expression) for expression in run.expressions}

--- a/tests/common.py
+++ b/tests/common.py
@@ -350,6 +350,31 @@ def create_base_ds():
     return df._readonly()
 
 
+@pytest.fixture(scope='session')
+def array_factory_numpy():
+    def create(x):
+        mask = [k is None for k in x]
+        if any(mask):
+            x = [x[0] if k is None else k for k in x]
+            return np.ma.array(x, mask=mask)
+        else:
+            return np.array(x)
+    return create
+
+
+@pytest.fixture(scope='session')
+def array_factory_arrow():
+    return pa.array
+
+
+@pytest.fixture(scope='session', params=['array_factory_numpy', 'array_factory_arrow'])
+def array_factory(request, array_factory_numpy, array_factory_arrow):
+    named = dict(array_factory_numpy=array_factory_numpy, array_factory_arrow=array_factory_arrow)
+    return named[request.param]
+
+array_factory1 = array_factory
+array_factory2 = array_factory
+
 @pytest.fixture(params=['df_factory_numpy', 'df_factory_arrow'])#, 'df_factory_parquet'])
 def df_factory(request, df_factory_numpy, df_factory_arrow):#, df_factory_parquet):
     named = dict(df_factory_numpy=df_factory_numpy, df_factory_arrow=df_factory_arrow)#, df_factory_parquet=df_factory_parquet)
@@ -359,7 +384,6 @@ def df_factory(request, df_factory_numpy, df_factory_arrow):#, df_factory_parque
 @pytest.fixture
 def df_factory_numpy():
     return vaex.from_arrays
-
 
 
 @pytest.fixture

--- a/tests/compute_test.py
+++ b/tests/compute_test.py
@@ -1,0 +1,53 @@
+import numbers
+import pytest
+
+import numpy as np
+import pyarrow as pa
+
+import vaex
+
+
+@pytest.fixture(scope='session')
+def x(array_factory1):
+    return array_factory1([0, 1, 2., None])
+
+
+@pytest.fixture(scope='session')
+def y(array_factory2):
+    return array_factory2([1, 2, None, None])
+
+
+def test_add(x, y):
+    df = vaex.from_arrays(x=x, y=y)
+    df['z'] = df.x + df.y
+    assert df['z'].tolist() == [1, 3, None, None]
+    assert isinstance(df['z'].values.tolist()[0], numbers.Number)
+    assert df['z'].values.tolist() == [1, 3, None, None]
+    assert df['z'].dtype == 'numeric'
+    # import pdb; pdb.set_trace()
+
+
+def test_stay_same_type(x):
+    df = vaex.from_arrays(x=x)
+    assert df.x.tolist()[0] == 0
+    assert isinstance(df.x.values, type(x))
+
+    assert (df.x*2).tolist() == [0, 2, 4, None]
+    assert isinstance((df.x*2).values, type(x))
+    assert (df.x*2).tolist()[0] == 0
+
+    assert (-df.x).tolist() == [0, -1, -2, None]
+    assert isinstance((-df.x).values, type(x))
+
+    # should trigger reverse add
+    assert (1-df.x).tolist() == [1, 0, -1, None]
+    assert isinstance((1-df.x).values, type(x))
+
+    assert (df.x.sin()).tolist()[0] == 0
+    assert (df.x.sin()).tolist()[-1] == None
+    assert isinstance(df.x.sin().values, type(x))
+
+# def test_values2():
+#     df = vaex.from_arrays(x=, y=y)
+#     df = vaex.from_scalars(x=0, y=1)
+#     assert isinstance(df.evaluate('cos(x)+y'), type(x))

--- a/tests/viz_test.py
+++ b/tests/viz_test.py
@@ -1,15 +1,37 @@
+import numpy as np
+
 import matplotlib
 import matplotlib.pyplot as plt
+import pytest
+
+import vaex
+
+
+matplotlib.use('agg')
+
 
 def test_histogram(df_trimmed):
     df = df_trimmed
-    matplotlib.use('agg')
     plt.figure()
     df.x.viz.histogram(show=False)
 
 
 def test_heatmap(df_trimmed):
     df = df_trimmed
-    matplotlib.use('agg')
     plt.figure()
     df.x.viz.histogram(show=False)
+
+
+# we should use this properly like mentioned in https://github.com/matplotlib/pytest-mpl
+# for now it's only coverage for debugging failures (instead of failures on notebook runs)
+
+@pytest.mark.mpl_image_compare(filename='test_histogram_with_what.png')
+def test_histogram_with_what(df):
+    fig = plt.figure()
+    df.viz.histogram(df.x, what=np.clip(np.log(-vaex.stat.mean(df.z)), 0, 10), limits='99.7%');
+    return fig
+
+@pytest.mark.mpl_image_compare(filename='test_heatmap_with_what.png')
+def test_heatmap_with_what(df):
+    df.viz.heatmap(df.x, df.y, what=np.log(vaex.stat.count()+1), limits='99.7%',
+        selection=[None, df.x < df.y, df.x < -10])


### PR DESCRIPTION
We can also mix numpy masked arrays and arrow arrays without losing missing values.