### PR TITLE
Fix typo in _get_column_meta_data function

### DIFF
--- a/packages/vaex-astro/vaex/astro/fits.py
+++ b/packages/vaex-astro/vaex/astro/fits.py
@@ -145,7 +145,7 @@ class FitsBinTable(DatasetMemoryMapped):
                 unit_str = table.header[unit_header_name]
                 unit = _try_unit(unit_str)
                 if unit:
-                    self.unit[column_name] = unit
+                    self.units[column_name] = unit
         #unit_header_name = "TUCD%d" % (i+1)
         #if ucd_header_name in table.header:
     @classmethod


### PR DESCRIPTION
Hello! I found a small typo that was causing an error when reading in FITS tables with `TUNITn` header keywords.