### PR TITLE
perf: skip CPP layer of Apache Arrow when possible for performance

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -516,7 +516,7 @@ def from_csv(filename_or_buffer, copy_index=False, chunk_size=None, convert=Fals
 def _from_csv_read(filename_or_buffer, copy_index, chunk_size, fs_options={}, **kwargs):
     import pandas as pd
     if not chunk_size:
-        with vaex.file.open(filename_or_buffer, fs_options=fs_options) as f:
+        with vaex.file.open(filename_or_buffer, fs_options=fs_options, for_arrow=True) as f:
             full_df = pd.read_csv(f, **kwargs)
             return from_pandas(full_df, copy_index=copy_index)
     else:

--- a/packages/vaex-core/vaex/arrow/dataset.py
+++ b/packages/vaex-core/vaex/arrow/dataset.py
@@ -153,8 +153,8 @@ def from_table(table):
 
 
 def open(path, fs_options):
-    source = vaex.file.open_for_arrow(path=path, mode='rb', fs_options=fs_options, mmap=True)
-    file_signature = source.read(6)
+    source = vaex.file.open(path=path, mode='rb', fs_options=fs_options, mmap=True, for_arrow=True)
+    file_signature = bytes(source.read(6))
     is_arrow_file = file_signature == b'ARROW1'
     source.seek(0)
 
@@ -171,7 +171,7 @@ def open(path, fs_options):
 
 def open_parquet(path, fs_options={}):
     import vaex.file
-    file_system, path = vaex.file.parse(path, fs_options)
+    file_system, path = vaex.file.parse(path, fs_options, for_arrow=True)
     arrow_ds = pyarrow.dataset.dataset(path, filesystem=file_system)
     return DatasetArrow(arrow_ds)
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5884,7 +5884,7 @@ class DataFrameLocal(DataFrame):
         if isinstance(to, str):
             schema = self[0:1].to_arrow_table(parallel=False, reduce_large=reduce_large).schema
             fs_options = fs_options or {}
-            with vaex.file.open_for_arrow(path=to, mode='wb', fs_options=fs_options) as sink:
+            with vaex.file.open(path=to, mode='wb', fs_options=fs_options) as sink:
                 if as_stream:
                     with pa.RecordBatchStreamWriter(sink, schema) as writer:
                         write(writer)
@@ -5911,7 +5911,7 @@ class DataFrameLocal(DataFrame):
         """
         import pyarrow.parquet as pq
         schema = self[0:1].to_arrow_table(parallel=False, reduce_large=True).schema
-        with vaex.file.open_for_arrow(path=path, mode='wb', fs_options=fs_options) as sink:
+        with vaex.file.open(path=path, mode='wb', fs_options=fs_options) as sink:
             with pq.ParquetWriter(sink, schema, **kwargs) as writer:
                 self.export_arrow(writer, progress=progress, chunk_size=chunk_size, parallel=parallel, reduce_large=True)
 

--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -181,16 +181,16 @@ def parse(path, fs_options={}, for_arrow=False):
         return module.parse(path, fs_options, for_arrow=for_arrow)
 
 
-def tokenize(path, fs_options={}):
-    """Deterministic token for a file, useful in combination with dask or detecting file changes.
+def fingerprint(path, fs_options={}):
+    """Deterministic fingerprint for a file, useful in combination with dask or detecting file changes.
 
     Based on mtime (modification time), file size, and the path. May lead to
     false negative if the path changes, but not the content.
 
-    >>> tokenize('/data/taxi.parquet')  # doctest: +SKIP
+    >>> fingerprint('/data/taxi.parquet')  # doctest: +SKIP
     '0171ec50cb2cf71b8e4f813212063a19'
 
-    >>> tokenize('s3://vaex/taxi/nyc_taxi_2015_mini.parquet', fs_options={'anon': True})  # doctest: +SKIP
+    >>> fingerprint('s3://vaex/taxi/nyc_taxi_2015_mini.parquet', fs_options={'anon': True})  # doctest: +SKIP
     '7c962e2d8c21b6a3681afb682d3bf91b'
     """
     fs, path = parse(path, fs_options)
@@ -199,11 +199,11 @@ def tokenize(path, fs_options={}):
         mtime = os.path.getmtime(path)
         size = os.path.getsize(path)
     else:
-        info = fs.get_file_info(path)
-        mtime = info.mtime
+        info = fs.get_file_info([path])[0]
+        mtime = info.mtime_ns
         size = info.size
     import vaex.cache
-    return vaex.cache.tokenize(('file', (path, mtime, size)))
+    return vaex.cache.fingerprint(('file', (path, mtime, size)))
 
 
 def open(path, mode='rb', fs_options={}, for_arrow=False, mmap=False):

--- a/packages/vaex-core/vaex/file/column.py
+++ b/packages/vaex-core/vaex/file/column.py
@@ -153,17 +153,9 @@ class ColumnFile(vaex.column.Column):
                             file = self.tls.file = vaex.file.dup(self.file)
                             self.file_handles.append(file)
                 # this is the fast path, that avoids a memory copy but gets a view on the underlying data
-                # cache.py:CachedFile supports this
-                if hasattr(file, '_as_numpy'):
-                    ar = file._as_numpy(offset, byte_length, self.dtype)
-                else:
-                    # Traditinal file object go this slower route
-                    # and they need per thread file object since the location (seek)
-                    # is in the state of the file object
-
-                    file.seek(offset)
-                    data = file.read(byte_length)
-                    ar = np.frombuffer(data, self.dtype, count=N)
+                file.seek(offset)
+                buf = file.read_buffer(byte_length)
+                ar = np.frombuffer(buf, self.dtype, count=N)
             if USE_CACHE:
                 with cache_lock:
                     cache[key] = ar

--- a/packages/vaex-core/vaex/file/gcs.py
+++ b/packages/vaex-core/vaex/file/gcs.py
@@ -20,7 +20,7 @@ def glob(path, fs_options={}):
     return ['gs://' + k + query for k in fs.glob(path)]
 
 
-def parse(path, fs_options={}):
+def parse(path, fs_options={}, for_arrow=False):
     path = path.replace('fsspec+gs://', 'gs://')
     path, options = split_options(path, fs_options)
     scheme, path = split_scheme(path)
@@ -29,6 +29,7 @@ def parse(path, fs_options={}):
     fs = gcsfs.GCSFileSystem(**options,)
     fs = pyarrow.fs.FSSpecHandler(fs)
     if use_cache:
-        fs = FileSystemHandlerCached(fs, scheme='gs')
-    fs = pyarrow.fs.PyFileSystem(fs)
+        fs = FileSystemHandlerCached(fs, scheme='gs', for_arrow=for_arrow)
+    if for_arrow:
+        fs = pyarrow.fs.PyFileSystem(fs)
     return fs, path

--- a/packages/vaex-core/vaex/file/gcs.py
+++ b/packages/vaex-core/vaex/file/gcs.py
@@ -22,11 +22,11 @@ def glob(path, fs_options={}):
 
 def parse(path, fs_options={}, for_arrow=False):
     path = path.replace('fsspec+gs://', 'gs://')
-    path, options = split_options(path, fs_options)
+    path, fs_options = split_options(path, fs_options)
     scheme, path = split_scheme(path)
     assert scheme == 'gs'
     use_cache = fs_options.pop('cache', 'true') in [True, 'true', 'True', '1']
-    fs = gcsfs.GCSFileSystem(**options,)
+    fs = gcsfs.GCSFileSystem(**fs_options)
     fs = pyarrow.fs.FSSpecHandler(fs)
     if use_cache:
         fs = FileSystemHandlerCached(fs, scheme='gs', for_arrow=for_arrow)

--- a/packages/vaex-core/vaex/file/s3.py
+++ b/packages/vaex-core/vaex/file/s3.py
@@ -22,16 +22,16 @@ def patch_profile(fs_options):
     return fs_options
 
 
-def parse(path, fs_options):
+def parse(path, fs_options, for_arrow=False):
     from .s3arrow import parse
     fs_options = patch_profile(fs_options)
     try:
         # raise pa.lib.ArrowNotImplementedError('FOR TESTING')
-        return parse(path, fs_options)
+        return parse(path, fs_options, for_arrow=for_arrow)
     except pa.lib.ArrowNotImplementedError:
         # fallback
         from .s3fs import parse
-        return parse(path, fs_options)
+        return parse(path, fs_options, for_arrow=for_arrow)
 
 
 def glob(path, fs_options={}):

--- a/packages/vaex-core/vaex/file/s3arrow.py
+++ b/packages/vaex-core/vaex/file/s3arrow.py
@@ -14,7 +14,7 @@ def glob(path, fs_options={}):
     return glob(path, fs_options)
 
 
-def parse(path, fs_options):
+def parse(path, fs_options, for_arrow=False):
     path, fs_options = split_options(path, fs_options)
     path = path.replace('arrow+s3://', 's3://')
     scheme, _ = split_scheme(path)
@@ -31,6 +31,7 @@ def parse(path, fs_options):
         fs_options['region'] = file_system.region
     fs = pa.fs.S3FileSystem(**fs_options)
     if use_cache:
-        fs = FileSystemHandlerCached(fs, scheme='s3')
-        fs = pyarrow.fs.PyFileSystem(fs)
+        fs = FileSystemHandlerCached(fs, scheme='s3', for_arrow=for_arrow)
+        if for_arrow:
+            fs = pyarrow.fs.PyFileSystem(fs)
     return fs, path

--- a/packages/vaex-core/vaex/file/s3fs.py
+++ b/packages/vaex-core/vaex/file/s3fs.py
@@ -61,7 +61,7 @@ def glob(path, fs_options={}):
     return [f'{scheme}://' + k + query for k in s3.glob(path)]
 
 
-def parse(path, fs_options):
+def parse(path, fs_options, for_arrow=False):
     path = path.replace('fsspec+s3://', 's3://')
     path, fs_options = split_options(path, fs_options)
     scheme, path = split_scheme(path)
@@ -73,6 +73,7 @@ def parse(path, fs_options):
     s3 = s3fs.S3FileSystem(anon=anon, default_fill_cache=False, **fs_options)
     fs = pyarrow.fs.FSSpecHandler(s3)
     if use_cache:
-        fs = FileSystemHandlerCached(fs, scheme='s3')
-    fs = pyarrow.fs.PyFileSystem(fs)
+        fs = FileSystemHandlerCached(fs, scheme='s3', for_arrow=for_arrow)
+    if for_arrow:
+        fs = pyarrow.fs.PyFileSystem(fs)
     return fs, path

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -81,7 +81,7 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
             self.file_map[self.path] = file
         else:
             mode = 'rb+' if self.write else 'rb'
-            file = vaex.file.open(self.path, mode=mode, fs_options=self.fs_options)
+            file = vaex.file.open(self.path, mode=mode, fs_options=self.fs_options, for_arrow=False)
             self.file_map[self.path] = file
         self.h5file = h5py.File(file, "r+" if self.write else "r")
 

--- a/tests/file_test.py
+++ b/tests/file_test.py
@@ -62,11 +62,11 @@ def test_split_options(tmpdir):
     assert vaex.file.split_options('s3://vaex/testing/??.hdf5?a=1&b=2') == ('s3://vaex/testing/??.hdf5', {'a': '1', 'b': '2'})
 
 
-def test_tokenize(tmpdir):
-    assert vaex.file.tokenize(__file__) == vaex.file.tokenize(__file__)
-    assert vaex.file.tokenize('s3://vaex/testing/xys.hdf5?anonymous=true') != vaex.file.tokenize('s3://vaex/testing/xys-masked.hdf5?anonymous=true')
-    assert vaex.file.tokenize('s3://vaex/testing/xys.hdf5?anonymous=true') == vaex.file.tokenize('s3://vaex/testing/xys.hdf5?anonymous=true')
-    assert vaex.file.tokenize('s3://vaex/testing/xys.hdf5', fs_options={'anonymous': True}) == vaex.file.tokenize('s3://vaex/testing/xys.hdf5?anonymous=true')
+def test_fingerprint(tmpdir):
+    assert vaex.file.fingerprint(__file__) == vaex.file.fingerprint(__file__)
+    assert vaex.file.fingerprint('s3://vaex/testing/xys.hdf5?anonymous=true') != vaex.file.fingerprint('s3://vaex/testing/xys-masked.hdf5?anonymous=true')
+    assert vaex.file.fingerprint('s3://vaex/testing/xys.hdf5?anonymous=true') == vaex.file.fingerprint('s3://vaex/testing/xys.hdf5?anonymous=true')
+    assert vaex.file.fingerprint('s3://vaex/testing/xys.hdf5', fs_options={'anonymous': True}) == vaex.file.fingerprint('s3://vaex/testing/xys.hdf5?anonymous=true')
 
 
 def test_memory_mappable():


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARROW-10709

When we use the CPP layer FileSystem, in combination with caching, we
get hit hard by memory copying/GIL (5x slower!).

When we know we don't pass the filesystem to CPP land, we can skip that
layer and avoid memory copies.

In the future, we can probably return a memoryview anyway based on the
Apache Arrow version number.

Effect, when reading hdf5 from cache: we go from 20 seconds down to 4.