### PR TITLE
String features for use with Apache Arrow v3.0

### DIFF
--- a/ci/conda-env-nightlies.yml
+++ b/ci/conda-env-nightlies.yml
@@ -1,1 +1,1 @@
-# pyarrow
+pyarrow

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -23,7 +23,7 @@ url = 'https://www.github.com/maartenbreddels/vaex'
 install_requires_core = ["numpy>=1.16", "astropy>=2", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2", "psutil>=1.2.1",
                          "requests", "six", "cloudpickle", "pandas", "dask[array]",
-                         "nest-asyncio>=1.3.3", "pyarrow>=1.0", "frozendict",
+                         "nest-asyncio>=1.3.3", "pyarrow>=3.0", "frozendict",
                          "blake3"]
 if sys.version_info[0] == 2:
     install_requires_core.append("futures>=2.2.0")

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -767,7 +767,7 @@ def dtype_of(ar):
     '''Creates a Vaex DataType from a NumPy or Arrow array'''
     if vaex.array_types.is_arrow_array(ar):
         return dtype(ar.type)
-    elif vaex.array_types.is_numpy_array(ar):
+    elif vaex.array_types.is_numpy_array(ar) or isinstance(ar, vaex.column.supported_column_types):
         return dtype(ar.dtype)
     else:
         raise TypeError(f'{ar} is not a an Arrow or NumPy array')

--- a/packages/vaex-core/vaex/arrow/convert.py
+++ b/packages/vaex-core/vaex/arrow/convert.py
@@ -289,3 +289,14 @@ def align(a, b):
     else:
         return a, b
     return
+
+
+def same_type(*arrays):
+    types = [ar.type for ar in arrays]
+    if any(types[0] != type for type in types):
+        if vaex.dtype(types[0]) == str:
+            # we have mixed large and normal string
+            return [large_string_to_string(ar) if ar.type == pa.large_string() else ar for ar in arrays]
+        else:
+            raise NotImplementedError
+    return arrays

--- a/packages/vaex-core/vaex/arrow/utils.py
+++ b/packages/vaex-core/vaex/arrow/utils.py
@@ -24,6 +24,7 @@ def list_unwrap(ar):
                     buffers = buffers[:2]
                     buffers = trim_offsets(offset, length, *buffers)
                     offset = 0
+                    new_values = vaex.array_types.to_arrow(new_values)
                     type = pa.list_(new_values.type)
                     ar = pa.ListArray.from_buffers(type, length, [buffers[0], buffers[1]], null_count, offset, children=[new_values])
                 else:

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -27,6 +27,9 @@ class Column(object):
 
 supported_column_types = (Column, ) + supported_array_types
 
+def is_column_like(col):
+    return isinstance(col, supported_column_types)
+
 
 class ColumnVirtualRange(Column):
     def __init__(self, start, stop, step=1, dtype=None):

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -631,13 +631,16 @@ class ColumnStringArrow(ColumnString):
                 references=references)
 
     @classmethod
-    def from_string_sequence(cls, string_sequence):
+    def from_string_sequence(cls, string_sequence, copy=False):
         s = string_sequence
         null_bitmap = s.null_bitmap
         if s.null_offset != 0:
             mask = ~s.mask()
             null_bitmap = np.frombuffer(pa.array(mask, pa.bool_()).buffers()[1], dtype='b')
-        return cls(s.indices, s.bytes, s.length, s.offset, string_sequence=s, null_bitmap=null_bitmap)
+        if copy:
+            return cls(s.indices.copy(), s.bytes.copy(), s.length, s.offset, string_sequence=s, null_bitmap=null_bitmap)
+        else:
+            return cls(s.indices, s.bytes, s.length, s.offset, string_sequence=s, null_bitmap=null_bitmap)
 
     @classmethod
     def from_arrow(cls, ar):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -478,7 +478,7 @@ class DataFrame(object):
         :param dropmissing: do not count missing values
         :param dropnan: do not count nan values
         :param dropna: short for any of the above, (see :func:`Expression.isna`)
-        :param bool axis: Axis over which to determine the unique elements (None will flatten arrays or lists)
+        :param int axis: Axis over which to determine the unique elements (None will flatten arrays or lists)
         :param str array_type: {array_type}
         """
         if dropna:

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -113,6 +113,22 @@ def register_function(scope=None, as_property=False, name=None, on_expression=Tr
         return f  # we leave the original function as is
     return wrapper
 
+
+def auto_str_unwrap(f):
+    '''Will take the first argument, and if a list, will unwrap/unraval, and apply f, and wrap again'''
+    @functools.wraps(f)
+    def decorated(x, *args, **kwargs):
+        if not isinstance(x, vaex.column.supported_column_types):
+            return f(x, *args, **kwargs)
+        dtype = vaex.dtype_of(x)
+        if dtype.is_list:
+            x, wrapper = vaex.arrow.utils.list_unwrap(x)
+            x = f(x, *args, **kwargs)
+            return wrapper(x)
+        else:
+            return f(x, *args, **kwargs)
+    return decorated
+
 # name maps to numpy function
 # <vaex name>:<numpy name>
 numpy_function_mapping = [name.strip().split(":") if ":" in name else (name, name) for name in """
@@ -939,6 +955,7 @@ def td_total_seconds(x):
 ########## string operations ##########
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_equals(x, y):
     """Tests if strings x and y are the same
 
@@ -988,6 +1005,7 @@ def str_equals(x, y):
 
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_capitalize(x):
     """Capitalize the first letter of a string sample.
 
@@ -1020,6 +1038,7 @@ def str_capitalize(x):
     return column.ColumnStringArrow.from_string_sequence(sl)
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_cat(x, other):
     """Concatenate two string columns on a row-by-row basis.
 
@@ -1060,6 +1079,7 @@ def str_cat(x, other):
     return column.ColumnStringArrow.from_string_sequence(sl)
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_center(x, width, fillchar=' '):
     """ Fills the left and right side of the strings with additional characters, such that the sample has a total of `width`
     characters.
@@ -1096,6 +1116,7 @@ def str_center(x, width, fillchar=' '):
 
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_contains(x, pattern, regex=True):
     """Check if a string pattern or regex is contained within a sample of a string column.
 
@@ -1332,11 +1353,23 @@ def str_index(x, sub, start=0, end=None):
     """
     return str_find(x, sub, start, end)
 
+
 @register_function(scope='str')
 def str_join(x, sep):
     """Same as find (difference with pandas is that it does not raise a ValueError)"""
-    sl = _to_string_list_sequence(x).join(sep)
-    return column.ColumnStringArrow.from_string_sequence(sl)
+    dtype = vaex.dtype_of(x)
+    assert dtype.is_list
+
+    values = x.values
+    offsets = vaex.array_types.to_numpy(x.offsets)
+    ss = _to_string_sequence(values)
+    x_joined_ss = vaex.strings.join(sep, offsets, ss, x.offset)
+    # TODO: we require a copy here, because the x_column and the string_seqence will be
+    # garbage collected, this is not idea, but once https://github.com/apache/arrow/pull/8990 is
+    # released, we can rely on that
+    x_column = column.ColumnStringArrow.from_string_sequence(x_joined_ss, copy=True)
+    x_joined = pa.array(x_column)
+    return x_joined
 
 
 @register_function(scope='str')
@@ -1827,16 +1860,27 @@ def str_slice(x, start=0, stop=None):  # TODO: support n
     return column.ColumnStringArrow.from_string_sequence(ss)
 
 # TODO: slice_replace (not sure it this makes sense)
-# TODO: n argument and rsplit
+
 @register_function(scope='str')
-def str_split(x, pattern=None):  # TODO: support n
-    x = _to_string_sequence(x)
-    if isinstance(x, vaex.strings.StringArray):
-        x = x.to_arrow()
-    if pattern == '':
-        raise ValueError('empty separator')
-    sll = x.split('' if pattern is None else pattern)
-    return sll
+def str_rsplit(x, pattern=None, max_splits=-1):
+    if not isinstance(x, vaex.array_types.supported_arrow_array_types):
+        x = pa.array(x)
+    if pattern is None:
+        return pc.utf8_split_whitespace(x, reverse=True, max_splits=max_splits)
+    else:
+        return pc.split_pattern(x, reverse=True, max_splits=max_splits)
+
+
+@register_function(scope='str')
+def str_split(x, pattern=None, max_splits=-1):
+    if not isinstance(x, vaex.array_types.supported_arrow_array_types):
+        x = pa.array(x)
+    if pattern is None:
+        return pc.utf8_split_whitespace(x, max_splits=max_splits)
+    else:
+        return pc.split_pattern(x, pattern=pattern, max_splits=max_splits)
+
+
 
 @register_function(scope='str')
 def str_startswith(x, pat):
@@ -1946,6 +1990,7 @@ def str_title(x):
 
 @register_function(scope='str')
 @docsubst
+@auto_str_unwrap
 def str_upper(x, ascii=False):
     """Converts all strings in a column to uppercase.
 
@@ -1988,6 +2033,7 @@ def str_upper(x, ascii=False):
 # TODO: wrap, is*, get_dummies(maybe?)
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_zfill(x, width):
     """Pad strings in a column by prepanding "0" characters.
 
@@ -2023,6 +2069,7 @@ def str_zfill(x, width):
 
 @register_function(scope='str')
 @docsubst
+@auto_str_unwrap
 def str_isalnum(x, ascii=False):
     """Check if all characters in a string sample are alphanumeric.
 
@@ -2059,6 +2106,7 @@ def str_isalnum(x, ascii=False):
 
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_isalpha(x):
     """Check if all characters in a string sample are alphabetic.
 
@@ -2090,6 +2138,7 @@ def str_isalpha(x):
     return _to_string_sequence(x).isalpha()
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_isdigit(x):
     """Check if all characters in a string sample are digits.
 
@@ -2121,6 +2170,7 @@ def str_isdigit(x):
     return _to_string_sequence(x).isdigit()
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_isspace(x):
     """Check if all characters in a string sample are whitespaces.
 
@@ -2152,6 +2202,7 @@ def str_isspace(x):
     return _to_string_sequence(x).isspace()
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_islower(x):
     """Check if all characters in a string sample are lowercase characters.
 
@@ -2183,6 +2234,7 @@ def str_islower(x):
     return _to_string_sequence(x).islower()
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_isupper(x):
     """Check if all characters in a string sample are lowercase characters.
 
@@ -2214,6 +2266,7 @@ def str_isupper(x):
     return _to_string_sequence(x).isupper()
 
 @register_function(scope='str')
+@auto_str_unwrap
 def str_istitle(x, ascii=False):
     '''TODO'''
     return _arrow_string_kernel_dispatch('is_title', ascii, x)

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -163,7 +163,6 @@ sinh
 sqrt
 tan
 tanh
-where
 """.strip().split()]
 for name, numpy_name in numpy_function_mapping:
     if not hasattr(np, numpy_name):
@@ -2499,3 +2498,60 @@ def add_geo_json(ds, json_or_file, column_name, longitude_expression, latitude_e
         return ds, mapping_dict
     else:
         return ds
+
+import vaex.arrow.numpy_dispatch
+
+@register_function()
+def where(condition, x, y):
+    # special where support for strings
+    # TODO: this should be replaced by an arrow compute function in the future
+    if type(x) == str:
+        if type(y) == str:
+            condition = vaex.array_types.to_arrow(condition).cast(pa.int8())
+            choices = pa.array([y, x])
+            values = choices.take(condition)
+            return values
+        else:
+            condition = vaex.array_types.to_arrow(condition)
+            indices = np.arange(len(y), dtype=np.int64)
+            # point to the last value
+            indices[vaex.array_types.to_numpy(condition)] = len(y)
+            indices = vaex.array_types.to_arrow(indices)
+
+            indices = vaex.arrow.numpy_dispatch.combine_missing(indices, condition)
+            y = vaex.array_types.to_arrow(y)
+            choices = vaex.array_types.concat([y, pa.array([x], type=y.type)])
+            values = choices.take(indices)
+            return values
+    elif type(y) == str:
+        condition = vaex.array_types.to_arrow(condition)
+        indices = np.arange(len(x), dtype=np.int64)
+        # point to the last value
+        indices[~vaex.array_types.to_numpy(condition)] = len(x)
+        indices = vaex.array_types.to_arrow(indices)
+
+        indices = vaex.arrow.numpy_dispatch.combine_missing(indices, condition)
+        x = vaex.array_types.to_arrow(x)
+        choices = vaex.array_types.concat([x, pa.array([y], type=x.type)])
+        values = choices.take(indices)
+        return values
+    elif vaex.column.is_column_like(x) and vaex.dtype_of(x).is_string:
+        assert vaex.dtype_of(y).is_string
+        condition = vaex.array_types.to_arrow(condition)
+        assert len(x) == len(y) == len(condition)
+        N = len(x)
+        indices = np.arange(N, dtype=np.int64)
+        mask = vaex.array_types.to_numpy(condition)
+        indices[~mask] += len(x)
+        indices = vaex.array_types.to_arrow(indices)
+
+        indices = vaex.arrow.numpy_dispatch.combine_missing(indices, condition)
+        x = vaex.array_types.to_arrow(x)
+        y = vaex.array_types.to_arrow(y)
+        x, y = vaex.arrow.convert.same_type(x, y)
+        choices = vaex.array_types.concat([x, y])
+        values = choices.take(indices)
+        return values
+    # default callback is on numpy
+    ar = np.where(condition, x, y)
+    return ar

--- a/tests/compute_test.py
+++ b/tests/compute_test.py
@@ -68,3 +68,39 @@ def test_where(s):
     df = vaex.from_arrays(s=s)
     expr = df.func.where(df['s'] == 'a', 'A', df['s'])
     assert expr.tolist() == ['A', 'b', None, 'd']
+    assert expr.dtype.is_string
+
+
+def test_where_large():
+    df = vaex.from_arrays(s=pa.array(['a', 'b', None, 'd'], type=pa.large_string()))
+    assert (df['s'] + df['s']).dtype.internal == pa.large_string()
+    expr = df.func.where(df['s'] == 'a', 'A', df['s'])
+    assert expr.tolist() == ['A', 'b', None, 'd']
+    assert expr.dtype.is_string
+
+def test_where_str_str(x):
+    df = vaex.from_arrays(x=x)
+    df['s'] = (df.x==1).where('a', 'b')
+    assert df.s.tolist() == ['b', 'a', 'b', None]
+    assert df.s.dtype.is_string
+
+
+def test_where_str_array(x, s):
+    df = vaex.from_arrays(x=x, s=s)
+    df['s2'] = (df.x==1).where('c', df.s)
+    assert df.s2.tolist() == ['a', 'c', None, None]
+    assert df.s2.dtype.is_string
+
+
+def test_where_array_str(x, s):
+    df = vaex.from_arrays(x=x, s=s)
+    df['s2'] = (df.x==1).where(df.s, 'c')
+    assert df.s2.tolist() == ['c', 'b', 'c', None]
+    assert df.s2.dtype.is_string
+
+
+def test_where_array_array(x, s):
+    df = vaex.from_arrays(x=x, s=s)
+    df['s2'] = (df.x==1).where(df.s, df.s + df.s)
+    assert df.s2.tolist() == ['aa', 'b', None, None]
+    assert df.s2.dtype.is_string

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -237,7 +237,6 @@ def test_string_index(dfs, sub, start, end):
 def test_string_join(dfs, pattern):
     assert dfs.s.str.split(pattern).str.join('-').tolist() == dfs.s.str.split(pattern).str.join('-').tolist()
 
-
 def test_string_len(dfs):
     assert dfs.s.str.len().astype('i4').tolist() == [len(k) for k in string_list]
     assert dfs.s.str_pandas.len().astype('i4').tolist() == [len(k) for k in string_list]
@@ -470,3 +469,19 @@ def test_string_operations_from_mmap_file(tmpdir):
 def test_string_operation_empty_df(df_factory):
     df = df_factory(s=["aap", "noot"])
     df[df.s == "MIES"].s.unique()
+
+
+def test_string_split():
+    df = vaex.from_arrays(s=["aap noot  mies", None, "kees", ""])
+    assert df.s.str.split().tolist() == [["aap", "noot", "mies"], None, ["kees"], [""]]
+    assert df.s.str.split(max_splits=1).tolist() == [["aap", "noot  mies"], None, ["kees"], [""]]
+
+
+def test_string_split_upper():
+    df = vaex.from_arrays(s=["aap noot  mies", None, "kees", ""])
+    assert df.s.str.split().str.upper().tolist() == [["AAP", "NOOT", "MIES"], None, ["KEES"], [""]]
+
+
+def test_string_split_contains():
+    df = vaex.from_arrays(s=["aap noot  mies", None, "kees", ""])
+    assert df.s.str.split().str.contains('aap').tolist() == [[True, False, False], None, [False], [False]]


### PR DESCRIPTION
We should support the string features that are ported to Apache Arrow v3, which should be released soon
 * [x] split https://github.com/apache/arrow/pull/8271
 * [x] work on arbitrary nested lists
 * [x] have custom join since https://github.com/apache/arrow/pull/8990 will not be in v3
 * ~~[ ] trim https://github.com/apache/arrow/pull/8621~~
 * [x] fillna for strings https://github.com/apache/arrow/pull/8628 which should make our fillna MUCH faster 🔥 
 * [x] Possibly implement `where` using fillna/take since that is also quite slow on strings now
