### PR TITLE
feat: define VAEX_USE_MMAP=False to avoid using memory mapping

### DIFF
--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -240,9 +240,9 @@ def open(path, mode='rb', fs_options={}, for_arrow=False, mmap=False):
             if mmap:
                 return pa.memory_map(path, mode)
             else:
-                return pa.OSFile(path, mode)
+                return FileProxy(pa.OSFile(path, mode), path, lambda: pa.OSFile(path, mode))
         else:
-            return normal_open(path, mode)
+            return FileProxy(pa.OSFile(path, mode), path, lambda: pa.OSFile(path, mode))
     if mode == 'rb':
         def create():
             return fs.open_input_file(path)

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -37,6 +37,10 @@ except:
     if not on_rtd:
         raise
 
+# TODO: also defined in writer.py, we should make this more uniform
+USE_MMAP = vaex.utils.get_env_type(bool, 'VAEX_USE_MMAP', True)
+
+
 
 def _try_unit(unit):
     try:
@@ -63,7 +67,7 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
     """Implements the vaex hdf5 file format"""
 
     def __init__(self, path, write=False, fs_options={}):
-        nommap = not vaex.file.memory_mappable(path)
+        nommap = (not vaex.file.memory_mappable(path)) or not USE_MMAP
         self.fs_options = fs_options
         super(Hdf5MemoryMapped, self).__init__(vaex.file.stringyfy(path), write=write, nommap=nommap)
         self._all_mmapped = True


### PR DESCRIPTION
This gives an option to try to not use memory mapping, which might be useful for debugging, or to inspect the performance under OSX using mmap or not.