### PR TITLE
fix: evaluate would sometimes return an array of list of arrays

### DIFF
--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -115,11 +115,15 @@ def convert(x, type, default_type="numpy"):
     import vaex.column
     if type == "numpy":
         if isinstance(x, (list, tuple)):
-            return np.concatenate([convert(k, type) for k in x])
+            return concat([convert(k, type) for k in x])
         else:
             return to_numpy(x, strict=True)
     if type == "numpy-arrow":  # used internally, numpy if possible, otherwise arrow
-        return to_numpy(x, strict=False)
+        if isinstance(x, (list, tuple)):
+            return concat([convert(k, type) for k in x])
+        else:
+            return to_numpy(x, strict=False)
+
     elif type == "arrow":
         if isinstance(x, (list, tuple)):
             return pa.chunked_array([convert(k, type) for k in x])

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5438,7 +5438,7 @@ class DataFrameLocal(DataFrame):
             expression_to_evaluate = list(set(expressions))  # lets assume we have to do them all
 
             for expression in set(expressions):
-                dtypes[expression] = dtype = df.data_type(expression)
+                dtypes[expression] = dtype = df.data_type(expression).internal
                 if expression not in df.columns:
                     virtual.add(expression)
                 # since we will use pre_filter=True, we'll get chunks of the data at unknown offset

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -6,12 +6,20 @@ from common import *
 @pytest.mark.parametrize("parallel", [True, False])
 def test_evaluate_iterator(df_local, chunk_size, prefetch, parallel):
     df = df_local
-    x = df.x.to_numpy()
-    total = 0
-    for i1, i2, chunk in df_local.evaluate_iterator('x', chunk_size=chunk_size, prefetch=prefetch, parallel=parallel, array_type='numpy'):
-        assert x[i1:i2].tolist() == chunk.tolist()
-        total += chunk.sum()
-    assert total == x.sum()
+    with small_buffer(df):
+        x = df.x.to_numpy()
+        z = df.z.to_numpy()
+        total = 0
+        for i1, i2, chunk in df_local.evaluate_iterator('x', chunk_size=chunk_size, prefetch=prefetch, parallel=parallel, array_type='numpy-arrow'):
+            assert x[i1:i2].tolist() == chunk.tolist()
+            total += chunk.sum()
+        assert total == x.sum()
+
+        total = 0
+        for i1, i2, chunk in df_local.evaluate_iterator('z', chunk_size=chunk_size, prefetch=prefetch, parallel=parallel, array_type='numpy-arrow'):
+            assert z[i1:i2].tolist() == chunk.tolist()
+            total += chunk.sum()
+        assert total == z.sum()
 
 
 @pytest.mark.parametrize("chunk_size", [2, 5])


### PR DESCRIPTION
This was exposed since we now calculate a dynamics chunk_size.
Also, because of a wrong dtype check, we lost performance due to
unneeded array copies going on.
Test now covers all cases.

Fixes #1083 