### PR TITLE
feat: add export_feather function to allow compressed arrow files

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -153,6 +153,7 @@ setup(name=name + '-core',
           'vaex.dataset.opener': [
               'arrow = vaex.arrow.opener:ArrowOpener',
               'parquet = vaex.arrow.opener:ParquetOpener',
+              'feather = vaex.arrow.opener:FeatherOpener',
           ],
           'vaex.file.scheme': [
               's3 = vaex.file.s3',

--- a/packages/vaex-core/vaex/arrow/opener.py
+++ b/packages/vaex-core/vaex/arrow/opener.py
@@ -14,6 +14,20 @@ class ArrowOpener:
         from .dataset import open
         return open(path, *args, **kwargs)
 
+class FeatherOpener(ArrowOpener):
+    @classmethod
+    def quick_test(cls, path, *args, **kwargs):
+        return vaex.file.ext(path) == '.feather'
+
+    @classmethod
+    def can_open(cls, path, *args, **kwargs):
+        return cls.quick_test(path, *args, **kwargs)
+
+    @staticmethod
+    def open(path, *args, **kwargs):
+        from .dataset import open
+        return open(path, *args, **kwargs)
+
 class ParquetOpener:
     @classmethod
     def quick_test(cls, path, *args, **kwargs):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5920,7 +5920,7 @@ class DataFrameLocal(DataFrame):
             write(to)
 
     @docsubst
-    def export_feather(self, to, parallel=True, reduce_large=True, compression='uncompressed'):
+    def export_feather(self, to, parallel=True, reduce_large=True, compression='lz4', fs_options=None):
         """Exports the DataFrame to an arrow file using the feather file format version 2
 
         Feather is exactly represented as the Arrow IPC file format on disk, but also support compression.
@@ -5929,12 +5929,15 @@ class DataFrameLocal(DataFrame):
         :param to: filename or file object
         :param bool parallel: {evaluate_parallel}
         :param bool reduce_large: If True, convert arrow large_string type to string type
-        :param to: Can be one of 'zstd', 'lz4' or 'uncompressed'
+        :param compression: Can be one of 'zstd', 'lz4' or 'uncompressed'
+        :param fs_options: Placeholder for now
         :return:
         """
         import pyarrow.feather as feather
         table = self.to_arrow_table(parallel=False, reduce_large=reduce_large)
-        feather.write_feather(table, to, compression=compression)
+        fs_options = fs_options or {}
+        with vaex.file.open(path=to, mode='wb', fs_options=fs_options) as sink:
+            feather.write_feather(table, sink, compression=compression)
 
     @docsubst
     def export_parquet(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, fs_options=None, fs=None, **kwargs):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5920,6 +5920,23 @@ class DataFrameLocal(DataFrame):
             write(to)
 
     @docsubst
+    def export_feather(self, to, parallel=True, reduce_large=True, compression='uncompressed'):
+        """Exports the DataFrame to an arrow file using the feather file format version 2
+
+        Feather is exactly represented as the Arrow IPC file format on disk, but also support compression.
+            see also https://arrow.apache.org/docs/python/feather.html
+
+        :param to: filename or file object
+        :param bool parallel: {evaluate_parallel}
+        :param bool reduce_large: If True, convert arrow large_string type to string type
+        :param to: Can be one of 'zstd', 'lz4' or 'uncompressed'
+        :return:
+        """
+        import pyarrow.feather as feather
+        table = self.to_arrow_table(parallel=False, reduce_large=reduce_large)
+        feather.write_feather(table, to, compression=compression)
+
+    @docsubst
     def export_parquet(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, fs_options=None, fs=None, **kwargs):
         """Exports the DataFrame to a parquet file.
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5922,7 +5922,7 @@ class DataFrameLocal(DataFrame):
             write(to)
 
     @docsubst
-    def export_feather(self, to, parallel=True, reduce_large=True, compression='lz4', fs_options=None):
+    def export_feather(self, to, parallel=True, reduce_large=True, compression='lz4', fs_options=None, fs=None):
         """Exports the DataFrame to an arrow file using the feather file format version 2
 
         Feather is exactly represented as the Arrow IPC file format on disk, but also support compression.
@@ -5932,13 +5932,14 @@ class DataFrameLocal(DataFrame):
         :param bool parallel: {evaluate_parallel}
         :param bool reduce_large: If True, convert arrow large_string type to string type
         :param compression: Can be one of 'zstd', 'lz4' or 'uncompressed'
-        :param fs_options: Placeholder for now
+        :param fs_options: {fs_options}
+        :param fs: {fs}
         :return:
         """
         import pyarrow.feather as feather
         table = self.to_arrow_table(parallel=False, reduce_large=reduce_large)
         fs_options = fs_options or {}
-        with vaex.file.open(path=to, mode='wb', fs_options=fs_options) as sink:
+        with vaex.file.open(path=to, mode='wb', fs_options=fs_options, fs=fs) as sink:
             feather.write_feather(table, sink, compression=compression)
 
     @docsubst
@@ -5953,6 +5954,7 @@ class DataFrameLocal(DataFrame):
         :param int chunk_size: {chunk_size_export}
         :param bool parallel: {evaluate_parallel}
         :param dict fs_options: {fs_options}
+        :param fs: {fs}
         :param **kwargs: Extra keyword arguments to be passed on to py:data:`pyarrow.parquet.ParquetWriter`.
         :return:
         """

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5869,6 +5869,8 @@ class DataFrameLocal(DataFrame):
         fs_options = fs_options or {}
         if naked_path.endswith('.arrow'):
             self.export_arrow(path, progress=progress, chunk_size=chunk_size, parallel=parallel, fs_options=fs_options, fs=fs)
+        elif naked_path.endswith('.feather'):
+            self.export_feather(path, parallel=parallel, fs_options=fs_options)
         elif naked_path.endswith('.hdf5'):
             self.export_hdf5(path, progress=progress, parallel=parallel)
         elif naked_path.endswith('.fits'):

--- a/packages/vaex-core/vaex/docstrings.py
+++ b/packages/vaex-core/vaex/docstrings.py
@@ -39,4 +39,4 @@ _doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel
 _doc_snippets['array_type'] = 'Type of output array, possible values are None/"numpy" (ndarray), "xarray" for a xarray.DataArray, or "list" for a Python list'
 _doc_snippets['ascii'] = 'Transform only ascii characters (usually faster).'
 _doc_snippets['fs_options'] = 'see :func:`vaex.open` e.g. for S3 {"profile": "myproject"}'
-_doc_snippets['fs_options'] = 'Pass a file system object directly, see :func:`vaex.open`'
+_doc_snippets['fs'] = 'Pass a file system object directly, see :func:`vaex.open`'

--- a/tests/cloud_dataset_test.py
+++ b/tests/cloud_dataset_test.py
@@ -20,7 +20,7 @@ def test_cloud_dataset_basics(base_url, cache):
 @pytest.mark.skipif(vaex.utils.devmode, reason='runs too slow when developing')
 @pytest.mark.parametrize("base_url", ["gs://vaex-data", "s3://vaex"])
 @pytest.mark.parametrize("cache", ["true", "false"])
-@pytest.mark.parametrize("file_format", ["hdf5", "arrow", "parquet", "csv"])
+@pytest.mark.parametrize("file_format", ["hdf5", "arrow", "parquet", "csv", "feather"])
 def test_cloud_dataset_masked(base_url, file_format, cache):
     # For now, caching of arrow & parquet is not supported
     kwargs = {}


### PR DESCRIPTION
So this PR is part suggestion and part question 😄 

I recently put together a [comparison of vaex and kdb+ for finance type analyses](https://www.aquaq.co.uk/q/comparing-columnar-data-formats-arrow-vaex-and-kdb/) - vaex comes out pretty well considering the difference is maturity - and one of the more important features vaex is currently lacking for this kind of workload is compression.  

[Feather (v2)](https://ursalabs.org/blog/2020-feather-v2/) adds compression support to arrow files, but otherwise files saved as feather seem identical to the arrow IPC format, and so work identically when opened in vaex (or appear to do so).  I've added a simple `export_feather` function here that allows for saving compressed arrow files.  So far as I can tell feather is currently the only way to do this (I think [ARROW-8470](https://issues.apache.org/jira/browse/ARROW-8470) is related to possibly expanding this).  For example:

```
import pandas as pd
import numpy as np
import vaex

data = pd.DataFrame({
  "A":np.array([1,2,3,4]),
  "B":["A","B","C","D"],
  "C":[np.datetime64('2019-10-07 09:00:00'),np.datetime64('2019-10-07 10:00:00'),np.datetime64('2019-10-07 11:00:00'),np.datetime64('2019-10-07 12:00:00')]
  })

vaex.from_pandas(data).export_feather('example.arrow', compression='zstd')

data = vaex.open('example.arrow')

>>> data
  #    A  B    C
  0    1  'A'  Timestamp('2019-10-07 09:00:00')
  1    2  'B'  Timestamp('2019-10-07 10:00:00')
  2    3  'C'  Timestamp('2019-10-07 11:00:00')
  3    4  'D'  Timestamp('2019-10-07 12:00:00')
```

Performance in general seems as fast as standard arrow files, although one thing I've noticed using larger files (in the GB range) is that the memory usage of the process goes up when opening the compressed file (before running any queries) so it's possible it's cheating.  Do you think this is a limitation of using compression, that it needs to load more into memory rather than just memory mapping?

Like I said I'm raising this PR as much to get your opinions as to get this actually merged (although it would be cool to get some form of this functionality in vaex!)