### PR TITLE
feat: join improvements for high cardinality data and particular data.

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -99,7 +99,8 @@ extension_strings = Extension("vaex.superstrings", [os.path.relpath(os.path.join
                                )
 extension_superutils = Extension("vaex.superutils", [
         os.path.relpath(os.path.join(dirname, "src/hash_object.cpp")),
-        os.path.relpath(os.path.join(dirname, "src/hash_primitives.cpp")),
+        os.path.relpath(os.path.join(dirname, "src/hash_primitives_pot.cpp")),
+        os.path.relpath(os.path.join(dirname, "src/hash_primitives_prime.cpp")),
         os.path.relpath(os.path.join(dirname, "src/superutils.cpp")),
         os.path.relpath(os.path.join(dirname, "src/hash_string.cpp")),
     ],

--- a/packages/vaex-core/src/agg_hash_primitive.cpp
+++ b/packages/vaex-core/src/agg_hash_primitive.cpp
@@ -1,5 +1,5 @@
 #include "agg.hpp"
-#include "hash_primitives.cpp"
+#include "hash_primitives.hpp"
 
 namespace vaex {
 
@@ -7,11 +7,12 @@ template<class DataType=double, class GridType=uint64_t, class IndexType=default
 class AggNUnique : public Aggregator {
 public:
     using Type = AggNUnique<DataType, GridType, IndexType, FlipEndian>;
+    using Counter = counter<DataType, hashmap_primitive>; // TODO: do we want a prime growth variant?
     using index_type = IndexType;
     using grid_type = GridType;
     using data_type = DataType;
     AggNUnique(Grid<IndexType>* grid, bool dropmissing, bool dropnan) : grid(grid), grid_data(nullptr), data_ptr(nullptr), data_mask_ptr(nullptr), selection_mask_ptr(nullptr), dropmissing(dropmissing), dropnan(dropnan) {
-        counters = new counter<data_type>[grid->length1d];
+        counters = new Counter[grid->length1d];
     }
     virtual ~AggNUnique() {
         if(grid_data)
@@ -84,7 +85,7 @@ public:
     }
     Grid<IndexType>* grid;
     grid_type* grid_data;
-    counter<data_type>* counters;
+    Counter* counters;
     data_type* data_ptr;
     uint64_t data_size;
     uint8_t* data_mask_ptr;

--- a/packages/vaex-core/src/hash.hpp
+++ b/packages/vaex-core/src/hash.hpp
@@ -8,6 +8,8 @@ namespace vaex {
 template<class Key, class Value, class Hash=std::hash<Key>, class Compare=std::equal_to<Key>>
 // using hashmap = ska::flat_hash_map<Key, Value, Hash, Compare>;
 using hashmap = tsl::hopscotch_map<Key, Value, Hash, Compare>;
+template<class Key, class Value, class Hash=std::hash<Key>, class Compare=std::equal_to<Key>>
+using hashmap_pg = tsl::hopscotch_pg_map<Key, Value, Hash, Compare>;
 // template<class Key,  class Hash, class Compare>
 // using hashset = tsl::hopscotch_set<Key, Hash, Compare>;
 

--- a/packages/vaex-core/src/hash.hpp
+++ b/packages/vaex-core/src/hash.hpp
@@ -5,10 +5,77 @@
 
 namespace vaex {
 
-template<class Key, class Value, class Hash=std::hash<Key>, class Compare=std::equal_to<Key>>
+// simple and fast https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key
+static inline std::size_t _hash64(uint64_t x) {
+    x = (x ^ (x >> 30)) * uint64_t(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)) * uint64_t(0x94d049bb133111eb);
+    x = x ^ (x >> 31);
+    return x;
+}
+
+// 64 and 32 bit should not have identity as hash function, if the lower bits are not used (like with Gaia's source_id)
+// we get horrible performance, which can be alivated by using prime growth
+
+template<typename T>
+struct hash {
+    std::size_t operator()(T const& val) const {
+        std::hash<T> h;
+        return h(val);
+    }
+};
+
+template<>
+struct hash<uint64_t> {
+    std::size_t operator()(uint64_t const val) const {
+        return _hash64(val);
+    }
+};
+
+template<>
+struct hash<int64_t> {
+    std::size_t operator()(uint64_t const val) const {
+        return _hash64(*reinterpret_cast<const int64_t*>(&val));
+    }
+};
+
+
+template<>
+struct hash<int32_t> {
+    std::size_t operator()(int32_t const val) const {
+        uint64_t v(val);
+        return _hash64(v);
+    }
+};
+
+template<>
+struct hash<uint32_t> {
+    std::size_t operator()(uint32_t const val) const {
+        uint64_t v(val);
+        return _hash64(v);
+    }
+};
+
+template<>
+struct hash<float> {
+    std::size_t operator()(float const val) const {
+        uint64_t v(0);
+        *reinterpret_cast<float*>(&v) = val;
+        return _hash64(v);
+    }
+};
+
+template<>
+struct hash<double> {
+    std::size_t operator()(double const val) const {
+        return _hash64(*reinterpret_cast<const uint64_t*>(&val));
+    }
+};
+
+
+template<class Key, class Value, class Hash=vaex::hash<Key>, class Compare=std::equal_to<Key>>
 // using hashmap = ska::flat_hash_map<Key, Value, Hash, Compare>;
 using hashmap = tsl::hopscotch_map<Key, Value, Hash, Compare>;
-template<class Key, class Value, class Hash=std::hash<Key>, class Compare=std::equal_to<Key>>
+template<class Key, class Value, class Hash=vaex::hash<Key>, class Compare=std::equal_to<Key>>
 using hashmap_pg = tsl::hopscotch_pg_map<Key, Value, Hash, Compare>;
 // template<class Key,  class Hash, class Compare>
 // using hashset = tsl::hopscotch_set<Key, Hash, Compare>;

--- a/packages/vaex-core/src/hash_primitives.cpp
+++ b/packages/vaex-core/src/hash_primitives.cpp
@@ -1,16 +1,18 @@
 #include "hash_primitives.hpp"
 
+
 namespace vaex {
-template<class T, class M>
-void init_hash(M m, std::string name) {
-    typedef counter<T> counter_type;
-    std::string countername = "counter_" + name;
+template<class T, class M, template<typename, typename> typename Hashmap>
+void init_hash_(M m, std::string name, std::string suffix) {
+    typedef counter<T, Hashmap> counter_type;
+    std::string countername = "counter_" + name + suffix;
     py::class_<counter_type>(m, countername.c_str())
         .def(py::init<>())
         .def("update", &counter_type::update, "add values", py::arg("values"), py::arg("start_index") = 0)
         .def("update", &counter_type::update_with_mask, "add masked values", py::arg("values"), py::arg("masks"), py::arg("start_index") = 0)
         .def("merge", &counter_type::merge)
         .def("extract", &counter_type::extract)
+        .def("reserve", &counter_type::reserve)
         .def("keys", &counter_type::keys)
         .def_property_readonly("count", [](const counter_type &c) { return c.count; })
         .def_property_readonly("nan_count", [](const counter_type &c) { return c.nan_count; })
@@ -19,8 +21,8 @@ void init_hash(M m, std::string name) {
         .def_property_readonly("has_null", [](const counter_type &c) { return c.null_count > 0; })
     ;
     {
-        std::string ordered_setname = "ordered_set_" + name;
-        typedef ordered_set<T> Type;
+        std::string ordered_setname = "ordered_set_" + name + suffix;
+        typedef ordered_set<T, Hashmap> Type;
         py::class_<Type>(m, ordered_setname.c_str())
             .def(py::init<>())
             .def(py::init(&Type::create))
@@ -29,6 +31,7 @@ void init_hash(M m, std::string name) {
             .def("update", &Type::update_with_mask, "add masked values", py::arg("values"), py::arg("masks"), py::arg("start_index") = 0)
             .def("merge", &Type::merge)
             .def("extract", &Type::extract)
+            .def("reserve", &Type::reserve)
             .def("keys", &Type::keys)
             .def("map_ordinal", &Type::map_ordinal)
             .def_property_readonly("count", [](const Type &c) { return c.count; })
@@ -39,14 +42,15 @@ void init_hash(M m, std::string name) {
         ;
     }
     {
-        std::string index_hashname = "index_hash_" + name;
-        typedef index_hash<T> Type;
+        std::string index_hashname = "index_hash_" + name + suffix;
+        typedef index_hash<T, Hashmap> Type;
         py::class_<Type>(m, index_hashname.c_str())
             .def(py::init<>())
             .def("update", &Type::update)
             .def("update", &Type::update_with_mask)
             .def("merge", &Type::merge)
             .def("extract", &Type::extract)
+            .def("reserve", &Type::reserve)
             .def("keys", &Type::keys)
             .def("map_index", &Type::map_index)
             .def("map_index", &Type::template map_index_write<int8_t>)
@@ -70,18 +74,4 @@ void init_hash(M m, std::string name) {
 }
 
 
-void init_hash_primitives(py::module &m) {
-    init_hash<int64_t>(m, "int64");
-    init_hash<uint64_t>(m, "uint64");
-    init_hash<int32_t>(m, "int32");
-    init_hash<uint32_t>(m, "uint32");
-    init_hash<int16_t>(m, "int16");
-    init_hash<uint16_t>(m, "uint16");
-    init_hash<int8_t>(m, "int8");
-    init_hash<uint8_t>(m, "uint8");
-    init_hash<bool>(m, "bool");
-    init_hash<float>(m, "float32");
-    init_hash<double>(m, "float64");
-
-}
 } // namespace vaex

--- a/packages/vaex-core/src/hash_primitives_pot.cpp
+++ b/packages/vaex-core/src/hash_primitives_pot.cpp
@@ -1,0 +1,22 @@
+#include "hash_primitives.cpp"
+
+namespace vaex {
+template<class T, class M>
+void init_hash(M m, std::string name) {
+    init_hash_<T, M, hashmap_primitive>(m, name, "");
+}
+
+void init_hash_primitives_power_of_two(py::module &m) {
+    init_hash<int64_t>(m, "int64");
+    init_hash<uint64_t>(m, "uint64");
+    init_hash<int32_t>(m, "int32");
+    init_hash<uint32_t>(m, "uint32");
+    init_hash<int16_t>(m, "int16");
+    init_hash<uint16_t>(m, "uint16");
+    init_hash<int8_t>(m, "int8");
+    init_hash<uint8_t>(m, "uint8");
+    init_hash<bool>(m, "bool");
+    init_hash<float>(m, "float32");
+    init_hash<double>(m, "float64");
+}
+};

--- a/packages/vaex-core/src/hash_primitives_prime.cpp
+++ b/packages/vaex-core/src/hash_primitives_prime.cpp
@@ -1,0 +1,23 @@
+#include "hash_primitives.cpp"
+
+namespace vaex {
+template<class T, class M>
+void init_hash_pg(M m, std::string name) {
+    init_hash_<T, M, hashmap_primitive_pg>(m, name, "_prime_growth");
+}
+
+void init_hash_primitives_prime(py::module &m) {
+    init_hash_pg<int64_t>(m, "int64");
+    init_hash_pg<uint64_t>(m, "uint64");
+    init_hash_pg<int32_t>(m, "int32");
+    init_hash_pg<uint32_t>(m, "uint32");
+    init_hash_pg<int16_t>(m, "int16");
+    init_hash_pg<uint16_t>(m, "uint16");
+    init_hash_pg<int8_t>(m, "int8");
+    init_hash_pg<uint8_t>(m, "uint8");
+    init_hash_pg<bool>(m, "bool");
+    init_hash_pg<float>(m, "float32");
+    init_hash_pg<double>(m, "float64");
+}
+};
+

--- a/packages/vaex-core/src/superutils.cpp
+++ b/packages/vaex-core/src/superutils.cpp
@@ -10,7 +10,8 @@ namespace py = pybind11;
 #define custom_isnan(value) (!(value==value))
 
 namespace vaex {
-    void init_hash_primitives(py::module &);
+    void init_hash_primitives_power_of_two(py::module &);
+    void init_hash_primitives_prime(py::module &);
     void init_hash_string(py::module &);
     void init_hash_object(py::module &);
 }
@@ -181,7 +182,8 @@ PYBIND11_MODULE(superutils, m) {
     ;
 
 
-    vaex::init_hash_primitives(m);
+    vaex::init_hash_primitives_power_of_two(m);
+    vaex::init_hash_primitives_prime(m);
     vaex::init_hash_string(m);
     vaex::init_hash_object(m);
 }

--- a/packages/vaex-core/src/superutils.cpp
+++ b/packages/vaex-core/src/superutils.cpp
@@ -4,6 +4,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <Python.h>
+#include "hash.hpp"
 
 namespace py = pybind11;
 
@@ -147,6 +148,12 @@ public:
     bool _owns_data;
 };
 
+template<typename T>
+std::size_t hash_func(T v) {
+    vaex::hash<T> h;
+    return h(v);
+}
+
 PYBIND11_MODULE(superutils, m) {
     _import_array();
 
@@ -181,6 +188,7 @@ PYBIND11_MODULE(superutils, m) {
         // .def("reduce", &Mask::reduce)
     ;
 
+    m.def("hash", hash_func<uint64_t>);
 
     vaex::init_hash_primitives_power_of_two(m);
     vaex::init_hash_primitives_prime(m);

--- a/packages/vaex-core/vaex/hash.py
+++ b/packages/vaex-core/vaex/hash.py
@@ -38,7 +38,7 @@ def ordered_set_type_from_dtype(dtype, transient=True):
     name = 'ordered_set_' + postfix
     return globals()[name]
 
-def index_type_from_dtype(dtype, transient=True):
+def index_type_from_dtype(dtype, transient=True, prime_growth=False):
     from .array_types import is_string_type
     if is_string_type(dtype):
         if transient:
@@ -50,6 +50,8 @@ def index_type_from_dtype(dtype, transient=True):
         if postfix == '>f8':
             postfix = 'float64'
     name = 'index_hash_' + postfix
+    if prime_growth:
+        name += "_prime_growth"
     return globals()[name]
 
 # from numpy import *


### PR DESCRIPTION
With particular data, we mean data (primotives) for which the lower
bits don't change much.
See https://tessil.github.io/hopscotch-map/#growth-policy

In those cases (since we use an identify hash function), it is better
to have a prime growth strategy.

Also, based on the cardinality, we use less hash maps.