### PR TITLE
🔨 categorical data should hide that it is dict/ordinal encode

### DIFF
--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -89,7 +89,7 @@ class AggregatorDescriptorBasic(AggregatorDescriptor):
             self.dtype_in = DataType(np.dtype('int64'))
             self.dtype_out = DataType(np.dtype('int64'))
         else:
-            self.dtype_in = df[str(self.expressions[0])].data_type()
+            self.dtype_in = df[str(self.expressions[0])].data_type().index_type
             self.dtype_out = self.dtype_in
             if self.short_name == "count":
                 self.dtype_out = DataType(np.dtype('int64'))

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -238,6 +238,7 @@ class ExecutorLocal(Executor):
                     raise TypeError(f'Evaluated a chunk ({name}) that is not an array of column like object: {chunk!r} (type={type(chunk)}')
             for name, chunk in chunks.items():
                 sanity_check(name, chunk)
+            chunks = {name: df._auto_encode_data(name, ar) for name, ar in chunks.items()}
             chunks = {name: vaex.arrow.numpy_dispatch.wrap(ar) for name, ar in chunks.items()}
             block_scope.values.update(chunks)
             block_scope.mask = filter_mask

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -95,6 +95,12 @@ class Meta(type):
                 def f(a, b):
                     self = a
                     # print(op, a, b)
+                    if self.df.is_category(self.expression) and self.df._encode_categoricals and not isinstance(b, Expression):
+                        labels = self.df.category_labels(self.expression)
+                        if b not in labels:
+                            raise ValueError(f'Value {b} not present in {labels}')
+                        b = labels.index(b)
+                        a = self.index_values()
                     try:
                         stringy = isinstance(b, str) or b.is_string()
                     except:

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2676,3 +2676,14 @@ def where(condition, x, y, dtype=None):
     ar = np.where(condition, x, y)
 
     return ar
+
+
+@register_function()
+def index_values(ar):
+    dtype = vaex.dtype_of(ar)
+    if not dtype.is_encoded:
+        raise TypeError(f'Can only get index values from a (dictionary) encoded array, not for {ar}')
+    if isinstance(ar, pa.ChunkedArray):
+        return pa.chunked_array([k.indices for k in ar.chunks], type=ar.type.index_type)
+    else:
+        return ar.indices

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -178,12 +178,13 @@ class GrouperCategory(BinnerBase):
     def __init__(self, expression, df=None, sort=False):
         self.df = df or expression.ds
         self.sort = sort
-        self.expression = expression
         # make sure it's an expression
-        self.expression = self.df[str(self.expression)]
-        self.label = self.expression._label
+        expression = self.df[str(expression)]
+        self.expression_original = expression
+        self.label = expression._label
+        self.expression = expression.index_values() if expression.dtype.is_encoded else expression
 
-        self.bin_values = self.df.category_labels(self.expression)
+        self.bin_values = self.df.category_labels(self.expression_original)
         if self.sort:
             # None will always be the first value
             if self.bin_values[0] is None:
@@ -195,8 +196,8 @@ class GrouperCategory(BinnerBase):
         else:
             self.sort_indices = None
 
-        self.N = self.df.category_count(self.expression)
-        self.min_value = self.df.category_offset(self.expression)
+        self.N = self.df.category_count(self.expression_original)
+        self.min_value = self.df.category_offset(self.expression_original)
         # TODO: what do we do with null values for categories?
         # if self.set.has_null:
         #     self.N += 1

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -345,7 +345,7 @@ class TaskAggregations(Task):
         # it is up the the executor to remove duplicate expressions
         self.expressions_all.extend(aggregator_descriptor.expressions)
         # TODO: optimize/remove?
-        self.dtypes = {expr: self.df.data_type(expr) for expr in self.expressions_all}
+        self.dtypes = {expr: self.df.data_type(expr).index_type for expr in self.expressions_all}
         return task
 
     def check(self):

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -472,7 +472,7 @@ def test_format_xarray_and_list(df_local):
     assert isinstance(count, list)
 
     df = df[:3]
-    df['g'] = df.x
+    df['g'] = df.x.astype('int32')
     df.categorize(df.g, labels=['aap', 'noot', 'mies'], inplace=True)
     count = df.count(binby='g', array_type='xarray')
     assert count.coords['g'].data.tolist() == ['aap', 'noot', 'mies']

--- a/tests/category_test.py
+++ b/tests/category_test.py
@@ -1,13 +1,22 @@
 from common import *
 import collections
 import numpy as np
+import pyarrow as pa
 import vaex
 import pytest
 
-def test_cat_string():
+
+@pytest.mark.parametrize("auto_encode", [False, True])
+def test_cat_string(auto_encode):
     ds0 = vaex.from_arrays(colors=['red', 'green', 'blue', 'green'])
     ds = ds0.ordinal_encode('colors')#, ['red', 'green'], inplace=True)
+    assert ds.colors.dtype.internal.name == 'int8'
+    ds = ds._auto_encode() if auto_encode else ds
     assert ds.is_category('colors')
+    if auto_encode:
+        assert ds.data_type('colors') == str
+    else:
+        assert ds.data_type('colors') == int
     assert ds.limits('colors', shape=128) == ([-0.5, 2.5], 3)
 
     ds = ds0.ordinal_encode('colors', values=['red', 'green'])
@@ -39,6 +48,7 @@ def test_categorize():
     assert ds0.category_labels(ds0.c) == ['a', 'b', 'c', 'd']
     assert ds0.category_count(ds0.c) == 4
 
+
 def test_cat_missing_values():
     colors = ['red', 'green', 'blue', 'green', 'MISSING']
     mask   = [False, False,   False,   False,  True]
@@ -63,3 +73,44 @@ def test_categorize_integers():
     df.categorize('x', inplace=True)  # same, but calculated from data
     assert df.count(binby='x').tolist() == [1] * 10
     assert df.binby('x', 'count').data.tolist() == [1] * 10
+
+
+@pytest.mark.parametrize("auto_encode", [False, True])
+def test_cat_compare(df_factory, auto_encode):
+    df = df_factory(x=np.array([0, 1, 2, 0], dtype='uint8'))
+    df = df.categorize('x', labels=['a', 'b', 'c'])
+    df = df._auto_encode() if auto_encode else df
+    if auto_encode:
+        assert df['x'].tolist() == ['a', 'b', 'c', 'a']
+        assert str(df.x == 'a') == '(index_values(x) == 0)'
+        assert df[df.x == 'a'].x.tolist() == ['a', 'a']
+        with pytest.raises(ValueError):
+            assert str(df.x == 'x') == '(x == 0)'
+    else:
+        # assert df['x'].tolist() == [0, 1, 2, 0]
+        # # assert str(df.x == 'a') == '(x == 0)'
+        assert df['x'].tolist() == [0, 1, 2, 0]
+        assert str(df.x == 0) == '(x == 0)'
+        assert df[df.x == 0].x.tolist() == [0, 0]
+
+
+def test_arrow_dict_encoded(df_factory_arrow):
+    indices = pa.array([0, 1, 0, 1, 2, 0, None, 2])
+    dictionary = pa.array(['aap', 'noot', 'mies'])
+    c = pa.DictionaryArray.from_arrays(indices, dictionary)
+    df = df_factory_arrow(c=c)
+    assert df.category_labels('c') == ['aap', 'noot', 'mies']
+    assert df.category_count('c') == 3
+    assert df.category_offset('c') == 0
+
+
+def test_index_values(df_factory_arrow):
+    indices = pa.array([0, 0, 1, 2])
+    dictionary = pa.array(['aap', 'noot', 'mies'])
+    c = pa.DictionaryArray.from_arrays(indices, dictionary)
+    c = pa.chunked_array([c[i:i+1] for i in range(len(c))])
+    df = df_factory_arrow(c=c)
+    df = df._auto_encode()
+    # assert df.c.index_values().tolist() == [0, 0, 1, 2]
+    with small_buffer(df, 2):
+        assert df[df.c == 'aap'].c.index_values().tolist() == [0, 0]

--- a/tests/common.py
+++ b/tests/common.py
@@ -195,7 +195,7 @@ def df_executor(request, df_trimmed, df_remote):
 
 if os.environ.get('VAEX_TEST_SKIP_REMOTE'):
     @pytest.fixture(params=['ds_filtered', 'ds_half', 'ds_trimmed', 'df_concat', 'df_arrow', 'df_parquet'])
-    def ds(request, ds_filtered, ds_half, ds_trimmed, ds_remote, df_concat, df_arrow, df_parquet):
+    def ds(request, ds_filtered, ds_half, ds_trimmed, df_concat, df_arrow, df_parquet):
         named = dict(ds_filtered=ds_filtered, ds_half=ds_half, ds_trimmed=ds_trimmed, df_concat=df_concat, df_arrow=df_arrow, df_parquet=df_parquet)
         return named[request.param]
 else:

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -123,11 +123,13 @@ def test_groupby_sort_string(df_factory, as_category):
     assert dfg['count'].tolist() == [4, 3, 1, 2]
 
 
-def test_groupby_1d_cat(ds_local):
+@pytest.mark.parametrize("auto_encode", [False, True])
+def test_groupby_1d_cat(ds_local, auto_encode):
     ds = ds_local.extract()
     g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2])
     ds.add_column('g', g)
     ds.categorize('g', labels=['cat', 'dog', 'snake'], inplace=True)
+    ds = ds._auto_encode() if auto_encode else ds
     dfg = ds.groupby(by=ds.g, agg='count')
 
     assert dfg.g.tolist() == ['cat', 'dog', 'snake']

--- a/tests/unique_test.py
+++ b/tests/unique_test.py
@@ -1,5 +1,6 @@
 from common import small_buffer
 
+import pytest
 import numpy as np
 import pyarrow as pa
 
@@ -77,3 +78,18 @@ def test_unique_list(df_types):
     df = df_types
     assert set(df.string_list.unique()) == {'aap', 'noot', 'mies', None}
     assert set(df.int_list.unique()) == {1, 2, 3, 4, 5, None}
+
+
+@pytest.mark.parametrize("auto_encode", [False, True])
+def test_unique_categorical(df_factory, auto_encode):
+    df = df_factory(x=vaex.string_column(['a', 'c', 'b', 'a', 'a']))
+    df = df.ordinal_encode('x')
+    df = df._auto_encode() if auto_encode else df
+    if auto_encode:
+        assert df.x.dtype == str
+        assert set(df.x.unique()) == {'a', 'b', 'c'}
+        assert df.x.nunique() == 3
+    else:
+        assert df.x.dtype == int
+        assert set(df.x.unique()) == {0, 1, 2}
+        assert df.x.nunique() == 3


### PR DESCRIPTION
It should just work as if a dataframe after df.ordinal_encode is the
same (so unique gives the same results etc). The only thing that should
be different is the performance.