### PR TITLE
RandomProjections implementation

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -25,7 +25,7 @@ pytest-timeout
 python-graphviz
 scikit-learn
 scipy
-s3fs
-gcsfs
+s3fs <0.6
+gcsfs <0.8
 tornado
 xarray

--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -25,7 +25,7 @@ pytest-timeout
 python-graphviz
 scikit-learn
 scipy
-s3fs <0.6
-gcsfs <0.8
+s3fs
+gcsfs
 tornado
 xarray

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -971,16 +971,18 @@ def format_exception_trace(e):
 
 
 class ProxyModule:
-    def __init__(self, name, version):
+    def __init__(self, name, version, modules=None):
         self.name = name
         self.module = None
         self.version = version
+        self.modules = modules if modules else [self.name]
 
     def _ensure_import(self):
         if self.module is None:
             import importlib
             try:
-                importlib.import_module(self.name)
+                for module_name in self.modules:
+                    importlib.import_module(module_name)
                 # the module object itself needs to be the top module
                 top_name = self.name.split(".")[0]
                 self.module = importlib.import_module(top_name)
@@ -1001,8 +1003,8 @@ $ conda install -c conda-forge "{self.name}{self.version}""
         return getattr(self.module, name)
 
 
-def optional_import(name, version=''):
-    return ProxyModule(name, version=version)
+def optional_import(name, version='', modules=None):
+    return ProxyModule(name, version=version, modules=modules)
 
 
 def div_ceil(n, d):

--- a/packages/vaex-ml/vaex/ml/__init__.py
+++ b/packages/vaex-ml/vaex/ml/__init__.py
@@ -92,7 +92,7 @@ if os.path.exists(filename_spec):
                 setattr(accessor, name, closure())
 
 
-from .transformations import PCA, PCAIncremental
+from .transformations import PCA, PCAIncremental, RandomProjections
 from .transformations import StandardScaler, MinMaxScaler, MaxAbsScaler, RobustScaler
 from .transformations import LabelEncoder, OneHotEncoder, FrequencyEncoder
 from .transformations import CycleTransformer

--- a/packages/vaex-ml/vaex/ml/spec.json
+++ b/packages/vaex-ml/vaex/ml/spec.json
@@ -166,7 +166,7 @@
     },
     {
         "classname": "RandomProjections",
-        "doc": "Reduce dimensionality through a random matrix projection.\n\n    The random projections method is based on the Johnson-Lindenstrauss lemma.\n    For mode details see https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma\n\n    Note that you need scikit-learn to fit this Transformer but not for transformations using an already fitter Transformer.\n    ",
+        "doc": "Reduce dimensionality through a random matrix projection.\n\n    The random projections method is based on the Johnson-Lindenstrauss lemma.\n    For mode details see https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma\n\n    Note that you need scikit-learn to fit this Transformer but not for transformations using an already fitter Transformer.\n\n    Example:\n\n    >>> import vaex\n    >>> import vaex.ml\n    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10], z=[2, -10, 2, 3, 0])\n    >>> df\n    #    x    y    z\n    0    2   -2    2\n    1    5    3  -10\n    2    7    0    2\n    3    2    0    3\n    4   15   10    0\n    >>> rand_proj = vaex.ml.RandomProjections(features=['x', 'y', 'z'], n_components=2)\n    >>> rand_proj.fit_transform(df)\n    #    x    y    z    random_projection_0    random_projection_1\n    0    2   -2    2                1.73363             -0.0700273\n    1    5    3  -10              -17.8742             -14.0226\n    2    7    0    2               -3.32911             -8.50181\n    3    2    0    3                2.04843             -1.27538\n    4   15   10    0              -17.0289             -28.6562\n    ",
         "module": "vaex.ml.transformations",
         "snake_name": "random_projections",
         "traits": [

--- a/packages/vaex-ml/vaex/ml/spec.json
+++ b/packages/vaex-ml/vaex/ml/spec.json
@@ -165,6 +165,71 @@
         "version": "1.0.0"
     },
     {
+        "classname": "RandomProjections",
+        "doc": "Reduce dimensionality through a random matrix projection.\n\n    The random projections method is based on the Johnson-Lindenstrauss lemma.\n    For mode details see https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma\n\n    Note that you need scikit-learn to fit this Transformer but not for transformations using an already fitter Transformer.\n    ",
+        "module": "vaex.ml.transformations",
+        "snake_name": "random_projections",
+        "traits": [
+            {
+                "default": null,
+                "has_default": false,
+                "help": "Ratio in the range (0, 1] of non-zero component in the random projection matrix. Only valid if `matrix_type` is \"sparse\". If density is None, the value is set to the minimum density as recommended by Ping Li et al.: 1 / sqrt(n_features).",
+                "name": "density",
+                "type": "Float"
+            },
+            {
+                "default": 0.1,
+                "has_default": false,
+                "help": "Parameter to control the quality of the embedding according to the Johnson-Lindenstrauss lemma when `n_components` is set to None. The value must be positive.",
+                "name": "eps",
+                "type": "Float"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "List of features to transform.",
+                "name": "features",
+                "type": "List"
+            },
+            {
+                "default": "gaussian",
+                "has_default": false,
+                "help": "The type of random matrix to create. The values can be \"gaussian\" and \"sparse\".",
+                "name": "matrix_type",
+                "type": "Enum"
+            },
+            {
+                "default": null,
+                "has_default": false,
+                "help": "Number of components to retain. If None (default) the number will be set via the Johnson-Lindenstrauss formula. See https://scikit-learn.org/stable/modules/generated/sklearn.random_projection.johnson_lindenstrauss_min_dim.html for more details.",
+                "name": "n_components",
+                "type": "CInt"
+            },
+            {
+                "default": "random_projection_",
+                "has_default": false,
+                "help": "Prefix for the names of the transformed features.",
+                "name": "prefix",
+                "type": "Unicode"
+            },
+            {
+                "default": null,
+                "has_default": true,
+                "help": "The random matrix.",
+                "name": "random_matrix_",
+                "type": "List"
+            },
+            {
+                "default": null,
+                "has_default": false,
+                "help": "Controls the pseudo random number generator used to generate the projection matrix at fit time. Used to get reproducible results.",
+                "name": "random_state",
+                "type": "Int"
+            }
+        ],
+        "version": "1.0.0"
+    },
+    {
         "classname": "LabelEncoder",
         "doc": "Encode categorical columns with integer values between 0 and num_classes-1.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(color=['red', 'green', 'green', 'blue', 'red'])\n    >>> df\n     #  color\n     0  red\n     1  green\n     2  green\n     3  blue\n     4  red\n    >>> encoder = vaex.ml.LabelEncoder(features=['color'])\n    >>> encoder.fit_transform(df)\n     #  color      label_encoded_color\n     0  red                          2\n     1  green                        1\n     2  green                        1\n     3  blue                         0\n     4  red                          2\n    ",
         "module": "vaex.ml.transformations",
@@ -203,7 +268,7 @@
     },
     {
         "classname": "OneHotEncoder",
-        "doc": "Encode categorical columns according ot the One-Hot scheme.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(color=['red', 'green', 'green', 'blue', 'red'])\n    >>> df\n     #  color\n     0  red\n     1  green\n     2  green\n     3  blue\n     4  red\n    >>> encoder = vaex.ml.OneHotEncoder(features=['color'])\n    >>> encoder.fit_transform(df)\n     #  color      color_blue    color_green    color_red\n     0  red                 0              0            1\n     1  green               0              1            0\n     2  green               0              1            0\n     3  blue                1              0            0\n     4  red                 0              0            1\n    ",
+        "doc": "Encode categorical columns according ot the One-Hot scheme.\n\n    Example:\n\n    >>> import vaex\n    >>> df = vaex.from_arrays(color=['red', 'green', 'green', 'blue', 'red'])\n    >>> df\n     #  color\u00ae\n     0  red\n     1  green\n     2  green\n     3  blue\n     4  red\n    >>> encoder = vaex.ml.OneHotEncoder(features=['color'])\n    >>> encoder.fit_transform(df)\n     #  color      color_blue    color_green    color_red\n     0  red                 0              0            1\n     1  green               0              1            0\n     2  green               0              1            0\n     3  blue                1              0            0\n     4  red                 0              0            1\n    ",
         "module": "vaex.ml.transformations",
         "snake_name": "one_hot_encoder",
         "traits": [

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -8,6 +8,9 @@ from vaex.utils import _ensure_strings_from_expressions
 import numpy as np
 import warnings
 
+sklearn = vaex.utils.optional_import("sklearn.decomposition")
+sklearn = vaex.utils.optional_import("sklearn.random_projection")
+
 help_features = 'List of features to transform.'
 help_prefix = 'Prefix for the names of the transformed features.'
 
@@ -137,6 +140,71 @@ help_prefix = 'Prefix for the names of the transformed features.'
 
 @register
 @generate.register
+class PCAIncremental(PCA):
+    '''Transform a set of features using the "sklearn.decomposition.IncrementalPCA" algorithm.
+
+    Note that you need to have scikit-learn installed to fit this Transformer, but not
+    for transformations using an already fitted Transformer.
+
+    Example:
+
+    >>> import vaex
+    >>> import vaex.ml
+    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10])
+    >>> df
+    #    x    y
+    0    2   -2
+    1    5    3
+    2    7    0
+    3    2    0
+    4   15   10
+    >>> pca = vaex.ml.PCAIncremental(n_components=2, features=['x', 'y'], batch_size=3)
+    >>> pca.fit_transform(df)
+    #    x    y      PCA_0      PCA_1
+    0    2   -2  -5.92532   -0.413011
+    1    5    3  -0.380494   1.39112
+    2    7    0  -0.840049  -2.18502
+    3    2    0  -4.61287    1.09612
+    4   15   10  11.7587     0.110794
+    '''
+    snake_name = 'pca_incremental'
+    batch_size = traitlets.Int(default_value=1000, help='Number of samples to be send to the transformer in each batch.')
+    noise_variance_ = traitlets.CFloat(default_value=0, help='The estimated noise covariance following the Probabilistic PCA model from Tipping and Bishop 1999.').tag(output=True)
+    n_samples_seen_ = traitlets.CInt(default_value=0, help='The number of samples processed by the transformer.').tag(output=True)
+
+    def fit(self, df, progress=None):
+        '''Fit the PCAIncremental model to the DataFrame.
+
+        :param df: A vaex DataFrame.
+        :param progress: If True or 'widget', display a progressbar of the fitting process.
+        '''
+
+        self.n_components = self.n_components or len(self.features)
+
+        n_samples = len(df)
+        progressbar = vaex.utils.progressbars(progress)
+        pca = sklearn.decomposition.IncrementalPCA(n_components=self.n_components,
+                                                   batch_size=self.batch_size,
+                                                   whiten=self.whiten)
+
+        for i1, i2, chunk in df.evaluate_iterator(self.features, chunk_size=self.batch_size, array_type='numpy'):
+            progressbar(i1 / n_samples)
+            chunk = np.array(chunk).T.astype(np.float64)
+            pca.partial_fit(X=chunk, check_input=False)
+        progressbar(1.0)
+
+        self.singular_values_ = pca.singular_values_.tolist()
+        self.eigen_vectors_ = pca.components_.T.tolist()
+        self.eigen_values_ = pca.explained_variance_.tolist()
+        self.explained_variance_ = pca.explained_variance_.tolist()
+        self.explained_variance_ratio_ = pca.explained_variance_ratio_.tolist()
+        self.means_ = pca.mean_.tolist()
+        self.noise_variance_ = pca.noise_variance_
+        self.n_samples_seen_ = pca.n_samples_seen_
+
+
+@register
+@generate.register
 class RandomProjections(Transformer):
     '''Reduce dimensionality through a random matrix projection.
 
@@ -194,9 +262,6 @@ class RandomProjections(Transformer):
 
         :param df: A vaex DataFrame.
         '''
-
-        sklearn = vaex.utils.optional_import("sklearn.random_projection")
-
         n_samples = len(df)
         n_features = len(self.features)
 
@@ -238,73 +303,6 @@ class RandomProjections(Transformer):
             copy[name] = expr
 
         return copy
-
-
-@register
-@generate.register
-class PCAIncremental(PCA):
-    '''Transform a set of features using the "sklearn.decomposition.IncrementalPCA" algorithm.
-
-    Note that you need to have scikit-learn installed to fit this Transformer, but not
-    for transformations using an already fitted Transformer.
-
-    Example:
-
-    >>> import vaex
-    >>> import vaex.ml
-    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10])
-    >>> df
-    #    x    y
-    0    2   -2
-    1    5    3
-    2    7    0
-    3    2    0
-    4   15   10
-    >>> pca = vaex.ml.PCAIncremental(n_components=2, features=['x', 'y'], batch_size=3)
-    >>> pca.fit_transform(df)
-    #    x    y      PCA_0      PCA_1
-    0    2   -2  -5.92532   -0.413011
-    1    5    3  -0.380494   1.39112
-    2    7    0  -0.840049  -2.18502
-    3    2    0  -4.61287    1.09612
-    4   15   10  11.7587     0.110794
-    '''
-    snake_name = 'pca_incremental'
-    batch_size = traitlets.Int(default_value=1000, help='Number of samples to be send to the transformer in each batch.')
-    noise_variance_ = traitlets.CFloat(default_value=0, help='The estimated noise covariance following the Probabilistic PCA model from Tipping and Bishop 1999.').tag(output=True)
-    n_samples_seen_ = traitlets.CInt(default_value=0, help='The number of samples processed by the transformer.').tag(output=True)
-
-    def fit(self, df, progress=None):
-        '''Fit the PCAIncremental model to the DataFrame.
-
-        :param df: A vaex DataFrame.
-        :param progress: If True or 'widget', display a progressbar of the fitting process.
-        '''
-
-        sklearn = vaex.utils.optional_import("sklearn.decomposition")
-
-        self.n_components = self.n_components or len(self.features)
-
-        n_samples = len(df)
-        progressbar = vaex.utils.progressbars(progress)
-        pca = sklearn.decomposition.IncrementalPCA(n_components=self.n_components,
-                                                   batch_size=self.batch_size,
-                                                   whiten=self.whiten)
-
-        for i1, i2, chunk in df.evaluate_iterator(self.features, chunk_size=self.batch_size, array_type='numpy'):
-            progressbar(i1 / n_samples)
-            chunk = np.array(chunk).T.astype(np.float64)
-            pca.partial_fit(X=chunk, check_input=False)
-        progressbar(1.0)
-
-        self.singular_values_ = pca.singular_values_.tolist()
-        self.eigen_vectors_ = pca.components_.T.tolist()
-        self.eigen_values_ = pca.explained_variance_.tolist()
-        self.explained_variance_ = pca.explained_variance_.tolist()
-        self.explained_variance_ratio_ = pca.explained_variance_ratio_.tolist()
-        self.means_ = pca.mean_.tolist()
-        self.noise_variance_ = pca.noise_variance_
-        self.n_samples_seen_ = pca.n_samples_seen_
 
 
 @register

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -8,8 +8,10 @@ from vaex.utils import _ensure_strings_from_expressions
 import numpy as np
 import warnings
 
-sklearn = vaex.utils.optional_import("sklearn.decomposition")
-sklearn = vaex.utils.optional_import("sklearn.random_projection")
+sklearn = vaex.utils.optional_import("sklearn", modules=[
+    "sklearn.decomposition",
+    "sklearn.random_projection"
+])
 
 help_features = 'List of features to transform.'
 help_prefix = 'Prefix for the names of the transformed features.'

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -128,6 +128,117 @@ class PCA(Transformer):
             copy[name] = expr
         return copy
 
+def dot_product(a, b):
+    products = ['%s * %s' % (ai, bi) for ai, bi in zip(a, b)]
+    return ' + '.join(products)
+
+help_prefix = 'Prefix for the names of the transformed features.'
+
+
+@register
+@generate.register
+class RandomProjections(Transformer):
+    '''Reduce dimensionality through a random matrix projection.
+
+    The random projections method is based on the Johnson-Lindenstrauss lemma.
+    For mode details see https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma
+
+    Note that you need scikit-learn to fit this Transformer but not for transformations using an already fitter Transformer.
+
+    Example:
+
+    >>> import vaex
+    >>> import vaex.ml
+    >>> df = vaex.from_arrays(x=[2,5,7,2,15], y=[-2,3,0,0,10], z=[2, -10, 2, 3, 0])
+    >>> df
+    #    x    y    z
+    0    2   -2    2
+    1    5    3  -10
+    2    7    0    2
+    3    2    0    3
+    4   15   10    0
+    >>> rand_proj = vaex.ml.RandomProjections(features=['x', 'y', 'z'], n_components=2)
+    >>> rand_proj.fit_transform(df)
+    #    x    y    z    random_projection_0    random_projection_1
+    0    2   -2    2                1.73363             -0.0700273
+    1    5    3  -10              -17.8742             -14.0226
+    2    7    0    2               -3.32911             -8.50181
+    3    2    0    3                2.04843             -1.27538
+    4   15   10    0              -17.0289             -28.6562
+    '''
+    snake_name = 'random_projections'
+    n_components = traitlets.CInt(default_value=None, allow_none=True, help='Number of components to retain. If None (default) the number will be set via the Johnson-Lindenstrauss formula. See https://scikit-learn.org/stable/modules/generated/sklearn.random_projection.johnson_lindenstrauss_min_dim.html for more details.')
+    eps = traitlets.Float(default_value=0.1, allow_none=True, help='Parameter to control the quality of the embedding according to the Johnson-Lindenstrauss lemma when `n_components` is set to None. The value must be positive.')
+    matrix_type = traitlets.Enum(values=['gaussian', 'sparse'], default_value='gaussian', help='The type of random matrix to create. The values can be "gaussian" and "sparse".')
+    density = traitlets.Float(default_value=None, allow_none=True, help='Ratio in the range (0, 1] of non-zero component in the random projection matrix. Only valid if `matrix_type` is "sparse". If density is None, the value is set to the minimum density as recommended by Ping Li et al.: 1 / sqrt(n_features).')
+    prefix = traitlets.Unicode(default_value="random_projection_", help=help_prefix)
+    random_state = traitlets.Int(default_value=None, allow_none=True, help='Controls the pseudo random number generator used to generate the projection matrix at fit time. Used to get reproducible results.')
+    random_matrix_ = traitlets.List(traitlets.List(traitlets.CFloat()), help='The random matrix.').tag(output=True)
+
+    @traitlets.validate('eps')
+    def _valid_eps(self, proposal):
+        if (proposal['value'] > 0) & (proposal['value'] < 1):
+            return proposal['value']
+        else:
+            raise traitlets.TraitError('`eps` must be between 0 and 1.')
+
+    @traitlets.validate('density')
+    def _valid_density(self, proposal):
+        if (proposal['value'] > 0) & (proposal['value'] <= 1):
+            return proposal['value']
+        else:
+            raise traitlets.TraitError('`density` must be 0 < density <= 1.')
+
+    def fit(self, df):
+        '''Fit the RandomProjections to the DataFrame.
+
+        :param df: A vaex DataFrame.
+        '''
+
+        sklearn = vaex.utils.optional_import("sklearn.random_projection")
+
+        n_samples = len(df)
+        n_features = len(self.features)
+
+        if self.n_components is None:
+            self.n_components = sklearn.random_projection.johnson_lindenstrauss_min_dim(n_samples=n_samples,
+                                                                                        eps=self.eps)
+
+        if self.matrix_type == 'gaussian':
+            self.random_matrix_ = sklearn.random_projection._gaussian_random_matrix(n_components=self.n_components,
+                                                                                    n_features=n_features,
+                                                                                    random_state=self.random_state).tolist()
+
+        else:
+            density = self.density or 'auto'
+            self.random_matrix_ = sklearn.random_projection._sparse_random_matrix(n_components=self.n_components,
+                                                                                  n_features=n_features,
+                                                                                  density=density,
+                                                                                  random_state=self.random_state).toarray().tolist()
+
+
+    def transform(self, df):
+        '''Apply the RandomProjection transformation to the DataFrame.
+
+        :param df: A vaex DataFrame
+
+        :return copy: A shallow copy of the DataFrame that includes the RandomProjection components.
+        :rtype: DataFrame
+        '''
+        copy = df.copy()
+        random_matrix = np.array(self.random_matrix_)
+        name_prefix_offset = 0
+        while self.prefix + str(name_prefix_offset) in copy.get_column_names(virtual=True, strings=True):
+            name_prefix_offset += 1
+
+        for component in range(self.n_components):
+            vector = random_matrix[component]
+            expr = dot_product(self.features, vector)
+            name = self.prefix + str(component + name_prefix_offset)
+            copy[name] = expr
+
+        return copy
+
 
 @register
 @generate.register
@@ -270,7 +381,7 @@ class OneHotEncoder(Transformer):
     >>> import vaex
     >>> df = vaex.from_arrays(color=['red', 'green', 'green', 'blue', 'red'])
     >>> df
-     #  color
+     #  color®
      0  red
      1  green
      2  green

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -76,8 +76,9 @@ def test_random_projections(n_components, matrix_type):
     df = vaex.from_dict(data=data_maker(n_rows=100_000, n_cols=31))
     features = df.get_column_names()
 
-    rand_proj = vaex.ml.RandomProjections(features=features, n_components=n_components, matrix_type=matrix_type)
+    rand_proj = df.ml.random_projections(features=features, n_components=n_components, matrix_type=matrix_type, transform=False)
     df_trans = rand_proj.fit_transform(df)
+
     assert np.array(rand_proj.random_matrix_).shape == (n_components, 31)
     assert len(df_trans.get_column_names(regex='^rand')) == n_components
 

--- a/tests/ml/ml_test.py
+++ b/tests/ml/ml_test.py
@@ -5,7 +5,14 @@ import vaex.ml
 import vaex.ml.datasets
 pytest.importorskip("sklearn")
 from sklearn.decomposition import PCA, IncrementalPCA
+from sklearn.random_projection import GaussianRandomProjection, SparseRandomProjection
 from sklearn.preprocessing import StandardScaler, MinMaxScaler, MaxAbsScaler, RobustScaler
+
+
+def data_maker(n_rows, n_cols):
+    return {f'feat_{i}': np.random.normal(loc=np.random.uniform(-100, 100),
+                                          scale=np.random.uniform(0.5, 25),
+                                          size=n_rows) for i in range(n_cols)}
 
 
 def test_pca(df_iris):
@@ -61,6 +68,39 @@ def test_valid_sklearn_pca_incremental(df_iris):
     # Compare the results
     np.testing.assert_almost_equal(df_transformed.evaluate('PCA_0'), sk_result[:, 0])
     np.testing.assert_almost_equal(df_transformed.evaluate('PCA_1'), sk_result[:, 1])
+
+
+@pytest.mark.parametrize("n_components", [5, 15, 150])
+@pytest.mark.parametrize("matrix_type", ['gaussian', 'sparse'])
+def test_random_projections(n_components, matrix_type):
+    df = vaex.from_dict(data=data_maker(n_rows=100_000, n_cols=31))
+    features = df.get_column_names()
+
+    rand_proj = vaex.ml.RandomProjections(features=features, n_components=n_components, matrix_type=matrix_type)
+    df_trans = rand_proj.fit_transform(df)
+    assert np.array(rand_proj.random_matrix_).shape == (n_components, 31)
+    assert len(df_trans.get_column_names(regex='^rand')) == n_components
+
+
+@pytest.mark.parametrize("matrix_type", ['gaussian', 'sparse'])
+def test_valid_sklearn_random_projections(df_iris, matrix_type):
+    df = df_iris
+    features = df.get_column_names()[:4]
+    random_state=42
+
+    rand_proj = vaex.ml.RandomProjections(features=features, n_components=3, matrix_type=matrix_type, random_state=random_state)
+    df_trans = rand_proj.fit_transform(df)
+    result = df_trans[df_trans.get_column_names(regex='^rand*')].values
+
+    if matrix_type == 'gaussian':
+        sk_gaus = GaussianRandomProjection(n_components=3, random_state=random_state)
+        sk_trans = sk_gaus.fit_transform(df[features].values)
+
+    else:
+        sk_sparse = SparseRandomProjection(n_components=3, random_state=random_state, dense_output=True)
+        sk_trans = sk_sparse.fit_transform(df[features].values)
+
+    np.testing.assert_almost_equal(result, sk_trans)
 
 
 def test_standard_scaler(df_iris):


### PR DESCRIPTION
This PR implements the `RandomProjections` method for dimensional reduction. 

It uses the methods in scikit-learn for creating the random matrices, so scikit-learn is needed as a dependency of using this transformer.  Scikit-learn is however not needed to apply the transformations of an already fitted transformer. 

- [x] `RandomProjections` implementation
- [x] Unit tests
- [ ] Code review 