### PR TITLE
feat: determine default chunk_size for smaller datasets

### DIFF
--- a/ci/04-run-test-suite.sh
+++ b/ci/04-run-test-suite.sh
@@ -2,4 +2,4 @@
 set -e
 
 source activate vaex-dev
-py.test tests packages/vaex-core/vaex/datatype_test.py packages/vaex-core/vaex/file/ packages/vaex-core/vaex/test/dataset.py::TestDataset --doctest-modules packages/vaex-core/vaex/datatype.py --timeout=1000
+py.test tests packages/vaex-core/vaex/datatype_test.py packages/vaex-core/vaex/file/ packages/vaex-core/vaex/test/dataset.py::TestDataset --doctest-modules packages/vaex-core/vaex/datatype.py packages/vaex-core/vaex/utils.py --timeout=1000

--- a/packages/vaex-core/vaex/export.py
+++ b/packages/vaex-core/vaex/export.py
@@ -163,7 +163,6 @@ def _export_column(dataset_input, dataset_output, column_name, shuffle, sort, se
     order_array, order_array_inverse, progress_status, parallel=True):
 
         if 1:
-            block_scope = dataset_input._block_scope(0, vaex.execution.buffer_size_default)
             to_array = dataset_output.columns[column_name]
             dtype = dataset_input.data_type(column_name, array_type='numpy')
             is_string = vaex.array_types.is_string_type(dtype)

--- a/packages/vaex-core/vaex/test/dataset.py
+++ b/packages/vaex-core/vaex/test/dataset.py
@@ -12,23 +12,21 @@ import astropy.units
 import pandas as pd
 import vaex.execution
 import contextlib
-a = vaex.execution.buffer_size_default # will crash if we decide to rename it
+
 
 basedir = os.path.dirname(__file__)
-# this will make the test execute more code and may show up bugs
-#vaex.execution.buffer_size_default = 3
 
 
 @contextlib.contextmanager
 def small_buffer(ds, size=3):
 	if ds.is_local():
-		previous = ds.executor.buffer_size
-		ds.executor.buffer_size = size
+		previous = ds.executor.chunk_size
+		ds.executor.chunk_size = size
 		ds._invalidate_caches()
 		try:
 			yield
 		finally:
-			ds.executor.buffer_size = previous
+			ds.executor.chunk_size = previous
 	else:
 		yield # for remote dfs we don't support this ... or should we?
 

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -992,3 +992,21 @@ $ conda install -c conda-forge "{self.name}{self.version}""
 
 def optional_import(name, version=''):
     return ProxyModule(name, version=version)
+
+
+def div_ceil(n, d):
+    """Integer divide that sounds up (to an int).
+
+    See https://stackoverflow.com/a/54585138/5397207
+
+    Examples
+    >>> div_ceil(6, 2)
+    3
+    >>> div_ceil(7, 2)
+    4
+    >>> div_ceil(8, 2)
+    4
+    >>> div_ceil(9, 2)
+    5
+    """
+    return (n + d - 1) // d

--- a/tests/common.py
+++ b/tests/common.py
@@ -45,13 +45,13 @@ class CallbackCounter(object):
 @contextlib.contextmanager
 def small_buffer(ds, size=3):
     if ds.is_local():
-        previous = ds.executor.buffer_size
-        ds.executor.buffer_size = size
+        previous = ds.executor.chunk_size
+        ds.executor.chunk_size = size
         ds._invalidate_selection_cache()
         try:
             yield
         finally:
-            ds.executor.buffer_size = previous
+            ds.executor.chunk_size = previous
     else:
         yield # for remote datasets we don't support this ... or should we?
 

--- a/tests/server/performance_test.py
+++ b/tests/server/performance_test.py
@@ -5,13 +5,13 @@ import contextlib
 @contextlib.contextmanager
 def small_buffer(ds, size=3):
     if ds.is_local():
-        previous = ds.executor.buffer_size
-        ds.executor.buffer_size = size
+        previous = ds.executor.chunk_size
+        ds.executor.chunk_size = size
         ds._invalidate_selection_cache()
         try:
             yield
         finally:
-            ds.executor.buffer_size = previous
+            ds.executor.chunk_size = previous
     else:
         yield # for remote datasets we don't support this ... or should we?
 


### PR DESCRIPTION
Now the maximum chunk_size is the old default (1024^2).
For smaller datasets, it will choose a chunk_size such that
each thread will get some work to do, unless smaller than
chunk_size_min_default which is set to 1024 by default.
TLDR, chunk_size will be between 1024 and 1024^2 from now on.
This can be configured with env var:
VAEX_CHUNK_SIZE_MIN=10
VAEX_CHUNK_SIZE_MAX=100000

A fixed, default chunk_size can also be set using:
VAEX_CHUNK_SIZE=123456