### PR TITLE
feat: support fsspec and arrow filesystem by passing around fs argument

### DIFF
--- a/packages/vaex-astro/vaex/astro/fits.py
+++ b/packages/vaex-astro/vaex/astro/fits.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("vaex.astro.fits")
 
 
 class FitsBinTable(DatasetMemoryMapped):
-    def __init__(self, filename, write=False, fs_options={}):
+    def __init__(self, filename, write=False, fs_options={}, fs=None):
         super(FitsBinTable, self).__init__(filename, write=write)
         self.ucds = {}
         self.units = {}

--- a/packages/vaex-astro/vaex/astro/gadget.py
+++ b/packages/vaex-astro/vaex/astro/gadget.py
@@ -50,7 +50,7 @@ def getinfo(filename, seek=None):
 
 
 class MemoryMappedGadget(DatasetMemoryMapped):
-	def __init__(self, filename, fs_options={}):
+	def __init__(self, filename, fs_options={}, fs=None):
 		super(MemoryMappedGadget, self).__init__(filename)
 		#h5file = h5py.File(self.filename)
 		length, posoffset, veloffset, header = getinfo(filename)

--- a/packages/vaex-astro/vaex/astro/votable.py
+++ b/packages/vaex-astro/vaex/astro/votable.py
@@ -5,13 +5,14 @@ from vaex.dataset import DatasetFile
 from vaex.dataset_misc import _try_unit
 
 class VOTable(DatasetFile):
-	def __init__(self, filename, fs_options):
+	def __init__(self, filename, fs_options={}, fs=None):
 		super().__init__(filename)
 		self.ucds = {}
 		self.units = {}
 		self.filename = filename
 		self.path = filename
-		votable = astropy.io.votable.parse(self.filename)
+		with vaex.file.open(filename, fs_options=fs_options, fs=fs) as f:
+			votable = astropy.io.votable.parse(f)
 
 		self.first_table = votable.get_first_table()
 		self.description = self.first_table.description

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2273,7 +2273,7 @@ class DataFrame(object):
                 selection = selections.selection_from_dict(selection_dict)
             self.set_selection(selection, name=name)
 
-    def state_write(self, file, fs_options=None):
+    def state_write(self, file, fs_options=None, fs=None):
         """Write the internal state to a json or yaml file (see :meth:`DataFrame.state_get`)
 
         Example
@@ -2341,16 +2341,15 @@ class DataFrame(object):
         :param dict fs_options: arguments to pass the the file system handler (s3fs or gcsfs)
         """
         fs_options = fs_options or {}
-        vaex.utils.write_json_or_yaml(file, self.state_get(), fs_options=fs_options)
+        vaex.utils.write_json_or_yaml(file, self.state_get(), fs_options=fs_options, fs=fs)
 
-    def state_load(self, file, use_active_range=False, fs_options=None):
+    def state_load(self, file, use_active_range=False, fs_options=None, fs=None):
         """Load a state previously stored by :meth:`DataFrame.state_write`, see also :meth:`DataFrame.state_set`.
 
         :param str file: filename (ending in .json or .yaml)
         :param dict fs_options: arguments to pass the the file system handler (s3fs or gcsfs)
         """
-        fs_options = fs_options or {}
-        state = vaex.utils.read_json_or_yaml(file, fs_options=fs_options)
+        state = vaex.utils.read_json_or_yaml(file, fs_options=fs_options, fs=fs)
         self.state_set(state, use_active_range=use_active_range)
 
     def remove_virtual_meta(self):
@@ -5854,7 +5853,7 @@ class DataFrameLocal(DataFrame):
         return left
 
     @docsubst
-    def export(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, fs_options=None):
+    def export(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, fs_options=None, fs=None):
         """Exports the DataFrame to a file depending on the file extension.
 
         E.g if the filename ends on .hdf5, `df.export_hdf5` is called.
@@ -5869,20 +5868,20 @@ class DataFrameLocal(DataFrame):
         naked_path, options = vaex.file.split_options(path)
         fs_options = fs_options or {}
         if naked_path.endswith('.arrow'):
-            self.export_arrow(path, progress=progress, chunk_size=chunk_size, parallel=parallel, fs_options=fs_options)
+            self.export_arrow(path, progress=progress, chunk_size=chunk_size, parallel=parallel, fs_options=fs_options, fs=fs)
         elif naked_path.endswith('.hdf5'):
             self.export_hdf5(path, progress=progress, parallel=parallel)
         elif naked_path.endswith('.fits'):
             self.export_fits(path, progress=progress)
         elif naked_path.endswith('.parquet'):
-            self.export_parquet(path, progress=progress, parallel=parallel, chunk_size=chunk_size, fs_options=fs_options)
+            self.export_parquet(path, progress=progress, parallel=parallel, chunk_size=chunk_size, fs_options=fs_options, fs=fs)
         elif naked_path.endswith('.csv'):
             self.export_csv(path, progress=progress, parallel=parallel, chunk_size=chunk_size)
         else:
             raise ValueError('''Unrecognized file extension. Please use .arrow, .hdf5, .parquet, .fits, or .csv to export to the particular file format.''')
 
     @docsubst
-    def export_arrow(self, to, progress=None, chunk_size=default_chunk_size, parallel=True, reduce_large=True, fs_options=None, as_stream=True):
+    def export_arrow(self, to, progress=None, chunk_size=default_chunk_size, parallel=True, reduce_large=True, fs_options=None, fs=None, as_stream=True):
         """Exports the DataFrame to a file of stream written with arrow
 
         :param to: filename, file object, or :py:data:`pyarrow.RecordBatchStreamWriter`, py:data:`pyarrow.RecordBatchFileWriter` or :py:data:`pyarrow.parquet.ParquetWriter`
@@ -5910,8 +5909,7 @@ class DataFrameLocal(DataFrame):
 
         if vaex.file.is_path_like(to):
             schema = self[0:1].to_arrow_table(parallel=False, reduce_large=reduce_large).schema
-            fs_options = fs_options or {}
-            with vaex.file.open(path=to, mode='wb', fs_options=fs_options) as sink:
+            with vaex.file.open(path=to, mode='wb', fs_options=fs_options, fs=fs) as sink:
                 if as_stream:
                     with pa.RecordBatchStreamWriter(sink, schema) as writer:
                         write(writer)
@@ -5922,7 +5920,7 @@ class DataFrameLocal(DataFrame):
             write(to)
 
     @docsubst
-    def export_parquet(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, fs_options=None, **kwargs):
+    def export_parquet(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, fs_options=None, fs=None, **kwargs):
         """Exports the DataFrame to a parquet file.
 
         Note: This may require that all of the data fits into memory (memory mapped data is an exception).
@@ -5938,12 +5936,12 @@ class DataFrameLocal(DataFrame):
         """
         import pyarrow.parquet as pq
         schema = self[0:1].to_arrow_table(parallel=False, reduce_large=True).schema
-        with vaex.file.open(path=path, mode='wb', fs_options=fs_options) as sink:
+        with vaex.file.open(path=path, mode='wb', fs_options=fs_options, fs=fs) as sink:
             with pq.ParquetWriter(sink, schema, **kwargs) as writer:
                 self.export_arrow(writer, progress=progress, chunk_size=chunk_size, parallel=parallel, reduce_large=True)
 
     @docsubst
-    def export_partitioned(self, path, by, directory_format='{key}={value}', progress=None, chunk_size=default_chunk_size, parallel=True, fs_options=None):
+    def export_partitioned(self, path, by, directory_format='{key}={value}', progress=None, chunk_size=default_chunk_size, parallel=True, fs_options={}, fs=None):
         '''Expertimental: export files using hive partitioning.
 
         If no extension is found in the path, we assume parquet files. Otherwise you can specify the
@@ -5988,13 +5986,13 @@ class DataFrameLocal(DataFrame):
             uuid = uuid4()
             fullpath = path.format(uuid=uuid, subdir=subdir, i=i)
             dirpath = os.path.dirname(fullpath)
-            vaex.file.create_dir(dirpath, fs_options=fs_options)
+            vaex.file.create_dir(dirpath, fs_options=fs_options, fs=fs)
             progressbar((i)/len(groups))
-            df[columns].export(fullpath, chunk_size=chunk_size, parallel=parallel, fs_options=fs_options)
+            df[columns].export(fullpath, chunk_size=chunk_size, parallel=parallel, fs_options=fs_options, fs=fs)
         progressbar(1)
 
     @docsubst
-    def export_many(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, max_workers=None, fs_options=None):
+    def export_many(self, path, progress=None, chunk_size=default_chunk_size, parallel=True, max_workers=None, fs_options=None, fs=None):
         """Export the DataFrame to multiple files of the same type in parallel.
 
         The path will be formatted using the i parameter (which is the chunk index).
@@ -6033,7 +6031,7 @@ class DataFrameLocal(DataFrame):
             i1, i2, chunks = item
             p = str(path).format(i=i, i1=i2, i2=i2)
             df = vaex.from_dict(chunks)
-            df.export(p, chunk_size=None, parallel=False, fs_options=fs_options)
+            df.export(p, chunk_size=None, parallel=False, fs_options=fs_options, fs=fs)
             return i2
         progressbar = vaex.utils.progressbars(progress)
         progressbar(0)

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -23,7 +23,7 @@ opener_classes = []
 HASH_VERSION = "1"
 
 
-def open(path, *args, **kwargs):
+def open(path, fs_options={}, fs=None, *args, **kwargs):
     failures = []
     if not opener_classes:
         for entry in pkg_resources.iter_entry_points(group='vaex.dataset.opener'):
@@ -37,15 +37,15 @@ def open(path, *args, **kwargs):
 
     # first the quick path
     for opener in opener_classes:
-        if opener.quick_test(path):
-            if opener.can_open(path, *args, **kwargs):
-                return opener.open(path, *args, **kwargs)
+        if opener.quick_test(path, fs_options=fs_options, fs=fs):
+            if opener.can_open(path, fs_options=fs_options, fs=fs, *args, **kwargs):
+                return opener.open(path, fs_options=fs_options, fs=fs, *args, **kwargs)
 
     # otherwise try all openers
     for opener in opener_classes:
         try:
-            if opener.can_open(path, *args, **kwargs):
-                return opener.open(path, *args, **kwargs)
+            if opener.can_open(path, fs_options=fs_options, fs=fs, *args, **kwargs):
+                return opener.open(path, fs_options=fs_options, fs=fs, *args, **kwargs)
         except Exception as e:
             failures.append((e, opener))
 
@@ -962,7 +962,7 @@ class DatasetFile(Dataset):
         pass
 
     @classmethod
-    def quick_test(cls, path, fs_options=None, *args, **kwargs):
+    def quick_test(cls, path, fs_options={}, fs=None, *args, **kwargs):
         return False
 
     @classmethod

--- a/packages/vaex-core/vaex/docstrings.py
+++ b/packages/vaex-core/vaex/docstrings.py
@@ -39,3 +39,4 @@ _doc_snippets['evaluate_parallel'] = 'Evaluate the (virtual) columns in parallel
 _doc_snippets['array_type'] = 'Type of output array, possible values are None/"numpy" (ndarray), "xarray" for a xarray.DataArray, or "list" for a Python list'
 _doc_snippets['ascii'] = 'Transform only ascii characters (usually faster).'
 _doc_snippets['fs_options'] = 'see :func:`vaex.open` e.g. for S3 {"profile": "myproject"}'
+_doc_snippets['fs_options'] = 'Pass a file system object directly, see :func:`vaex.open`'

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -419,8 +419,8 @@ def yaml_load(f):
     return yaml.safe_load(f)
 
 
-def write_json_or_yaml(file, data, fs_options={}):
-    file, path = vaex.file.file_and_path(file, mode='w', fs_options=fs_options)
+def write_json_or_yaml(file, data, fs_options={}, fs=None):
+    file, path = vaex.file.file_and_path(file, mode='w', fs_options=fs_options, fs=fs)
     try:
         if path:
             base, ext = os.path.splitext(path)
@@ -436,8 +436,8 @@ def write_json_or_yaml(file, data, fs_options={}):
         file.close()
 
 
-def read_json_or_yaml(file, fs_options={}):
-    file, path = vaex.file.file_and_path(file, fs_options=fs_options)
+def read_json_or_yaml(file, fs_options={}, fs=None):
+    file, path = vaex.file.file_and_path(file, fs_options=fs_options, fs=fs)
     try:
         if path:
             base, ext = os.path.splitext(path)


### PR DESCRIPTION
Instead of us creating the filesystem, we let uses create it, and pass
it down to vaex.

Example:
```python
import vaex
import fsspec
fs = fsspec.filesystem('https')
vaex.open('https://github.com/vaexio/vaex-datasets/releases/download/v1.0/helmi-dezeeuw-2000-FeH-v2-10percent.hdf5',
          fs=fs)
```