### PR TITLE
fix: allow executor to be in a different thread

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -673,6 +673,8 @@ class DataFrame(object):
         grid = self._create_grid(binby, limits, shape, selection=selection, delay=True)
         @delayed
         def compute(expression, grid, selection, edges, progressbar):
+            if not hasattr(self.local, '_aggregator_nest_count'):
+                self.local._aggregator_nest_count = 0
             self.local._aggregator_nest_count += 1
             try:
                 if expression in ["*", None]:


### PR DESCRIPTION
Because self.local._aggregator_nest_count is set from the calling thread
and the thread doing the execution may not have set the _aggregator_nest_count
attributes, we could get the following exception:
```
>       self.local._aggregator_nest_count += 1
E       AttributeError: '_thread._local' object has no attribute '_aggregator_nest_count'
```