### PR TITLE
Feat: allow parsing of the FloatDtypes() from pandas

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -107,7 +107,7 @@ def open(path, convert=False, shuffle=False, fs_options={}, fs=None, *args, **kw
     :param dict fs_options: Extra arguments passed to an optional file system if needed:
         * Amazon AWS S3
             * `anonymous` - access file without authentication (public files)
-            * `access_key` - AWS access key, if not provided will use the standard env vars, or the `~/.aws/credentials` file 
+            * `access_key` - AWS access key, if not provided will use the standard env vars, or the `~/.aws/credentials` file
             * `secret_key` - AWS secret key, similar to `access_key`
             * `profile` - If multiple profiles are present in `~/.aws/credentials`, pick this one instead of 'default', see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
             * `region` - AWS Region, e.g. 'us-east-1`, will be determined automatically if not provided.
@@ -411,6 +411,8 @@ def from_pandas(df, name="pandas", copy_index=False, index_name="index"):
             values = np.ma.array(values._data, mask=values._mask)
         elif hasattr(pd.core.arrays, 'StringArray') and isinstance(values, pd.core.arrays.StringArray):
             values = pa.array(values)
+        elif hasattr(pd.core.arrays, 'FloatingArray') and isinstance(values, pd.core.arrays.FloatingArray):
+            values = np.ma.array(values._data, mask=values._mask)
         try:
             columns[name] = vaex.dataset.to_supported_array(values)
         except Exception as e:

--- a/tests/from_pandas_test.py
+++ b/tests/from_pandas_test.py
@@ -11,6 +11,7 @@ def test_from_pandas():
         'text_missing': pd.Series(['Some', 'parts', None, 'missing', None], dtype='string'),
         'float': [1, 30, -2, 1.5, 0.000],
         'float_missing': [1, None, -2, 1.5, 0.000],
+        'float_missing_masked': pd.Series([1, None, -2, 1.5, 0.000], dtype=pd.Float64Dtype()),
         'int_missing': pd.Series([1, None, 5, 1, 10], dtype='Int64'),
         'datetime_1': [pd.NaT, datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1), datetime.datetime(2019, 1, 1, 1, 1, 1)],
         'datetime_2': [pd.NaT, None, pd.NaT, pd.NaT, pd.NaT],
@@ -22,7 +23,6 @@ def test_from_pandas():
 
     # Get pandas dataframe
     pandas_df = pd.DataFrame(dd_dict)
-    pandas_df['float_missing_masked'] = pandas_df['float_missing'].astype(pd.Float64Dtype())
     pandas_df['datetime_7'] = pd.to_timedelta(pandas_df['datetime_2'] - pandas_df['datetime_1'])
     vaex_df = vaex.from_pandas(pandas_df)
     repr_value = repr(vaex_df)

--- a/tests/from_pandas_test.py
+++ b/tests/from_pandas_test.py
@@ -22,6 +22,7 @@ def test_from_pandas():
 
     # Get pandas dataframe
     pandas_df = pd.DataFrame(dd_dict)
+    pandas_df['float_missing_masked'] = pandas_df['float_missing'].astype(pd.Float64Dtype())
     pandas_df['datetime_7'] = pd.to_timedelta(pandas_df['datetime_2'] - pandas_df['datetime_1'])
     vaex_df = vaex.from_pandas(pandas_df)
     repr_value = repr(vaex_df)
@@ -36,7 +37,9 @@ def test_from_pandas():
     # assert vaex_df.text_missing.is_masked == True
     assert vaex_df.int_missing.is_masked == True
     assert vaex_df.float_missing.is_masked == False
+    assert vaex_df.float_missing_masked.is_masked == True
     assert vaex_df.int_missing.tolist() == [1, None, 5, 1, 10]
     assert vaex_df.text_missing.tolist() == ['Some', 'parts', None, 'missing', None]
     assert vaex_df.float_missing.values[[0, 2, 3, 4]].tolist() == [1.0, -2.0, 1.5, 0.0]
     assert np.isnan(vaex_df.float_missing.values[1])
+    assert vaex_df.float_missing_masked.tolist() == [1.0, None, -2.0, 1.5, 0.0]


### PR DESCRIPTION
This PR allows vaex to parse the `Float64Dtype()` from pandas, which allows for masked values (also works for 32bits).

- [x] Implementation
- [x] Test update
- [ ] Review