### PR TITLE
🐛Fix isin() dtype downcasting and use_hashmap=False

### DIFF
--- a/packages/vaex-core/src/strings.cpp
+++ b/packages/vaex-core/src/strings.cpp
@@ -377,10 +377,10 @@ class StringSequenceBase : public StringSequence {
             if(has_null() || others->has_null()) {
                 for(size_t i = 0; i < length; i++) {
                     bool found = false;
-                    if(is_null(i)) {
+                    if(!is_null(i)) {
                         auto str = view(i);
                         for(size_t j = 0; j < others->length; j++) {
-                            if(others->is_null(j)) {
+                            if(!others->is_null(j)) {
                                 auto other = others->view(j);
                                 found = str == other;
                                 if(found)

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -864,6 +864,7 @@ def f({0}):
         """
         if use_hashmap:
             # easiest way to create a set is using the vaex dataframe
+            values = np.array(values, dtype=self.dtype.numpy)  # ensure that values are the same dtype as the expression (otherwise the set downcasts at the C++ level during execution)
             df_values = vaex.from_arrays(x=values)
             ordered_set = df_values._set(df_values.x)
             var = self.df.add_variable('var_isin_ordered_set', ordered_set, unique=True)

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -872,7 +872,7 @@ def f({0}):
             if self.is_string():
                 values = vaex.column._to_string_sequence(values)
             else:
-                values = np.array(values, dtype=self.dtype)
+                values = np.array(values, dtype=self.dtype.numpy)
             var = self.df.add_variable('isin_values', values, unique=True)
             return self.df['isin(%s, %s)' % (self, var)]
 

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2485,10 +2485,17 @@ def _isin(x, values):
         # but numpy doesn't know what to do with that
         if hasattr(values, 'to_numpy'):
             values = values.to_numpy()
-        if np.ma.isMaskedArray(x):
-            return np.ma.isin(x, values)
+        mask = isnan(values)
+        if np.any(mask):
+            if np.ma.isMaskedArray(x):
+                return np.ma.isin(x, values) | isnan(x)
+            else:
+                return np.isin(x, values) | isnan(x)
         else:
-            return np.isin(x, values)
+            if np.ma.isMaskedArray(x):
+                return np.ma.isin(x, values)
+            else:
+                return np.isin(x, values)
 
 
 @register_function(name='isin_set', on_expression=False)

--- a/tests/isin_test.py
+++ b/tests/isin_test.py
@@ -32,3 +32,22 @@ def test_isin_object():
 
     assert expr_x.tolist() == [True, False, False]
     assert expr_y.tolist() == [False, True, False]
+
+
+def test_isin_diff_dtypes():
+    x = np.array([1.01, 2.02, 3.03])
+    s = np.array(['dog', 'cat', 'mouse'])
+    sm = np.array(['dog', 'cat', None])
+    df = vaex.from_arrays(x=x, s=s, sm=sm)
+
+    # Test cases for use_hashmap=True (default behavior)
+    assert df.x.isin([1], use_hashmap=True).tolist() == [False, False, False]
+    assert df.x.isin([1.01], use_hashmap=True).tolist() == [True, False, False]
+    assert df.s.isin(['elephant', 'dog'], use_hashmap=True).tolist() == [True, False, False]
+    assert df.sm.isin(['cat', 'dog'], use_hashmap=True).tolist() == [True, True, False]
+
+    # Test cases for use_hashmap=False
+    assert df.x.isin([1], use_hashmap=False).tolist() == [False, False, False]
+    assert df.x.isin([1.01], use_hashmap=False).tolist() == [True, False, False]
+    assert df.s.isin(['elephant', 'dog'], use_hashmap=False).tolist() == [True, False, False]
+    assert df.sm.isin(['cat', 'dog'], use_hashmap=False).tolist() == [True, True, False]

--- a/tests/isin_test.py
+++ b/tests/isin_test.py
@@ -12,6 +12,7 @@ def test_isin():
     n = np.array([-5, np.nan, 1])
     df = vaex.from_arrays(x=x, y=y, s=s, sm=sm, w=w, m=m, n=n)
 
+    # use_hashmap = True (default behavior)
     assert df.x.isin([1, 2.02, 5, 6]).tolist() == [False, True, False]
     assert df.y.isin([5, -1, 0]).tolist() == [False, False, True]
     assert df.s.isin(['elephant', 'dog']).tolist() == [True, False, False]
@@ -19,8 +20,15 @@ def test_isin():
     assert df.w.isin([2, None]).tolist() == [True, False, True]
     assert df.m.isin([1, 2, 3]).tolist() == [False, False, True]
     assert df.n.isin([2, np.nan]).tolist() == [False, True, False]
-    # TODO: this fails, we should have a separate issue for it
-    assert df.n.isin([2, np.nan]).tolist() == [False, True, False]
+
+    # use_hashmap = False
+    assert df.x.isin([1, 2.02, 5, 6], use_hashmap=False).tolist() == [False, True, False]
+    assert df.y.isin([5, -1, 0], use_hashmap=False).tolist() == [False, False, True]
+    assert df.s.isin(['elephant', 'dog'], use_hashmap=False).tolist() == [True, False, False]
+    assert df.sm.isin(['cat', 'dog'], use_hashmap=False).tolist() == [True, True, False]
+    assert df.w.isin([2, None], use_hashmap=False).tolist() == [True, False, True]
+    assert df.m.isin([1, 2, 3], use_hashmap=False).tolist() == [False, False, True]
+    assert df.n.isin([2, np.nan], use_hashmap=False).tolist() == [False, True, False]
 
 
 def test_isin_object():
@@ -43,11 +51,7 @@ def test_isin_diff_dtypes():
     # Test cases for use_hashmap=True (default behavior)
     assert df.x.isin([1], use_hashmap=True).tolist() == [False, False, False]
     assert df.x.isin([1.01], use_hashmap=True).tolist() == [True, False, False]
-    assert df.s.isin(['elephant', 'dog'], use_hashmap=True).tolist() == [True, False, False]
-    assert df.sm.isin(['cat', 'dog'], use_hashmap=True).tolist() == [True, True, False]
 
     # Test cases for use_hashmap=False
     assert df.x.isin([1], use_hashmap=False).tolist() == [False, False, False]
     assert df.x.isin([1.01], use_hashmap=False).tolist() == [True, False, False]
-    assert df.s.isin(['elephant', 'dog'], use_hashmap=False).tolist() == [True, False, False]
-    assert df.sm.isin(['cat', 'dog'], use_hashmap=False).tolist() == [True, True, False]

--- a/tests/isin_test.py
+++ b/tests/isin_test.py
@@ -1,8 +1,11 @@
+import pytest
+
 import numpy as np
 import vaex
 
 
-def test_isin():
+@pytest.mark.parametrize("use_hashmap", [False, True])
+def test_isin(use_hashmap):
     x = np.array([1.01, 2.02, 3.03])
     y = np.array([1, 3, 5])
     s = np.array(['dog', 'cat', 'mouse'])
@@ -12,23 +15,13 @@ def test_isin():
     n = np.array([-5, np.nan, 1])
     df = vaex.from_arrays(x=x, y=y, s=s, sm=sm, w=w, m=m, n=n)
 
-    # use_hashmap = True (default behavior)
-    assert df.x.isin([1, 2.02, 5, 6]).tolist() == [False, True, False]
-    assert df.y.isin([5, -1, 0]).tolist() == [False, False, True]
-    assert df.s.isin(['elephant', 'dog']).tolist() == [True, False, False]
-    assert df.sm.isin(['cat', 'dog']).tolist() == [True, True, False]
-    assert df.w.isin([2, None]).tolist() == [True, False, True]
-    assert df.m.isin([1, 2, 3]).tolist() == [False, False, True]
-    assert df.n.isin([2, np.nan]).tolist() == [False, True, False]
-
-    # use_hashmap = False
-    assert df.x.isin([1, 2.02, 5, 6], use_hashmap=False).tolist() == [False, True, False]
-    assert df.y.isin([5, -1, 0], use_hashmap=False).tolist() == [False, False, True]
-    assert df.s.isin(['elephant', 'dog'], use_hashmap=False).tolist() == [True, False, False]
-    assert df.sm.isin(['cat', 'dog'], use_hashmap=False).tolist() == [True, True, False]
-    assert df.w.isin([2, None], use_hashmap=False).tolist() == [True, False, True]
-    assert df.m.isin([1, 2, 3], use_hashmap=False).tolist() == [False, False, True]
-    assert df.n.isin([2, np.nan], use_hashmap=False).tolist() == [False, True, False]
+    assert df.x.isin([1, 2.02, 5, 6], use_hashmap=use_hashmap).tolist() == [False, True, False]
+    assert df.y.isin([5, -1, 0], use_hashmap=use_hashmap).tolist() == [False, False, True]
+    assert df.s.isin(['elephant', 'dog'], use_hashmap=use_hashmap).tolist() == [True, False, False]
+    assert df.sm.isin(['cat', 'dog'], use_hashmap=use_hashmap).tolist() == [True, True, False]
+    assert df.w.isin([2, None], use_hashmap=use_hashmap).tolist() == [True, False, True]
+    assert df.m.isin([1, 2, 3], use_hashmap=use_hashmap).tolist() == [False, False, True]
+    assert df.n.isin([2, np.nan], use_hashmap=use_hashmap).tolist() == [False, True, False]
 
 
 def test_isin_object():
@@ -42,16 +35,12 @@ def test_isin_object():
     assert expr_y.tolist() == [False, True, False]
 
 
-def test_isin_diff_dtypes():
+@pytest.mark.parametrize("use_hashmap", [False, True])
+def test_isin_diff_dtypes(use_hashmap):
     x = np.array([1.01, 2.02, 3.03])
     s = np.array(['dog', 'cat', 'mouse'])
     sm = np.array(['dog', 'cat', None])
     df = vaex.from_arrays(x=x, s=s, sm=sm)
 
-    # Test cases for use_hashmap=True (default behavior)
-    assert df.x.isin([1], use_hashmap=True).tolist() == [False, False, False]
-    assert df.x.isin([1.01], use_hashmap=True).tolist() == [True, False, False]
-
-    # Test cases for use_hashmap=False
-    assert df.x.isin([1], use_hashmap=False).tolist() == [False, False, False]
-    assert df.x.isin([1.01], use_hashmap=False).tolist() == [True, False, False]
+    assert df.x.isin([1], use_hashmap=use_hashmap).tolist() == [False, False, False]
+    assert df.x.isin([1.01], use_hashmap=use_hashmap).tolist() == [True, False, False]


### PR DESCRIPTION
- Fixes #1320 at the Python level; technically, the bug is caused at the C++ level when the `set.isin()` function implicitly downcasts its own values to the same type as the value its comparing against; ex: input column is a float and `isin([1])` is called (1 is an int) --> all floats are downcasted/rounded down to the nearest int and can return incorrect results
- One test case/assert isolates a potential C++ bug but I was not able to fix it at this time; more details are below

Currently, one assert case fails for a masked string column when `use_hashmap = False`. Specifically, I believe there is a bug at the C++ level when a masked string column's `<string_column>.string_sequence.isin()` function is called. There are no issues when `use_hashmap = True` as evident by an earlier assert in the test case. Hoping a vaex maintainer can take a closer look at it or guide me in the right direction.