### PR TITLE
feat: Hive based partitioned datasets support. Read parquet, write any

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -13,6 +13,7 @@ numpy
 pandas
 pcre
 pip
+psutil
 python-annoy
 # py-xgboost
 # pyarrow

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -210,9 +210,9 @@ def open(path, convert=False, shuffle=False, fs_options={}, *args, **kwargs):
                         path_output=path_output, fs_options_output=fs_options,
                         *args, **kwargs
                     )
-                    ds = vaex.dataset.open(path_output, fs_options=fs_options)
+                    ds = vaex.dataset.open(path_output, fs_options=fs_options, **kwargs)
                 else:
-                    ds = vaex.dataset.open(path, fs_options=fs_options)
+                    ds = vaex.dataset.open(path, fs_options=fs_options, **kwargs)
                 df = vaex.from_dataset(ds)
                 if df is None:
                     if os.path.exists(path):

--- a/packages/vaex-core/vaex/arrow/opener.py
+++ b/packages/vaex-core/vaex/arrow/opener.py
@@ -17,7 +17,8 @@ class ArrowOpener:
 class ParquetOpener:
     @classmethod
     def quick_test(cls, path, *args, **kwargs):
-        return vaex.file.ext(path) == '.parquet'
+        ext = vaex.file.ext(path)
+        return ext == '.parquet' or ext == ''
 
     @classmethod
     def can_open(cls, path, *args, **kwargs):

--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -196,6 +196,13 @@ def parse(path, fs_options={}, for_arrow=False):
         return module.parse(path, fs_options, for_arrow=for_arrow)
 
 
+def create_dir(path, fs_options):
+    fs, path = parse(path, fs_options=fs_options)
+    if fs is None:
+        fs = pa.fs.LocalFileSystem()
+    fs.create_dir(path, recursive=True)
+
+
 def fingerprint(path, fs_options={}):
     """Deterministic fingerprint for a file, useful in combination with dask or detecting file changes.
 

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2275,8 +2275,7 @@ for name in dir(scopes['str']):
 def _ordinal_values(x, ordered_set):
     from vaex.column import _to_string_sequence
 
-    if not isinstance(x, np.ndarray) or x.dtype.kind in 'US' or\
-        isinstance(ordered_set, vaex.superutils.ordered_set_string):
+    if not isinstance(x, vaex.array_types.supported_array_types) or isinstance(ordered_set, vaex.superutils.ordered_set_string):
         # sometimes the dtype can be object, but seen as an string array
         x = _to_string_sequence(x)
     return ordered_set.map_ordinal(x)

--- a/tests/arrow/convert_test.py
+++ b/tests/arrow/convert_test.py
@@ -25,14 +25,18 @@ def test_bool_sliced():
 
 @pytest.mark.skipif(pa.__version__.split(".")[0] == '1', reason="segfaults in arrow v1")
 @pytest.mark.parametrize("offset", list(range(1, 17)))
-def test_large_string_to_string(offset):
+@pytest.mark.parametrize("chunked", [True, False])
+def test_large_string_to_string(offset, chunked):
     s = pa.array(['aap', 'noot', None, 'mies'] * 3, type=pa.large_string())
+    if chunked:
+        s = pa.chunked_array([s.slice(0, 5), s.slice(5)])
     ns = convert.large_string_to_string(s)
     ns.validate()
     assert s.type != ns.type
-    assert s.tolist() == ns.tolist()
+    assert s.to_pylist() == ns.to_pylist()
 
     s = s.slice(offset)
     ns = convert.large_string_to_string(s)
-    assert ns.offset < 8
-    assert s.tolist() == ns.tolist()
+    if not chunked:
+        assert ns.offset < 8
+    assert s.to_pylist() == ns.to_pylist()

--- a/tests/arrow/partitioned_test.py
+++ b/tests/arrow/partitioned_test.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+import shutil
+import glob
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pyarrow.dataset
+
+import vaex
+
+
+path = Path(__file__).parent.parent
+data_path = path / 'data'
+
+
+countries = ['US', 'US', 'NL', 'FR', 'NL', 'NL']
+years = [2020, 2021, 2020, 2020, 2019, 2020]
+values = [1, 2, 3, 4, 5, 6]
+table = pa.table({
+    'country': countries,
+    'year': years,
+    'value': values,
+})
+
+
+def test_partitioning_basics_hive():
+    shutil.rmtree(data_path / 'parquet_dataset_partitioned_hive', ignore_errors=True)
+
+    pq.write_to_dataset(table, data_path / 'parquet_dataset_partitioned_hive', partition_cols=['year', 'country'])
+    ds = pa.dataset.dataset(data_path / 'parquet_dataset_partitioned_hive', partitioning="hive")  #, format="parquet", )
+    # import pdb; pdb.set_trace()
+    df = vaex.open(data_path / 'parquet_dataset_partitioned_hive', partitioning="hive")
+    # import pdb; pdb.set_trace()
+    assert set(df.value.tolist()) == set(values)
+    assert set(df.year.tolist()) == set(years)
+    assert set(df.country.tolist()) == set(countries)
+
+
+def test_partitioning_write_parquet():
+    shutil.rmtree(data_path / 'parquet_dataset_partitioned_vaex', ignore_errors=True)
+    df = vaex.from_arrow_table(table)
+    df.export_partitioned(data_path / 'parquet_dataset_partitioned_vaex', ['country', 'year'])
+    df = vaex.open(data_path / 'parquet_dataset_partitioned_vaex', partitioning="hive")
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_vaex/*/*/*.parquet'))) == 5  # 5 unique values
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_vaex/country=US/year=2020/*.parquet'))) == 1
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_vaex/country=NL/year=2020/*.parquet'))) == 1
+    # import pdb; pdb.set_trace()
+    assert set(df.value.tolist()) == set(values)
+    assert set(df.year.tolist()) == set(years)
+    assert set(df.country.tolist()) == set(countries)
+
+
+def test_partitioning_write_hdf5():
+    shutil.rmtree(data_path / 'parquet_dataset_partitioned_vaex', ignore_errors=True)
+    df = vaex.from_arrow_table(table)
+    df.export_partitioned(data_path / 'parquet_dataset_partitioned_vaex_my_choice/{subdir}/{i}.hdf5', ['country'])
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_vaex_my_choice/*/*.hdf5'))) == 3  # 5 unique values
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_vaex_my_choice/country=US/0.hdf5'))) == 1
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_vaex_my_choice/country=NL/1.hdf5'))) == 1
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_vaex_my_choice/country=FR/2.hdf5'))) == 1
+
+
+def test_partitioning_write_directory():
+    shutil.rmtree(data_path / 'parquet_dataset_partitioned_directory1', ignore_errors=True)
+    shutil.rmtree(data_path / 'parquet_dataset_partitioned_directory2', ignore_errors=True)
+
+    partitioning = pa.dataset.partitioning(
+        pa.schema([("country", pa.string())])
+    )
+
+    df = vaex.from_arrow_table(table)
+    df.export_partitioned(data_path / 'parquet_dataset_partitioned_directory1', ['country'], directory_format='{value}')
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_directory1/*/*.parquet'))) == 3  # 3 unique values
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_directory1/US/*.parquet'))) == 1
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_directory1/NL/*.parquet'))) == 1
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_directory1/FR/*.parquet'))) == 1
+
+    assert set(df.value.tolist()) == set(values)
+    assert set(df.year.tolist()) == set(years)
+    assert set(df.country.tolist()) == set(countries)
+
+
+    # now with 2 keys
+    partitioning = pa.dataset.partitioning(
+        pa.schema([("year", pa.int64()), ("country", pa.string())])
+    )
+    df.export_partitioned(data_path / 'parquet_dataset_partitioned_directory2', ['year', 'country'], directory_format='{value}')
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_directory2/*/*/*.parquet'))) == 5  # 5 unique values
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_directory2/2020/US/*.parquet'))) == 1
+    assert len(glob.glob(str(data_path / 'parquet_dataset_partitioned_directory2/2020/NL/*.parquet'))) == 1
+
+    df = vaex.open(data_path / 'parquet_dataset_partitioned_directory2', partitioning=partitioning)
+    assert set(df.value.tolist()) == set(values)
+    assert set(df.year.tolist()) == set(years)
+    assert set(df.country.tolist()) == set(countries)

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -271,3 +271,25 @@ def test_groupby_same_result():
 
         assert vc.values.tolist() == group_sort['count'].values.tolist(), 'counts are not correct.'
         assert vc.index.tolist() == group_sort['h'].values.tolist(), 'the indices of the counts are not correct.'
+
+
+def test_groupby_iter():
+    # ds = ds_local.extract()
+    g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 0, 1], dtype='int32')
+    s = np.array(list(map(str, [0, 0, 0, 0, 1, 1, 1, 1, 2, 2])))
+    df = vaex.from_arrays(g=g, s=s)
+    groupby = df.groupby('g')
+    assert set(groupby.groups) == {(0, ), (1, )}
+    dfs = list(groupby)
+    assert dfs[0][0] == (0, )
+    assert dfs[0][1].g.tolist() == [0] * 5
+    assert dfs[1][0] == (1, )
+    assert dfs[1][1].g.tolist() == [1] * 5
+
+    groupby = df.groupby(['g', 's'])
+    assert set(groupby.groups) == {(0, '0'), (1, '1'), (0, '2'), (1, '2')}
+    dfs = list(groupby)
+    assert dfs[0][0] == (0, '0')
+    assert dfs[0][1].g.tolist() == [0] * 4
+    assert dfs[1][0] == (0, '2')
+    assert dfs[1][1].g.tolist() == [0] * 1


### PR DESCRIPTION
Fixes #834

Similar to groupby, we can write those partitions to disk:
```python
import vaex
countries = ['US', 'US', 'NL', 'FR', 'NL', 'NL']
years = [2020, 2021, 2020, 2020, 2019, 2020]
values = [1, 2, 3, 4, 5, 6]
df = vaex.from_dict({
    'country': countries,
    'year': years,
    'value': values,
})
df.export_partitioned('./partitioned', by=['country', 'year'])
```
```
$ ls -R ./partitioned/
./partitioned/:
'country=FR'  'country=NL'  'country=US'

'./partitioned/country=FR':
'year=2020'

'./partitioned/country=FR/year=2020':
c543a46a-8188-4a0d-bd97-609c2adea36f.parquet

'./partitioned/country=NL':
'year=2019'  'year=2020'

'./partitioned/country=NL/year=2019':
545776eb-16dc-46d6-9882-fd68114b42be.parquet

'./partitioned/country=NL/year=2020':
c4211f02-10ef-499c-9175-5ffbcd274770.parquet

'./partitioned/country=US':
'year=2020'  'year=2021'

'./partitioned/country=US/year=2020':
e5d2ec3d-23f4-441e-aa7b-1a143c4c5b6b.parquet

'./partitioned/country=US/year=2021':
469bf3c2-7df7-4dad-b4b7-cc8f1cb7409a.parquet
```
If you don't like the uuid names:
```python
df.export_partitioned('./partitioned_fixed/{subdir}/vaex.parquet', by=['country', 'year'])
```

```
$ ls -R ./partitioned_fixed/
./partitioned_fixed/:
'country=FR'  'country=NL'  'country=US'

'./partitioned_fixed/country=FR':
'year=2020'

'./partitioned_fixed/country=FR/year=2020':
vaex.parquet

'./partitioned_fixed/country=NL':
'year=2019'  'year=2020'

'./partitioned_fixed/country=NL/year=2019':
vaex.parquet

'./partitioned_fixed/country=NL/year=2020':
vaex.parquet

'./partitioned_fixed/country=US':
'year=2020'  'year=2021'

'./partitioned_fixed/country=US/year=2020':
vaex.parquet

'./partitioned_fixed/country=US/year=2021':
vaex.parquet
```

Reading only supports Hive format, with parquet.
```
import vaex
df = vaex.open('./partitioned_fixed/')
print(df)
```
```
  #    value  country      year
  0        4  'FR'         2020
  1        5  'NL'         2019
  2        3  'NL'         2020
  3        6  'NL'         2020
  4        1  'US'         2020
  5        2  'US'         2021
```

Here country and year are not stored on disk, they get created on the fly.