### PR TITLE
feat: sum over list

### DIFF
--- a/packages/vaex-core/vaex/arrow/numpy_dispatch.py
+++ b/packages/vaex-core/vaex/arrow/numpy_dispatch.py
@@ -3,34 +3,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import vaex
 from ..expression import _binary_ops, _unary_ops, reversable
-
-
-def combine_missing(a, b):
-    # return a copy of a with missing values of a and b combined
-    if a.null_count > 0 or b.null_count > 0:
-        a, b = vaex.arrow.convert.align(a, b)
-        if isinstance(a, pa.ChunkedArray):
-            # divide and conquer
-            assert isinstance(b, pa.ChunkedArray)
-            assert len(a.chunks) == len(b.chunks)
-            return pa.chunked_array([combine_missing(ca, cb) for ca, cb in zip(a.chunks, b.chunks)])
-        if a.offset != 0:
-            a = vaex.arrow.convert.trim_buffers_ipc(a)
-        if b.offset != 0:
-            b = vaex.arrow.convert.trim_buffers_ipc(b)
-        assert a.offset == 0
-        assert b.offset == 0
-        # not optimal
-        nulls = pc.invert(pc.or_(a.is_null(), b.is_null()))
-        assert nulls.offset == 0
-        nulls_buffer = nulls.buffers()[1]
-        # this is not the case: no reason why it should be (TODO: open arrow issue)
-        # assert nulls.buffers()[0] is None
-        buffers = a.buffers()
-        return pa.Array.from_buffers(a.type, len(a), [nulls_buffer] + buffers[1:])
-    else:
-        return a
-
+from .utils import combine_missing
 
 class NumpyDispatch:
     def __init__(self, ar):

--- a/packages/vaex-core/vaex/arrow/utils.py
+++ b/packages/vaex-core/vaex/arrow/utils.py
@@ -1,9 +1,10 @@
 import vaex
 import pyarrow as pa
-from .convert import trim_offsets
+import pyarrow.compute as pc
 
 def list_unwrap(ar):
     '''Returns the values in a (nested) list, and a callable that puts it back in the same structure'''
+    from .convert import trim_offsets
     list_parameters = []
     dtype = vaex.dtype_of(ar)   
     while dtype.is_list:
@@ -32,3 +33,30 @@ def list_unwrap(ar):
         else:
             return new_values
     return ar, wrapper
+
+
+def combine_missing(a, b):
+    # return a copy of a with missing values of a and b combined
+    if a.null_count > 0 or b.null_count > 0:
+        a, b = vaex.arrow.convert.align(a, b)
+        if isinstance(a, pa.ChunkedArray):
+            # divide and conquer
+            assert isinstance(b, pa.ChunkedArray)
+            assert len(a.chunks) == len(b.chunks)
+            return pa.chunked_array([combine_missing(ca, cb) for ca, cb in zip(a.chunks, b.chunks)])
+        if a.offset != 0:
+            a = vaex.arrow.convert.trim_buffers_ipc(a)
+        if b.offset != 0:
+            b = vaex.arrow.convert.trim_buffers_ipc(b)
+        assert a.offset == 0
+        assert b.offset == 0
+        # not optimal
+        nulls = pc.invert(pc.or_(a.is_null(), b.is_null()))
+        assert nulls.offset == 0
+        nulls_buffer = nulls.buffers()[1]
+        # this is not the case: no reason why it should be (TODO: open arrow issue)
+        # assert nulls.buffers()[0] is None
+        buffers = a.buffers()
+        return pa.Array.from_buffers(a.type, len(a), [nulls_buffer] + buffers[1:])
+    else:
+        return a

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -476,3 +476,13 @@ def test_format_xarray_and_list(df_local):
     count = df.sum([df.x, df.g], binby='g', array_type='xarray')
     assert count.coords['expression'].data.tolist() == ['x', 'g']
     assert count.coords['g'].data.tolist() == ['aap', 'noot', 'mies']
+
+
+@pytest.mark.parametrize("offset", [0, 1])
+def test_list_sum(offset):
+    data = [1, 2, None], None, [], [1, 3, 4, 5]
+    df = vaex.from_arrays(i=pa.array(data).slice(offset))
+    assert df.i.sum() == [16, 13][offset]
+    assert df.i.sum(axis=1).tolist() == [3, None, 0, 13][offset:]
+    assert df.i.sum(axis=[0, 1]) == [16, 13][offset]
+    # assert df.i.sum(axis=0)  # not supported, not sure what this should return


### PR DESCRIPTION
Example
```python
    data = [1, 2, None], None, [], [1, 3, 4, 5]
    df = vaex.from_arrays(i=pa.array(data).slice(offset))
    assert df.i.sum() == [16, 13][offset]
    assert df.i.sum(axis=1).tolist() == [3, None, 0, 13]
    assert df.i.sum(axis=1, fill_missing=99).tolist() == [3, 99, 0, 13]
    assert df.i.sum(axis=1, fill_missing_item=10).tolist() == [13, None, 0, 13]
    assert df.i.sum(axis=1, fill_empty=10).tolist() == [3, None, 10, 13]
    assert df.i.sum(axis=[0, 1]) == [16, 13][offset]
    # assert df.i.sum(axis=0)  # not supported, not sure what this should return
```