### PR TITLE
Fix: Support for loading state files from GCS

### DIFF
--- a/packages/vaex-core/vaex/file/cache.py
+++ b/packages/vaex-core/vaex/file/cache.py
@@ -194,6 +194,21 @@ class CachedFile:
             self.length = self.data_file.length
             self.mask_length = self.mask_file.length
 
+    def readable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def seekable(self):
+        return True
+
+    def closed(self):
+        return self.file.closed()
+
+    def flush(self):
+        pass
+
     def dup(self):
         if callable(self.file):
             file = self.file

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -99,3 +99,19 @@ def test_filter_rename_column():
     assert df_test.get_column_names() == ['feat1', 'feat2']
     assert df_test.feat1.tolist() == [5]
     assert df_test.feat2.tolist() == [10]
+
+
+def test_state_load_gcs():
+    df = vaex.ml.datasets.load_iris()
+    f = vaex.file.open('gs://vaex-data/testing/test_iris_state.json', fs_options={'token': 'anon', 'cache': True})
+    import io
+    f = io.TextIOWrapper(f, encoding='utf8')
+    f.read()
+    df.state_load('gs://vaex-data/testing/test_iris_state.json', fs_options={'token': 'anon', 'cache': True})
+
+    assert df.column_count() == 7
+    assert 'norm_sepal_length' in df.column_names
+    assert 'minmax_petal_width' in df.column_names
+    assert df.minmax_petal_width.minmax().tolist() == [0, 1]
+    assert df.norm_sepal_length.mean().round(decimals=5) == 0
+    assert df.norm_sepal_length.std().round(decimals=5) == 1


### PR DESCRIPTION
This PR irons out the support for loading state files from cloud storage. 

To do:
- [x] Implement a unit-test for this
- [ ] Add support to ignore or not to cache files (as model/state might be updated in the cloud, and we want to pick up this change)
- [ ] Review

