### PR TITLE
River integration

### DIFF
--- a/packages/vaex-ml/vaex/ml/incubator/river.py
+++ b/packages/vaex-ml/vaex/ml/incubator/river.py
@@ -1,0 +1,137 @@
+import warnings
+
+import numpy as np
+
+import pandas as pd
+
+import traitlets
+
+import vaex
+import vaex.serialize
+from vaex.ml import generate
+from vaex.ml import state
+from vaex.ml.state import serialize_pickle
+
+@vaex.serialize.register
+@generate.register
+class RiverModel(state.HasState):
+    '''This class wraps River (github.com/online-ml/river) estimators, making them vaex pipeline objects.
+
+    This class conveniently wraps River models making them vaex pipeline objects.
+    Thus they take full advantage of the serialization and pipeline system of vaex.
+    Only the River models that implement the `learn_many` are compatible.
+    One can also wrap an entire River pipeline, as long as each pipeline step
+    implements the `learn_many` method. With the wrapper one can iterate over the
+    data multiple times (epochs), and optinally shuffle each batch before it is
+    sent to the estimator. The `predict` method wil require as much memory as
+    needed to output the predictions as a numpy array, while the `transform`
+    method is evaluated lazily, and no memory copies are made.
+
+    Example:
+    >>> import vaex
+    >>> import vaex.ml
+    >>> from vaex.ml.incubator.river import RiverModel
+    >>> from river.linear_model import LinearRegression
+    >>> from river import optim
+    >>>
+    >>> df = vaex.example()
+    >>>
+    >>> features = df.column_names[:6]
+    >>> target = 'FeH'
+    >>>
+    >>> df = df.ml.standard_scaler(features=features, prefix='scaled_')
+    >>>
+    >>> features = df.get_column_names(regex='^scaled_')
+    >>> model = LinearRegression(optimizer=optim.SGD(lr=0.1), intercept_lr=0.1)
+    >>>
+    >>> river_model = RiverModel(model=model,
+                            features=features,
+                            target=target,
+                            batch_size=10_000,
+                            num_epochs=3,
+                            shuffle=True,
+                            prediction_name='pred_FeH')
+    >>>
+    >>> river_model.fit(df=df)
+    >>> df = river_model.transform(df)
+    >>> df.head(5)[['FeH', 'pred_FeH']]
+      #       FeH    pred_FeH
+      0  -1.00539    -1.6332
+      1  -1.70867    -1.56632
+      2  -1.83361    -1.55338
+      3  -1.47869    -1.60646
+      4  -1.85705    -1.5996
+    '''
+    snake_name = 'river_model'
+    model = traitlets.Any(default_value=None, allow_none=True, help='Write me').tag(**serialize_pickle)
+    features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
+    target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
+    batch_size = traitlets.Int(default_value=1_000_000, allow_none=False, help='Number of samples to be sent to the model in each batch.')
+    num_epochs = traitlets.Int(default_value=1, allow_none=False, help='Number of times each batch is sent to the model.')
+    shuffle = traitlets.Bool(default_value=False, allow_none=False, help='If True, shuffle the samples before sending them to the model.')
+    prediction_name = traitlets.Unicode(default_value='prediction', help='The name of the virtual column housing the predictions.')
+
+    def __call__(self, *args):
+        X = {feature: np.asarray(arg, np.float64) for arg, feature in zip(args, self.features)}
+        X = pd.DataFrame(X)
+        return self.model.predict_many(X).values
+
+
+    def predict(self, df):
+        '''Get an in memory numpy array with the predictions of the Model
+
+        :param df: A vaex DataFrame containing the input features
+        :returns: A in-memory numpy array containing the Model predictions
+        :rtype: numpy.array
+        '''
+        return self.model.predict_many(df.to_pandas_df(column_names=self.features)).values
+
+
+    def transform(self, df):
+        '''
+        Transform A DataFrame such that it contains the predictions of the Model in a form of a virtual column.
+
+        :param df: A vaex DataFrame
+
+        :return df: A vaex DataFrame
+        :rtype: DataFrame
+        '''
+        copy = df.copy()
+        lazy_function = copy.add_function('river_model_prediction_function', self, unique=True)
+        expression = lazy_function(*self.features)
+        copy.add_virtual_column(self.prediction_name, expression, unique=False)
+        return copy
+
+
+    def fit(self, df, progress=None):
+        '''Fit the RiverModel to the DataFrame.
+
+        :param df: A vaex DataFrame containig the features and target on which to train the model
+        :param progress: If True, display a progressbar which tracks the training progress.
+        '''
+
+        # Check whether the model is appropriate
+        assert hasattr(self.model, 'learn_many')
+
+        n_samples = len(df)
+
+        progressbar = vaex.utils.progressbars(progress)
+
+        # Portions of the DataFrame to evaluate
+        expressions = self.features + [self.target]
+
+        for epoch in range(self.num_epochs):
+            for i1, i2, df_tmp in df.to_pandas_df(column_names=expressions, chunk_size=self.batch_size):
+                progressbar((n_samples * epoch + i1) / (self.num_epochs * n_samples))
+                y_tmp = df_tmp.pop(self.target)
+
+                if self.shuffle:
+                    shuffle_index = np.arange(len(df_tmp))
+                    df_tmp = df_tmp.iloc[shuffle_index]
+                    y_tmp = y_tmp.iloc[shuffle_index]
+
+                # Train the model
+                self.model.learn_many(X=df_tmp, y=y_tmp)  # We should also support weights
+        progressbar(1.0)
+
+

--- a/packages/vaex-ml/vaex/ml/incubator/river.py
+++ b/packages/vaex-ml/vaex/ml/incubator/river.py
@@ -63,7 +63,7 @@ class RiverModel(state.HasState):
       4  -1.85705    -1.5996
     '''
     snake_name = 'river_model'
-    model = traitlets.Any(default_value=None, allow_none=True, help='Write me').tag(**serialize_pickle)
+    model = traitlets.Any(default_value=None, allow_none=True, help='A River model which implements the `learn_many` method.').tag(**serialize_pickle)
     features = traitlets.List(traitlets.Unicode(), help='List of features to use.')
     target = traitlets.Unicode(allow_none=False, help='The name of the target column.')
     batch_size = traitlets.Int(default_value=1_000_000, allow_none=False, help='Number of samples to be sent to the model in each batch.')

--- a/packages/vaex-ml/vaex/ml/spec.json
+++ b/packages/vaex-ml/vaex/ml/spec.json
@@ -911,7 +911,6 @@
         "version": "1.0.0"
     },
     {
-<<<<<<< HEAD
         "classname": "KMeans",
         "doc": "The KMeans clustering algorithm.\n\n    Example:\n\n    >>> import vaex.ml\n    >>> import vaex.ml.cluster\n    >>> df = vaex.ml.datasets.load_iris()\n    >>> features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']\n    >>> cls = vaex.ml.cluster.KMeans(n_clusters=3, features=features, init='random', max_iter=10)\n    >>> cls.fit(df)\n    >>> df = cls.transform(df)\n    >>> df.head(5)\n     #    sepal_width    petal_length    sepal_length    petal_width    class_    prediction_kmeans\n     0            3               4.2             5.9            1.5         1                    2\n     1            3               4.6             6.1            1.4         1                    2\n     2            2.9             4.6             6.6            1.3         1                    2\n     3            3.3             5.7             6.7            2.1         2                    0\n     4            4.2             1.4             5.5            0.2         0                    1\n    ",
         "module": "vaex.ml.cluster",
@@ -923,35 +922,17 @@
                 "help": "Coordinates of cluster centers.",
                 "name": "cluster_centers",
                 "type": "List"
-=======
-        "classname": "RiverModel",
-        "doc": "This class wraps River (github.com/online-ml/river) estimators, making them vaex pipeline objects.\n\n    This class conveniently wraps River models making them vaex pipeline objects.\n    Thus they take full advantage of the serialization and pipeline system of vaex.\n    Only the River models that implement the `learn_many` are compatible.\n    One can also wrap an entire River pipeline, as long as each pipeline step\n    implements the `learn_many` method. With the wrapper one can iterate over the\n    data multiple times (epochs), and optinally shuffle each batch before it is\n    sent to the estimator. The `predict` method wil require as much memory as\n    needed to output the predictions as a numpy array, while the `transform`\n    method is evaluated lazily, and no memory copies are made.\n\n    Example:\n    >>> import vaex\n    >>> import vaex.ml\n    >>> from vaex.ml.incubator.river import RiverModel\n    >>> from river.linear_model import LinearRegression\n    >>> from river import optim\n    >>>\n    >>> df = vaex.example()\n    >>>\n    >>> features = df.column_names[:6]\n    >>> target = 'FeH'\n    >>>\n    >>> df = df.ml.standard_scaler(features=features, prefix='scaled_')\n    >>>\n    >>> features = df.get_column_names(regex='^scaled_')\n    >>> model = LinearRegression(optimizer=optim.SGD(lr=0.1), intercept_lr=0.1)\n    >>>\n    >>> river_model = RiverModel(model=model,\n                            features=features,\n                            target=target,\n                            batch_size=10_000,\n                            num_epochs=3,\n                            shuffle=True,\n                            prediction_name='pred_FeH')\n    >>>\n    >>> river_model.fit(df=df)\n    >>> df = river_model.transform(df)\n    >>> df.head(5)[['FeH', 'pred_FeH']]\n      #       FeH    pred_FeH\n      0  -1.00539    -1.6332\n      1  -1.70867    -1.56632\n      2  -1.83361    -1.55338\n      3  -1.47869    -1.60646\n      4  -1.85705    -1.5996\n    ",
-        "module": "vaex.ml.incubator.river",
-        "snake_name": "river_model",
-        "traits": [
-            {
-                "default": 1000000,
-                "has_default": false,
-                "help": "Number of samples to be sent to the model in each batch.",
-                "name": "batch_size",
-                "type": "Int"
->>>>>>> ada16889 (Make the river model wrapper accessible via the fast vaex API)
             },
             {
                 "default": null,
                 "has_default": true,
-<<<<<<< HEAD
                 "help": "List of features to cluster.",
-=======
-                "help": "List of features to use.",
->>>>>>> ada16889 (Make the river model wrapper accessible via the fast vaex API)
                 "name": "features",
                 "type": "List"
             },
             {
                 "default": null,
                 "has_default": false,
-<<<<<<< HEAD
                 "help": "Sum of squared distances of samples to their closest cluster center.",
                 "name": "inertia",
                 "type": "CFloat"
@@ -1004,7 +985,33 @@
                 "help": "If True, enable verbosity mode.",
                 "name": "verbose",
                 "type": "CBool"
-=======
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "RiverModel",
+        "doc": "This class wraps River (github.com/online-ml/river) estimators, making them vaex pipeline objects.\n\n    This class conveniently wraps River models making them vaex pipeline objects.\n    Thus they take full advantage of the serialization and pipeline system of vaex.\n    Only the River models that implement the `learn_many` are compatible.\n    One can also wrap an entire River pipeline, as long as each pipeline step\n    implements the `learn_many` method. With the wrapper one can iterate over the\n    data multiple times (epochs), and optinally shuffle each batch before it is\n    sent to the estimator. The `predict` method wil require as much memory as\n    needed to output the predictions as a numpy array, while the `transform`\n    method is evaluated lazily, and no memory copies are made.\n\n    Example:\n    >>> import vaex\n    >>> import vaex.ml\n    >>> from vaex.ml.incubator.river import RiverModel\n    >>> from river.linear_model import LinearRegression\n    >>> from river import optim\n    >>>\n    >>> df = vaex.example()\n    >>>\n    >>> features = df.column_names[:6]\n    >>> target = 'FeH'\n    >>>\n    >>> df = df.ml.standard_scaler(features=features, prefix='scaled_')\n    >>>\n    >>> features = df.get_column_names(regex='^scaled_')\n    >>> model = LinearRegression(optimizer=optim.SGD(lr=0.1), intercept_lr=0.1)\n    >>>\n    >>> river_model = RiverModel(model=model,\n                            features=features,\n                            target=target,\n                            batch_size=10_000,\n                            num_epochs=3,\n                            shuffle=True,\n                            prediction_name='pred_FeH')\n    >>>\n    >>> river_model.fit(df=df)\n    >>> df = river_model.transform(df)\n    >>> df.head(5)[['FeH', 'pred_FeH']]\n      #       FeH    pred_FeH\n      0  -1.00539    -1.6332\n      1  -1.70867    -1.56632\n      2  -1.83361    -1.55338\n      3  -1.47869    -1.60646\n      4  -1.85705    -1.5996\n    ",
+        "module": "vaex.ml.incubator.river",
+        "snake_name": "river_model",
+        "traits": [
+            {
+                "default": 1000000,
+                "has_default": false,
+                "help": "Number of samples to be sent to the model in each batch.",
+                "name": "batch_size",
+                "type": "Int"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to use.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": false,
                 "help": "A River model which implements the `learn_many` method.",
                 "name": "model",
                 "type": "Any"
@@ -1043,7 +1050,6 @@
                 "help": "The name of the target column.",
                 "name": "target",
                 "type": "Unicode"
->>>>>>> ada16889 (Make the river model wrapper accessible via the fast vaex API)
             }
         ],
         "version": "1.0.0"

--- a/packages/vaex-ml/vaex/ml/spec.py
+++ b/packages/vaex-ml/vaex/ml/spec.py
@@ -10,6 +10,7 @@ from . import catboost
 from . import lightgbm
 from . import xgboost
 from . import cluster
+from .incubator import river
 
 
 def lmap(f, values):

--- a/packages/vaex-ml/vaex/ml/spec_new.json
+++ b/packages/vaex-ml/vaex/ml/spec_new.json
@@ -911,7 +911,6 @@
         "version": "1.0.0"
     },
     {
-<<<<<<< HEAD
         "classname": "KMeans",
         "doc": "The KMeans clustering algorithm.\n\n    Example:\n\n    >>> import vaex.ml\n    >>> import vaex.ml.cluster\n    >>> df = vaex.ml.datasets.load_iris()\n    >>> features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']\n    >>> cls = vaex.ml.cluster.KMeans(n_clusters=3, features=features, init='random', max_iter=10)\n    >>> cls.fit(df)\n    >>> df = cls.transform(df)\n    >>> df.head(5)\n     #    sepal_width    petal_length    sepal_length    petal_width    class_    prediction_kmeans\n     0            3               4.2             5.9            1.5         1                    2\n     1            3               4.6             6.1            1.4         1                    2\n     2            2.9             4.6             6.6            1.3         1                    2\n     3            3.3             5.7             6.7            2.1         2                    0\n     4            4.2             1.4             5.5            0.2         0                    1\n    ",
         "module": "vaex.ml.cluster",
@@ -923,35 +922,17 @@
                 "help": "Coordinates of cluster centers.",
                 "name": "cluster_centers",
                 "type": "List"
-=======
-        "classname": "RiverModel",
-        "doc": "This class wraps River (github.com/online-ml/river) estimators, making them vaex pipeline objects.\n\n    This class conveniently wraps River models making them vaex pipeline objects.\n    Thus they take full advantage of the serialization and pipeline system of vaex.\n    Only the River models that implement the `learn_many` are compatible.\n    One can also wrap an entire River pipeline, as long as each pipeline step\n    implements the `learn_many` method. With the wrapper one can iterate over the\n    data multiple times (epochs), and optinally shuffle each batch before it is\n    sent to the estimator. The `predict` method wil require as much memory as\n    needed to output the predictions as a numpy array, while the `transform`\n    method is evaluated lazily, and no memory copies are made.\n\n    Example:\n    >>> import vaex\n    >>> import vaex.ml\n    >>> from vaex.ml.incubator.river import RiverModel\n    >>> from river.linear_model import LinearRegression\n    >>> from river import optim\n    >>>\n    >>> df = vaex.example()\n    >>>\n    >>> features = df.column_names[:6]\n    >>> target = 'FeH'\n    >>>\n    >>> df = df.ml.standard_scaler(features=features, prefix='scaled_')\n    >>>\n    >>> features = df.get_column_names(regex='^scaled_')\n    >>> model = LinearRegression(optimizer=optim.SGD(lr=0.1), intercept_lr=0.1)\n    >>>\n    >>> river_model = RiverModel(model=model,\n                            features=features,\n                            target=target,\n                            batch_size=10_000,\n                            num_epochs=3,\n                            shuffle=True,\n                            prediction_name='pred_FeH')\n    >>>\n    >>> river_model.fit(df=df)\n    >>> df = river_model.transform(df)\n    >>> df.head(5)[['FeH', 'pred_FeH']]\n      #       FeH    pred_FeH\n      0  -1.00539    -1.6332\n      1  -1.70867    -1.56632\n      2  -1.83361    -1.55338\n      3  -1.47869    -1.60646\n      4  -1.85705    -1.5996\n    ",
-        "module": "vaex.ml.incubator.river",
-        "snake_name": "river_model",
-        "traits": [
-            {
-                "default": 1000000,
-                "has_default": false,
-                "help": "Number of samples to be sent to the model in each batch.",
-                "name": "batch_size",
-                "type": "Int"
->>>>>>> ada16889 (Make the river model wrapper accessible via the fast vaex API)
             },
             {
                 "default": null,
                 "has_default": true,
-<<<<<<< HEAD
                 "help": "List of features to cluster.",
-=======
-                "help": "List of features to use.",
->>>>>>> ada16889 (Make the river model wrapper accessible via the fast vaex API)
                 "name": "features",
                 "type": "List"
             },
             {
                 "default": null,
                 "has_default": false,
-<<<<<<< HEAD
                 "help": "Sum of squared distances of samples to their closest cluster center.",
                 "name": "inertia",
                 "type": "CFloat"
@@ -1004,7 +985,33 @@
                 "help": "If True, enable verbosity mode.",
                 "name": "verbose",
                 "type": "CBool"
-=======
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
+        "classname": "RiverModel",
+        "doc": "This class wraps River (github.com/online-ml/river) estimators, making them vaex pipeline objects.\n\n    This class conveniently wraps River models making them vaex pipeline objects.\n    Thus they take full advantage of the serialization and pipeline system of vaex.\n    Only the River models that implement the `learn_many` are compatible.\n    One can also wrap an entire River pipeline, as long as each pipeline step\n    implements the `learn_many` method. With the wrapper one can iterate over the\n    data multiple times (epochs), and optinally shuffle each batch before it is\n    sent to the estimator. The `predict` method wil require as much memory as\n    needed to output the predictions as a numpy array, while the `transform`\n    method is evaluated lazily, and no memory copies are made.\n\n    Example:\n    >>> import vaex\n    >>> import vaex.ml\n    >>> from vaex.ml.incubator.river import RiverModel\n    >>> from river.linear_model import LinearRegression\n    >>> from river import optim\n    >>>\n    >>> df = vaex.example()\n    >>>\n    >>> features = df.column_names[:6]\n    >>> target = 'FeH'\n    >>>\n    >>> df = df.ml.standard_scaler(features=features, prefix='scaled_')\n    >>>\n    >>> features = df.get_column_names(regex='^scaled_')\n    >>> model = LinearRegression(optimizer=optim.SGD(lr=0.1), intercept_lr=0.1)\n    >>>\n    >>> river_model = RiverModel(model=model,\n                            features=features,\n                            target=target,\n                            batch_size=10_000,\n                            num_epochs=3,\n                            shuffle=True,\n                            prediction_name='pred_FeH')\n    >>>\n    >>> river_model.fit(df=df)\n    >>> df = river_model.transform(df)\n    >>> df.head(5)[['FeH', 'pred_FeH']]\n      #       FeH    pred_FeH\n      0  -1.00539    -1.6332\n      1  -1.70867    -1.56632\n      2  -1.83361    -1.55338\n      3  -1.47869    -1.60646\n      4  -1.85705    -1.5996\n    ",
+        "module": "vaex.ml.incubator.river",
+        "snake_name": "river_model",
+        "traits": [
+            {
+                "default": 1000000,
+                "has_default": false,
+                "help": "Number of samples to be sent to the model in each batch.",
+                "name": "batch_size",
+                "type": "Int"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to use.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": false,
                 "help": "A River model which implements the `learn_many` method.",
                 "name": "model",
                 "type": "Any"
@@ -1043,7 +1050,6 @@
                 "help": "The name of the target column.",
                 "name": "target",
                 "type": "Unicode"
->>>>>>> ada16889 (Make the river model wrapper accessible via the fast vaex API)
             }
         ],
         "version": "1.0.0"

--- a/tests/ml/river_test.py
+++ b/tests/ml/river_test.py
@@ -1,0 +1,133 @@
+import pytest
+import vaex
+pytest.importorskip('river')
+from vaex.ml.incubator.river import RiverModel
+
+import numpy as np
+
+from river.linear_model import LinearRegression, LogisticRegression
+import river.optim
+
+
+models_regression = [LinearRegression()]
+models_classification = [LogisticRegression()]
+
+
+def test_river_regression(df_example):
+    df = df_example
+    df_train, df_test = df.ml.train_test_split(test_size=0.1, verbose=False)
+
+    features = df_train.column_names[:6]
+    target = 'FeH'
+
+    river_model = RiverModel(model=LinearRegression(),
+                             features=features,
+                             target=target,
+                             batch_size=50_000,
+                             num_epochs=3,
+                             shuffle=True,
+                             prediction_name='pred')
+    river_model.fit(df=df_train)
+    df_train = river_model.transform(df_train)
+
+    # State transfer
+    state = df_train.state_get()
+    df_test.state_set(state)
+
+    assert df_train.column_count() == df_test.column_count()
+    assert df_test.pred.values.shape == (33000,)
+
+    pred_in_memory = river_model.predict(df_test)
+    np.testing.assert_array_almost_equal(pred_in_memory, df_test.pred.values, decimal=1)
+
+
+def test_river_classification(df_iris_1e5):
+    df = df_iris_1e5
+    # Convert to a binary problem
+    df['target'] = (df['class_'] == 2).astype('int')
+    df_train, df_test = df.ml.train_test_split(test_size=0.1, verbose=False)
+
+    features = df_train.column_names[:4]
+    target = 'target'
+
+    river_model = RiverModel(model=LogisticRegression(),
+                             features=features,
+                             target=target,
+                             batch_size=50_000,
+                             num_epochs=3,
+                             shuffle=True,
+                             prediction_name='pred')
+    river_model.fit(df=df_train)
+    df_train = river_model.transform(df_train)
+
+    # State transfer
+    state = df_train.state_get()
+    df_test.state_set(state)
+
+    assert df_train.column_count() == df_test.column_count()
+    assert df_test.pred.values.shape == (10050,)
+
+    pred_in_memory = river_model.predict(df_test)
+    np.testing.assert_array_almost_equal(pred_in_memory, df_test.pred.values, decimal=1)
+
+
+def test_river_sertialize(tmpdir, df_example):
+    df = df_example
+    df_train, df_test = df.ml.train_test_split(test_size=0.1, verbose=False)
+
+    features = df_train.column_names[:6]
+    target = 'FeH'
+
+    river_model = RiverModel(model=LinearRegression(),
+                             features=features,
+                             target=target,
+                             batch_size=50_000,
+                             num_epochs=3,
+                             shuffle=True,
+                             prediction_name='pred')
+    river_model.fit(df=df_train)
+    df_train = river_model.transform(df_train)
+
+    # State transfer - serialization
+    df_train.state_write(str(tmpdir.join('test.json')))
+    df_test.state_load(str(tmpdir.join('test.json')))
+
+    assert df_train.column_count() == df_test.column_count()
+    assert df_test.pred.values.shape == (33000,)
+
+    pred_in_memory = river_model.predict(df_test)
+    np.testing.assert_array_almost_equal(pred_in_memory, df_test.pred.values, decimal=1)
+
+@pytest.mark.parametrize("batch_size", [6789, 10_000])
+@pytest.mark.parametrize("num_epochs", [1, 5])
+def test_river_learn_many_calls(batch_size, num_epochs, df_example):
+    df = df_example
+    df_train, df_test = df.ml.train_test_split(test_size=0.1, verbose=False)
+
+    features = df_train.column_names[:6]
+    target = 'FeH'
+
+    N_total = len(df_train)
+    num_batches = (N_total + batch_size - 1) // batch_size
+
+    # Create a mock model for counting the number of samples seen and partial_fit calls
+    class MockModel():
+        def __init__(self):
+            self.n_samples_ = 0
+            self.n_learn_many_calls_ = 0
+
+        def learn_many(self, X, y):
+            self.n_samples_ += X.shape[0]
+            self.n_learn_many_calls_ += 1
+
+    river_model = RiverModel(model=MockModel(),
+                             features=features,
+                             target=target,
+                             num_epochs=num_epochs,
+                             batch_size=batch_size,
+                             shuffle=False,
+                             prediction_name='pred')
+
+    river_model.fit(df=df_train)
+    assert river_model.model.n_samples_ == N_total * num_epochs
+    assert river_model.model.n_learn_many_calls_ == num_batches * num_epochs


### PR DESCRIPTION
This PR provides a convenient wrapper around models and even pipelines of [River](https://github.com/online-ml/river).
The requirement is that the models implement the `learn_many` method, and currently it is assumed that the `predict_many` method returns a pandas Series. 

For the reason / motivation behind this, please see https://github.com/online-ml/river/discussions/515.

With the wrapper, the River models become part of the vaex computational graph, and one gets full benefit of the serialization and lazy evaluation. 

Here is a basic example:

```python
import vaex
import vaex.ml
from vaex.ml.incubator.river import RiverModel

from river.linear_model import LinearRegression
from river import optim

df = vaex.example()

# Train test split
df_train, df_test = df.ml.train_test_split(test_size=0.2, verbose=False)

# Features
features = ['x', 'y', 'z', 'vx', 'vy', 'vz']
target = 'FeH'

# Preprocessing
df_train = df_train.ml.standard_scaler(features=features, prefix='scaled_')

# New pre-processed features
features = df_train.get_column_names(regex='^scaled_')

river_model = RiverModel(model=LinearRegression(optimizer=optim.SGD(lr=0.1), intercept_lr=0.1), 
                         features=features, 
                         target=target, 
                         batch_size=10_000, 
                         num_epochs=1,
                         prediction_name='river')
river_model.fit(df=df_train, progress='widget')
df_train = river_model.transform(df_train)

# Serialize to disk
df_train.state_write('./state_river.json')
df_test.state_load('./state_river.json')
df_test.head(5)
```

One can even use the full River pipeline, provided each step in the pipeline implements the `learn_many` method:

```python
import vaex
import vaex.ml
from vaex.ml.incubator.river import RiverModel

from river.linear_model import LinearRegression
from river import optim
from river.compose import Pipeline
from river.preprocessing import StandardScaler

df = vaex.example()

# Train test split
df_train, df_test = df.ml.train_test_split(test_size=0.2, verbose=False)

# Features
features = ['x', 'y', 'z', 'vx', 'vy', 'vz']
target = 'FeH'


pipe = Pipeline(('scale', StandardScaler()),
                ('model', LinearRegression(optimizer=optim.SGD(lr=0.1), intercept_lr=0.1))
               )


river_pipe = RiverModel(model=pipe,
                        features=features, 
                        target=target, 
                        batch_size=10, 
                        num_epochs=1,
                        prediction_name='river')

river_pipe.fit(df=df_train, progress='widget')
df_train = river_pipe.transform(df_train)

# Serialize to disk
df_train.state_write('./state_river.json')
df_test.state_load('./state_river.json')
df_test.head(5)                        
```

Currently only the `LinearRegression` and `LogisticRegression` models are tested. We hope that River will implement the `learn_many` method to more of their models - they have a decent variety of models, including tree-based models and are doing excellent work. 

The Dense neural network implementation in principle should also work, but the `predict_many` method returns a pandas DataFrame instead of a series. 

Thoughts & Comments welcome. 

