### PR TITLE
🐎 avoid nested renaming for dataset, and collapse in single operation

### DIFF
--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -450,6 +450,25 @@ class DatasetRenamed(Dataset):
         self._ids = frozendict({renaming.get(name, name): ar for name, ar in original._ids.items()})
         self._set_row_count()
 
+    def renamed(self, renaming):
+        # # {'a': 'x', 'b': 'y'} and {'x': 'a', 'b': 'z', 'c', 'q'} -> {'b': 'z', 'c': 'q'}
+        resulting = {}
+        renaming = renaming.copy()  # we'll modify in place
+        for old, new in self.renaming.items():
+            if new in renaming:
+                if old == renaming[new]:
+                    pass # e.g.  x->a->x
+                else:
+                    resulting[old] = renaming[new]
+                del renaming[new]  # we already covered this
+            else:
+                # e.g. x->a->a
+                resulting[old] = new
+        # e.g. x->x->a
+        resulting.update(renaming)
+        return DatasetRenamed(self.original, resulting)
+
+
     def _create_columns(self):
         self._columns = frozendict({self.renaming.get(name, name): ar for name, ar in self.original.items()})
 

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -78,12 +78,21 @@ def test_array_rename():
     assert rebuild(ds1) != rebuild(ds2)
 
     ds3 = ds2.renamed({'z': 'x'})
+    assert ds3.original is ds1, "no nested renaming"
     assert ds3['y'] is y
     assert ds3['x'] is x
 
     # different data, but same ids/hashes
     assert ds1 == ds3
     assert rebuild(ds1) == rebuild(ds3)
+
+    # testing that
+    # {'a': 'x', 'b': 'y'} and {'x': 'a', 'b': 'z', 'c', 'q'} -> {'b': 'z', 'c': 'q'}
+    ds1 = dataset.DatasetArrays(a=x, b=y, c=x+y)
+    ds2 = ds1.renamed({'a': 'x', 'b': 'y'})
+    ds3 = ds2.renamed({'x': 'a', 'b': 'z', 'c': 'q'})
+    assert ds3.original is ds1
+    assert ds3.renaming == {'b': 'z', 'c': 'q'}
 
 
 def test_merge():

--- a/tests/rename_test.py
+++ b/tests/rename_test.py
@@ -11,6 +11,7 @@ def test_rename(ds_filtered):
     assert ds.r.values.tolist() == xvalues
     assert ds.q.values.tolist() == qvalues
 
+
 def test_rename_existing_expression(df_local):
     df = df_local
     x_old = df['x']
@@ -18,7 +19,6 @@ def test_rename_existing_expression(df_local):
     # the x_old expression needs to be rewritten as well
     df['x'] = df.x * 2
     assert x_old.tolist() == xvalues
-
 
 
 def test_reassign_virtual(ds_local):


### PR DESCRIPTION
Originally from #1287