### PR TITLE
Improv: KMeans can be used via the fast api of vaex.ml

### DIFF
--- a/packages/vaex-ml/vaex/ml/cluster.py
+++ b/packages/vaex-ml/vaex/ml/cluster.py
@@ -1,6 +1,6 @@
 import numpy as np
 import traitlets
-import vaex.ml.state
+import vaex.ml.transformations
 import logging
 import vaex
 import vaex.serialize
@@ -63,7 +63,7 @@ def centroid_stats(centroids, counts, sumpos, inertia, *blocks):
 
 @vaex.serialize.register
 @generate.register
-class KMeans(vaex.ml.state.HasState):
+class KMeans(vaex.ml.transformations.Transformer):
     '''The KMeans clustering algorithm.
 
     Example:
@@ -83,6 +83,7 @@ class KMeans(vaex.ml.state.HasState):
      3            3.3             5.7             6.7            2.1         2                    0
      4            4.2             1.4             5.5            0.2         0                    1
     '''
+    snake_name = 'kmeans'
     features = traitlets.List(traitlets.Unicode(), help='List of features to cluster.')
     n_clusters = traitlets.CInt(default_value=2, help='Number of clusters to form.')
     init = traitlets.Union([Matrix(), traitlets.Unicode()], default_value='random', help='Method for initializing the centroids.')
@@ -91,8 +92,7 @@ class KMeans(vaex.ml.state.HasState):
                                                    and the final results will be the best output of the n_init \
                                                    consecutive runs in terms of inertia.')
     max_iter = traitlets.CInt(default_value=300, help='Maximum number of iterations of the KMeans algorithm for a single run.')
-    random_state = traitlets.CInt(default_value=None, allow_none=True, help='Random number generation for centroid initialization. \
-                                                                             If an int is specified, the randomness becomes deterministic.')
+    random_state = traitlets.CInt(default_value=None, allow_none=True, help='Random number generation for centroid initialization. If an int is specified, the randomness becomes deterministic.')
     verbose = traitlets.CBool(default_value=False, help='If True, enable verbosity mode.')
     cluster_centers = traitlets.List(traitlets.List(traitlets.CFloat()), help='Coordinates of cluster centers.')
     inertia = traitlets.CFloat(default_value=None, allow_none=True, help='Sum of squared distances of samples to their closest cluster center.')
@@ -196,7 +196,7 @@ class KMeans(vaex.ml.state.HasState):
         clusters = centroids.shape[1]
         dimensions = centroids.shape[2]
         # print("k =", k)
-        assert dimensions == len(self.features), "nr of dimensions for centroid should equal nr of features"
+        assert dimensions == len(self.features), "The number of dimensions for the centroid should equal the number of features."
 
         def map(*blocks):  # this will be called with a chunk of the data
             sumpos = np.zeros((runs, clusters, dimensions))

--- a/packages/vaex-ml/vaex/ml/spec.json
+++ b/packages/vaex-ml/vaex/ml/spec.json
@@ -909,5 +909,84 @@
             }
         ],
         "version": "1.0.0"
+    },
+    {
+        "classname": "KMeans",
+        "doc": "The KMeans clustering algorithm.\n\n    Example:\n\n    >>> import vaex.ml\n    >>> import vaex.ml.cluster\n    >>> df = vaex.ml.datasets.load_iris()\n    >>> features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']\n    >>> cls = vaex.ml.cluster.KMeans(n_clusters=3, features=features, init='random', max_iter=10)\n    >>> cls.fit(df)\n    >>> df = cls.transform(df)\n    >>> df.head(5)\n     #    sepal_width    petal_length    sepal_length    petal_width    class_    prediction_kmeans\n     0            3               4.2             5.9            1.5         1                    2\n     1            3               4.6             6.1            1.4         1                    2\n     2            2.9             4.6             6.6            1.3         1                    2\n     3            3.3             5.7             6.7            2.1         2                    0\n     4            4.2             1.4             5.5            0.2         0                    1\n    ",
+        "module": "vaex.ml.cluster",
+        "snake_name": "kmeans",
+        "traits": [
+            {
+                "default": null,
+                "has_default": true,
+                "help": "Coordinates of cluster centers.",
+                "name": "cluster_centers",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to cluster.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": false,
+                "help": "Sum of squared distances of samples to their closest cluster center.",
+                "name": "inertia",
+                "type": "CFloat"
+            },
+            {
+                "default": "random",
+                "has_default": false,
+                "help": "Method for initializing the centroids.",
+                "name": "init",
+                "type": "Union"
+            },
+            {
+                "default": 300,
+                "has_default": false,
+                "help": "Maximum number of iterations of the KMeans algorithm for a single run.",
+                "name": "max_iter",
+                "type": "CInt"
+            },
+            {
+                "default": 2,
+                "has_default": false,
+                "help": "Number of clusters to form.",
+                "name": "n_clusters",
+                "type": "CInt"
+            },
+            {
+                "default": 1,
+                "has_default": false,
+                "help": "Number of centroid initializations.                                                    The KMeans algorithm will be run for each initialization,                                                    and the final results will be the best output of the n_init                                                    consecutive runs in terms of inertia.",
+                "name": "n_init",
+                "type": "CInt"
+            },
+            {
+                "default": "prediction_kmeans",
+                "has_default": false,
+                "help": "The name of the virtual column that houses the cluster labels for each point.",
+                "name": "prediction_label",
+                "type": "Unicode"
+            },
+            {
+                "default": null,
+                "has_default": false,
+                "help": "Random number generation for centroid initialization. If an int is specified, the randomness becomes deterministic.",
+                "name": "random_state",
+                "type": "CInt"
+            },
+            {
+                "default": false,
+                "has_default": false,
+                "help": "If True, enable verbosity mode.",
+                "name": "verbose",
+                "type": "CBool"
+            }
+        ],
+        "version": "1.0.0"
     }
 ]

--- a/packages/vaex-ml/vaex/ml/spec.py
+++ b/packages/vaex-ml/vaex/ml/spec.py
@@ -9,6 +9,7 @@ from . import generate
 from . import catboost
 from . import lightgbm
 from . import xgboost
+from . import cluster
 
 
 def lmap(f, values):


### PR DESCRIPTION
- `vaex.ml.cluster.KMeans` can now be used via the fast or functional API of `vaex.ml`
- improved docstring formatting
- no functionality changes