### PR TITLE
feat: DataFrame pickle support for Dask, Ray and multiprocessing.

### DIFF
--- a/packages/vaex-core/src/agg.hpp
+++ b/packages/vaex-core/src/agg.hpp
@@ -188,6 +188,10 @@ public:
     void set_data(StringSequence* string_sequence, size_t index) {
         this->string_sequence = string_sequence;
     }
+    void clear_data_mask() {
+        this->data_mask_ptr = nullptr;
+        this->data_mask_size = 0;
+    }
     void set_data_mask(py::buffer ar) {
         py::buffer_info info = ar.request();
         if(info.ndim != 1) {

--- a/packages/vaex-core/src/agg_hash_primitive.cpp
+++ b/packages/vaex-core/src/agg_hash_primitive.cpp
@@ -67,6 +67,10 @@ public:
         this->data_ptr = (data_type*)info.ptr;
         this->data_size = info.shape[0];
     }
+    void clear_data_mask() {
+        this->data_mask_ptr = nullptr;
+        this->data_mask_size = 0;
+    }
     void set_data_mask(py::buffer ar) {
         py::buffer_info info = ar.request();
         if(info.ndim != 1) {
@@ -120,6 +124,7 @@ void add_agg(Module m, Base& base, const char* class_name) {
             }
         )
         .def("set_data", &Agg::set_data)
+        .def("clear_data_mask", &Agg::clear_data_mask)
         .def("set_data_mask", &Agg::set_data_mask)
         .def("set_selection_mask", &Agg::set_selection_mask)
         .def("reduce", &Agg::reduce)

--- a/packages/vaex-core/src/agg_hash_string.cpp
+++ b/packages/vaex-core/src/agg_hash_string.cpp
@@ -55,6 +55,10 @@ public:
     void set_data(StringSequence* string_sequence, size_t index) {
         this->string_sequence = string_sequence;
     }
+    void clear_data_mask() {
+        this->data_mask_ptr = nullptr;
+        this->data_mask_size = 0;
+    }
     void set_data_mask(py::buffer ar) {
         py::buffer_info info = ar.request();
         if(info.ndim != 1) {
@@ -111,6 +115,7 @@ void add_agg(Module m, Base& base, const char* class_name) {
             }
         )
         .def("set_data", &Agg::set_data)
+        .def("clear_data_mask", &Agg::clear_data_mask)
         .def("set_data_mask", &Agg::set_data_mask)
         .def("set_selection_mask", &Agg::set_selection_mask)
         .def("reduce", &Agg::reduce)

--- a/packages/vaex-core/src/superagg.cpp
+++ b/packages/vaex-core/src/superagg.cpp
@@ -32,6 +32,10 @@ public:
         this->objects = (data_type*)info.ptr;
         this->objects_size = info.shape[0];
     }
+    void clear_data_mask() {
+        this->data_mask_ptr = nullptr;
+        this->data_mask_size = 0;
+    }
     void set_data_mask(py::buffer ar) {
         py::buffer_info info = ar.request();
         if(info.ndim != 1) {
@@ -142,6 +146,10 @@ public:
         }
         this->data_ptr = (data_type*)info.ptr;
         this->data_size = info.shape[0];
+    }
+    void clear_data_mask() {
+        this->data_mask_ptr = nullptr;
+        this->data_mask_size = 0;
     }
     void set_data_mask(py::buffer ar) {
         py::buffer_info info = ar.request();
@@ -540,6 +548,7 @@ void add_agg(Module m, Base& base, const char* class_name) {
         )
         .def("set_data", &Agg::set_data)
         .def("set_data_mask", &Agg::set_data_mask)
+        .def("clear_data_mask", &Agg::clear_data_mask)
         .def("reduce", &Agg::reduce)
     ;
 }
@@ -569,6 +578,7 @@ void add_agg_arg(Module m, Base& base, const char* class_name) {
         )
         .def("set_data", &Agg::set_data)
         .def("set_data_mask", &Agg::set_data_mask)
+        .def("clear_data_mask", &Agg::clear_data_mask)
         .def("reduce", &Agg::reduce)
     ;
 }

--- a/packages/vaex-core/src/superagg_binners.cpp
+++ b/packages/vaex-core/src/superagg_binners.cpp
@@ -71,6 +71,10 @@ public:
         this->ptr = (T*)info.ptr;
         this->_size = info.shape[0];
     }
+    void clear_data_mask() {
+        this->data_mask_ptr = nullptr;
+        this->data_mask_size = 0;
+    }
     void set_data_mask(py::buffer ar) {
         py::buffer_info info = ar.request();
         if(info.ndim != 1) {
@@ -159,6 +163,10 @@ public:
     //     this->ptr = &m(0);
     //     this->_size = ar.size();
     // }
+    void clear_data_mask() {
+        this->data_mask_ptr = nullptr;
+        this->data_mask_size = 0;
+    }
     void set_data_mask(py::buffer ar) {
         py::buffer_info info = ar.request();
         if(info.ndim != 1) {
@@ -182,6 +190,7 @@ void add_binner_ordinal_(Module m, Base& base, std::string postfix) {
     py::class_<Type>(m, class_name.c_str(), base)
         .def(py::init<std::string, T, T>())
         .def("set_data", &Type::set_data)
+        .def("clear_data_mask", &Type::clear_data_mask)
         .def("set_data_mask", &Type::set_data_mask)
         .def("copy", &Type::copy)
         .def_property_readonly("expression", [](const Type &binner) {
@@ -213,6 +222,7 @@ void add_binner_scalar_(Module m, Base& base, std::string postfix) {
     py::class_<Type>(m, class_name.c_str(), base)
         .def(py::init<std::string, double, double, uint64_t>())
         .def("set_data", &Type::set_data)
+        .def("clear_data_mask", &Type::clear_data_mask)
         .def("set_data_mask", &Type::set_data_mask)
         .def("copy", &Type::copy)
         .def_property_readonly("expression", [](const Type &binner) {

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -353,6 +353,7 @@ class TaskPartAggregations:
                 references.extend([block, mask])
             else:
                 binner.set_data(block)
+                binner.clear_data_mask()
                 references.extend([block])
         all_aggregators = []
         for agg_desc, selections, aggregation2d, selection_waslist in self.aggregations:
@@ -393,6 +394,8 @@ class TaskPartAggregations:
                 if selection_mask is not None:
                     agg.set_data_mask(selection_mask)
                     references.extend([selection_mask])
+                else:
+                    agg.clear_data_mask()
         grid.bin(all_aggregators, N)
         self.has_values = True
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5891,7 +5891,8 @@ class DataFrameLocal(DataFrame):
             else:
                 table = self.to_arrow_table(chunk_size=chunk_size, parallel=parallel, reduce_large=reduce_large)
                 writer.write_table(table)
-        if isinstance(to, str):
+
+        if vaex.file.is_path_like(to):
             schema = self[0:1].to_arrow_table(parallel=False, reduce_large=reduce_large).schema
             fs_options = fs_options or {}
             with vaex.file.open(path=to, mode='wb', fs_options=fs_options) as sink:

--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -71,6 +71,14 @@ def file_and_path(file, mode='r', fs_options={}):
         return file, stringyfy(file)
 
 
+def is_path_like(path):
+    try:
+        stringyfy(path)
+        return True
+    except ValueError:
+        return False
+
+
 def stringyfy(path):
     """Get string from path like object of file like object
 

--- a/packages/vaex-server/vaex/server/client.py
+++ b/packages/vaex-server/vaex/server/client.py
@@ -99,3 +99,14 @@ class Client:
         finally:
             del self._msg_id_to_tasks[msg_id]
             pass
+
+    @property
+    def url(self):
+        protocol = "ws"
+        return "%s://%s:%d%s" % (protocol, self.hostname, self.port, self.base_path)
+
+    @property
+    def _url(self):
+        protocol = "ws"
+        return "%s://%s:%d%swebsocket" % (protocol, self.hostname, self.port, self.base_path)
+

--- a/packages/vaex-server/vaex/server/dataframe.py
+++ b/packages/vaex-server/vaex/server/dataframe.py
@@ -3,6 +3,7 @@ __author__ = 'breddels'
 import numpy as np
 import logging
 from vaex.dataframe import DataFrame
+import vaex
 
 
 logger = logging.getLogger("vaex.server.dataframe")
@@ -37,6 +38,28 @@ class DataFrameRemote(DataFrame):
         self._index_end = length_original
         self._dtype_cache = {}
         self.fraction = 1
+
+    def __getstate__(self):
+        return {
+            'length_original': self._length_original,
+            'column_names': self.column_names,
+            'dtypes': self._dtypes,
+            'url': self.executor.client.url,
+            'state': self.state_get(),
+        }
+
+    def __setstate__(self, state):
+        self._init()
+        self.column_names = state['column_names']
+        self._dtypes = state['dtypes']
+        self._length_original = state['length_original']
+        self._length_unfiltered = self._length_original
+        self._index_start = 0
+        self._index_end = self._length_original
+        self.fraction = 1
+        client = vaex.server.connect(state['url'])
+        self.executor = vaex.server.executor.Executor(client)
+        self.state_set(state['state'], use_active_range=True, trusted=True)
 
     def is_local(self):
         return False

--- a/packages/vaex-server/vaex/server/tornado_client.py
+++ b/packages/vaex-server/vaex/server/tornado_client.py
@@ -38,11 +38,6 @@ class Client(client.Client):
         self._check_version()
         self.update()
 
-    @property
-    def _url(self):
-        protocol = "ws"
-        return "%s://%s:%d%swebsocket" % (protocol, self.hostname, self.port, self.base_path)
-
 
 class ClientWebsocket(Client):
     def _send_and_forget(self, msg, msg_id=None):

--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -1,0 +1,123 @@
+import pytest
+import pickle
+import numpy as np
+import vaex
+
+N_rows = 1024*4
+
+def test_pickle_roundtrip(df_local):
+    df = df_local
+    data = pickle.dumps(df)
+    df2 = pickle.loads(data)
+    if 'obj' in df:
+        # comparison fails for obj
+        df = df.drop('obj')
+        df2 = df2.drop('obj')
+    df['x'].tolist() == df2['x'].tolist()
+    df.x.tolist() == df2.x.tolist()
+    assert df.compare(df2) == ([], [], [], [])
+
+
+def test_pick_file(tmpdir, file_extension):
+    x = np.arange(N_rows, dtype='i8')
+    df = vaex.from_arrays(x=x, x2=-x)
+    df['y'] = df.x**2
+    data = pickle.dumps(df)
+    # if the data is in memory, pickle will be large
+    assert len(data) > len(x) * x.itemsize
+    xsum = df.x.sum()
+    ysum = df.y.sum()
+
+    # but on disk, it should just pickle the file path
+    # TODO: arrow is not supported yet
+    for ext in 'hdf5 parquet'.split():
+        path = tmpdir / f'test.{ext}'
+        df.export(path)
+        df = vaex.open(path)
+        data = pickle.dumps(df)
+        assert len(data) < 700
+        assert df.x.sum() == xsum
+        assert df.y.sum() == ysum
+
+
+
+@pytest.fixture(params=['hdf5', 'parquet'])
+def file_extension(request):
+    return request.param
+
+
+@pytest.fixture()
+def df_file(file_extension, tmpdir):
+    x = np.arange(N_rows, dtype='i8')
+    df = vaex.from_arrays(x=x, x2=-x)
+    df['y'] = df.x**2
+    path = tmpdir / f'test.{file_extension}'
+    df.export(path)
+    df = vaex.open(path)
+    yield df
+
+
+def test_slice(df_file):
+    df = df_file[:len(df_file)-2]
+    assert len(pickle.dumps(df)) < 2000
+    df2 = pickle.loads(pickle.dumps(df))
+    assert df.compare(df2) == ([], [], [], [])
+
+
+def test_rename(df_file):
+    df = df_file[:len(df_file)-2]
+    df.rename('x', 'a')
+    assert len(pickle.dumps(df)) < 2000
+    df2 = pickle.loads(pickle.dumps(df))
+    assert df.compare(df2) == ([], [], [], [])
+
+
+def test_drop(df_file):
+    df = df_file.drop('x2')
+    assert len(pickle.dumps(df)) < 2000
+    df2 = pickle.loads(pickle.dumps(df))
+    assert df.compare(df2) == ([], [], [], [])
+
+
+def test_merge_files(df_file, tmpdir):
+    path = tmpdir / 'test2.hdf5'
+    df_file[['x']].export(path)
+    df_join = vaex.open(path)
+    df_join.rename('x', 'z')
+    df = df_file.join(df_join)
+    assert len(pickle.dumps(df)) < 2000
+    df2 = pickle.loads(pickle.dumps(df))
+    assert df.compare(df2) == ([], [], [], [])
+    assert df2.sum('x-z') == 0
+
+
+def test_merge_data(df_file, tmpdir):
+    df_join = vaex.from_arrays(z=df_file.x.values)
+    df = df_file.join(df_join)
+    assert len(pickle.dumps(df)) > N_rows * 4, 'transport all'
+    df2 = pickle.loads(pickle.dumps(df))
+    assert df.compare(df2) == ([], [], [], [])
+    assert (df2.x - df2.z).sum() == 0
+
+
+def test_take(df_file, tmpdir):
+    df = df_file.shuffle()
+    assert len(pickle.dumps(df)) > N_rows * 4, 'indices take space'
+    df2 = pickle.loads(pickle.dumps(df))
+    assert df.compare(df2) == ([], [], [], [])
+    assert df2.x.sum() == df_file.x.sum()
+
+
+def test_concat(df_file, tmpdir):
+    path = tmpdir / 'test2.hdf5'
+    df_file[['x']].export(path)
+    df_concat = vaex.open(path)
+    df = vaex.concat([df_file, df_concat])
+    assert len(pickle.dumps(df)) < 2000
+    df2 = pickle.loads(pickle.dumps(df))
+    assert len(df) == len(df_file) * 2
+    assert len(df2) == len(df_file) * 2
+    # assert df.compare(df2) == ([], [], [], [])
+    assert df2.x.count() == len(df_file) * 2, 'x is repeated'
+    assert df2.x.sum() == df_file.x.sum() * 2, 'x is repeated'
+    assert df2.y.sum() == df_file.y.sum(), 'y is not repeated'

--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -41,7 +41,7 @@ def test_pick_file(tmpdir, file_extension):
 
 
 
-@pytest.fixture(params=['hdf5', 'parquet'])
+@pytest.fixture(params=['hdf5', 'parquet', 'arrow'])
 def file_extension(request):
     return request.param
 


### PR DESCRIPTION
Note that this not means you get free distributed computing, but it's possible to very efficiently pass around a vaex dataframes in Dask, Ray or multiprocessing (which use pickle).

Pickling `hdf5`, `parquet` and 'arrow ipc' backed dataframes pass the file path around, which means it is quite fast. CSV backed files currently pass around the data, which is slower (This will change).



# Dask example
```
# terminal 1
$ dask-scheduler --host localhost
# terminal 2:
# note that vaex does its own multi threading, so in this case we have 2 processes with 1 threads, and vaex will swap 16 threads in each of those processes.
$ VAEX_NUM_THREADS=16 dask-worker localhost:8786 --nthreads=1 --nprocs=2 --memory-limit=100G
```

Dask complains about memory usage, but that's all memory mapped memory it is reading, so we pass `--memory-limit=100G`.

```python
import dask
import vaex
from dask.distributed import Client
client = Client('127.0.0.1:8786')


@dask.delayed
def partial_sum(df):
    sub_total = df.total_amount.sum()
    return sub_total


if __name__ == '__main__':
    df = vaex.open('/data/taxi/yellow_taxi_2009_2015_f32_app.hdf5')
    N = len(df)
    print(f'{N:,}')
    print(df.get_column_names())

    df1, df2 = df[:N//2], df[N//2:]
    for i in range(10):
        total = (partial_sum(df1) + partial_sum(df2)).compute()
        print(total)

```