### PR TITLE
🐛 column names equal to function names

### DIFF
--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -233,6 +233,11 @@ class ExecutorLocal(Executor):
                 chunks = {k:vaex.array_types.filter(v, filter_mask) for k, v, in chunks.items()}
             else:
                 filter_mask = None
+            def sanity_check(name, chunk):
+                if not vaex.column.is_column_like(chunk):
+                    raise TypeError(f'Evaluated a chunk ({name}) that is not an array of column like object: {chunk!r} (type={type(chunk)}')
+            for name, chunk in chunks.items():
+                sanity_check(name, chunk)
             chunks = {name: vaex.arrow.numpy_dispatch.wrap(ar) for name, ar in chunks.items()}
             block_scope.values.update(chunks)
             block_scope.mask = filter_mask

--- a/packages/vaex-core/vaex/scopes.py
+++ b/packages/vaex-core/vaex/scopes.py
@@ -120,8 +120,6 @@ class _BlockScope(ScopeBase):
         # return self.df.columns[variable][self.i1:self.i2]
         if variable == 'df':
             return self  # to support df['no!identifier']
-        if variable in expression_namespace:
-            return expression_namespace[variable]
         try:
             if variable in self.values:
                 return self.values[variable]
@@ -155,6 +153,8 @@ class _BlockScope(ScopeBase):
             elif variable in self.df.functions:
                 f = self.df.functions[variable].f
                 return vaex.arrow.numpy_dispatch.autowrapper(f)
+            elif variable in expression_namespace:
+                return expression_namespace[variable]
             if variable not in self.values:
                 raise KeyError("Unknown variables or column: %r" % (variable,))
 

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -20,6 +20,12 @@ def test_column_names(df_arrow):
     assert '__x' in ds.get_column_names(regex='__x', hidden=True)
 
 
+def test_column_name_and_function_name(tmpdir):
+    df = vaex.from_scalars(foo=1, x=1)
+    df.add_function('foo', lambda x: x+1)
+    assert df.foo.tolist() == [1]
+
+
 def test_add_invalid_name(tmpdir):
     # support invalid names and keywords
     df = vaex.from_dict({'X!1': x, 'class': x*2})


### PR DESCRIPTION
cc @antoinerg who got bitten by a column called 'float', this now works:
```python
import vaex
import os
with open("data.csv", "w") as fd:
    fd.write("id,float\n0,7.5\n1,8.5\n")
df = vaex.from_csv('data.csv')
print(df["float"].nunique())
df
```