### PR TITLE
fix: NumpyDispatch with ColumnStringArrow

### DIFF
--- a/packages/vaex-core/vaex/arrow/numpy_dispatch.py
+++ b/packages/vaex-core/vaex/arrow/numpy_dispatch.py
@@ -10,6 +10,7 @@ class NumpyDispatch:
         self._array = ar
         if isinstance(ar, vaex.column.ColumnStringArrow):
             ar = pa.array(ar)
+            self._array = ar
         if isinstance(ar, np.ndarray):
             self._numpy_array = ar
             self._arrow_array = None

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -115,7 +115,7 @@ def test_create_datetime64_column_from_ints():
     df['minute'] = (df.time % 100).format('%02d')
 
     expr = df.year.format('%4d') + '-' + df.month.format('%02d') + '-' + df.day.format('%02d') + 'T' + df.hour + ':' + df.minute
-    assert expr.values.astype(np.datetime64).tolist() == expr.astype('datetime64').tolist()
+    assert expr.to_numpy().astype(np.datetime64).tolist() == expr.astype('datetime64').tolist()
 
 
 def test_create_datetime64_column_from_str():
@@ -127,8 +127,8 @@ def test_create_datetime64_column_from_str():
     df = vaex.from_arrays(year=year, month=month, day=day, hour=hour, minute=minute)
 
     expr = df.year + '-' + df.month + '-' + df.day + 'T' + df.hour + ':' + df.minute
-    assert expr.values.astype(np.datetime64).tolist() == expr.astype('datetime64').tolist()
-    assert expr.values.astype('datetime64[ns]').tolist() == expr.astype('datetime64[ns]').to_numpy().tolist()
+    assert expr.to_numpy().astype(np.datetime64).tolist() == expr.astype('datetime64').tolist()
+    assert expr.to_numpy().astype('datetime64[ns]').tolist() == expr.astype('datetime64[ns]').to_numpy().tolist()
 
 def test_create_str_column_from_datetime64():
     date = np.array([np.datetime64('2009-10-12T03:31:00'),

--- a/tests/fillna_test.py
+++ b/tests/fillna_test.py
@@ -143,3 +143,19 @@ def test_fillna_string_dtype():
 
     # Confirm that the column "name" is still of type string after fillna
     assert df['name'].is_string()
+
+def test_fillna_num_to_string_dtype():
+    # Generate the input
+    inp = vaex.from_arrays(
+        int1=np.ma.array([1, 0], mask=[0, 1], dtype=int),
+        float1=np.ma.array([3.14, 0], mask=[0, 1], dtype=float),
+    )
+
+    # Convert to string
+    inp['int1'] = inp['int1'].astype('string')
+    inp['float1'] = inp['float1'].astype('string')
+
+    assert inp['int1'].is_string
+    assert inp['float1'].is_string
+    assert inp['int1'].fillna('').tolist() == ['1', '']
+    assert inp['float1'].fillna('').tolist() == ['3.14', '']


### PR DESCRIPTION
In the case of ColumnStringArrow, NumpyDispatch was converting to a PyArrow array but then not doing anything with it. Instead, it needed to updated the object's `_array` attribute.