### PR TITLE
fix: ColumnIndexed slice issue when all indices are masked

### DIFF
--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -88,6 +88,7 @@ class ColumnNumpyLike(Column):
     """Wraps a numpy like object (like hdf5 dataset) into a column vaex understands"""
     def __init__(self, ar):
         self.ar = ar  # this should behave like a numpy array
+        self.dtype = ar.dtype
 
     def __len__(self):
         return len(self.ar)
@@ -201,7 +202,10 @@ class ColumnIndexed(Column):
             # the minimal slice, and get those (not the most efficient)
             if self.masked:
                 unmasked_indices = indices[~mask]
-                i1, i2 = np.min(unmasked_indices), np.max(unmasked_indices)
+                if len(unmasked_indices) > 0:
+                    i1, i2 = np.min(unmasked_indices), np.max(unmasked_indices)
+                else:
+                    i1, i2 = 0, 0
             else:
                 i1, i2 = np.min(indices), np.max(indices)
             ar_unfiltered = ar_unfiltered[i1:i2+1]

--- a/tests/column_test.py
+++ b/tests/column_test.py
@@ -111,6 +111,14 @@ def test_column_indexed(df_local):
     assert column_masked.trim(0, 1).masked
 
 
+def test_column_indexed_all_masked():
+    indices = np.array([-1, -1])
+    col = vaex.column.ColumnNumpyLike(np.arange(2))
+    column = vaex.column.ColumnIndexed(col, indices, masked=True)
+    assert column[0:1].tolist() == [None]
+    assert column[0:2].tolist() == [None, None]
+
+
 @pytest.mark.skipif(pa.__version__.split(".")[0] == '1', reason="segfaults in arrow v1")
 @pytest.mark.parametrize("i1", list(range(0, 8)))
 @pytest.mark.parametrize("i2", list(range(0, 8)))


### PR DESCRIPTION
Fixes #1001 closes #1031

I generated a test case (and fix, obviously 😄)that fails for the latest vaex version:
```
 'vaex': '4.0.0a7',
 'vaex-core': '4.0.0a12',
 'vaex-viz': '0.5.0.dev1',
 'vaex-hdf5': '0.7.0a5',
 'vaex-server': '0.4.0a1',
 'vaex-astro': '0.8.0.dev1',
 'vaex-jupyter': '0.6.0.dev1',
 'vaex-ml': '0.11.0a4'
```

The issue is caused by all indices being masked, which I force by attempting a join where there are no identical join keys. I added a test case that will fail should the issue still persist.

Let me know if you need anything else from me!

Edit: Apologies if the test case is in the wrong place. I'm not sure where you build server tries to load the test files.