### PR TITLE
🐎 perform groupby in a sparse way for less memory usage/performance (~250 times faster)

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -319,6 +319,7 @@ class DataFrame(object):
 
     def map_reduce(self, map, reduce, arguments, progress=False, delay=False, info=False, to_numpy=True, ignore_filter=False, pre_filter=False, name='map reduce (custom)', selection=None):
         # def map_wrapper(*blocks):
+        pre_filter = pre_filter and self.filtered
         task = tasks.TaskMapReduce(self, arguments, map, reduce, info=info, to_numpy=to_numpy, ignore_filter=ignore_filter, selection=selection, pre_filter=pre_filter)
         progressbar = vaex.utils.progressbars(progress)
         progressbar.add_task(task, name)
@@ -408,7 +409,7 @@ class DataFrame(object):
                 sets[thread_index].update(ar)
         def reduce(a, b):
             pass
-        self.map_reduce(map, reduce, columns, delay=delay, name='set', info=True, to_numpy=False, selection=selection)
+        self.map_reduce(map, reduce, columns, delay=delay, name='set', info=True, to_numpy=False, selection=selection, pre_filter=True)
         sets = [k for k in sets if k is not None]
         set0 = sets[0]
         for other in sets[1:]:

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -6326,7 +6326,7 @@ class DataFrameLocal(DataFrame):
     #     self._has_selection = mask is not None
     #     # self.signal_selection_changed.emit(self)
 
-    def groupby(self, by=None, agg=None, sort=False):
+    def groupby(self, by=None, agg=None, sort=False, assume_sparse=True):
         """Return a :class:`GroupBy` or :class:`DataFrame` object when agg is not None
 
         Examples:
@@ -6375,10 +6375,11 @@ class DataFrameLocal(DataFrame):
         :param dict, list or agg agg: Aggregate operation in the form of a string, vaex.agg object, a dictionary
             where the keys indicate the target column names, and the values the operations, or the a list of aggregates.
             When not given, it will return the groupby object.
+        :param bool assume_sparse: Assume that when grouping by multiple keys, that the existing pairs are sparse compared to the cartesian product.
         :return: :class:`DataFrame` or :class:`GroupBy` object.
         """
         from .groupby import GroupBy
-        groupby = GroupBy(self, by=by, sort=sort)
+        groupby = GroupBy(self, by=by, sort=sort, combine=assume_sparse)
         if agg is None:
             return groupby
         else:

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -33,7 +33,7 @@ class Run:
         self.df = self.tasks[0].df
         self.pre_filter = tasks[0].pre_filter
         if any(self.pre_filter != task.pre_filter for task in tasks[1:]):
-            raise ValueError("All tasks need to be pre_filter'ed or not pre_filter'ed, it cannot be mixed")
+            raise ValueError(f"All tasks need to be pre_filter'ed or not pre_filter'ed, it cannot be mixed: {tasks}")
         if self.pre_filter and not self.df.filtered:
             raise ValueError("Requested pre_filter for task while DataFrame is not filtered")
         self.expressions = list(set(expression for task in tasks for expression in task.expressions_all))

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -948,7 +948,7 @@ def required_dtype_for_max(N, signed=True):
         dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
     for dtype in dtypes:
         if N <= np.iinfo(dtype).max:
-            return dtype
+            return np.dtype(dtype)
     else:
         raise ValueError(f'Cannot store a max value on {N} inside an uint64/int64')
 

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -196,6 +196,20 @@ def test_groupby_2d(ds_local):
     assert dfg['count'].tolist() == [3, 1, 4, 2]
 
 
+
+@pytest.mark.parametrize("assume_sparse", [True, False])
+def test_groupby_2d_cat(df_factory, assume_sparse):
+    g = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2]
+    h = [5, 5, 5, 6, 5, 5, 5, 5, 6, 6]
+    df = df_factory(g=g, h=h)
+    df.categorize('g', inplace=True)
+    df.categorize('h', inplace=True)
+    dfg = df.groupby(by=[df.g, df.h], agg={'count': vaex.agg.count()}).sort('g')
+    assert dfg.g.tolist() == [0, 0, 1, 2]
+    assert dfg['count'].tolist() == [3, 1, 4, 2]
+
+
+
 def test_groupby_datetime():
     t = np.arange('2015-01-01', '2015-02-01', dtype=np.datetime64)
     y = np.arange(len(t))
@@ -314,7 +328,8 @@ def test_groupby_same_result():
         assert vc.index.tolist() == group_sort['h'].values.tolist(), 'the indices of the counts are not correct.'
 
 
-def test_groupby_iter():
+@pytest.mark.parametrize("assume_sparse", [True, False])
+def test_groupby_iter(assume_sparse):
     # ds = ds_local.extract()
     g = np.array([0, 0, 0, 0, 1, 1, 1, 1, 0, 1], dtype='int32')
     s = np.array(list(map(str, [0, 0, 0, 0, 1, 1, 1, 1, 2, 2])))
@@ -327,7 +342,7 @@ def test_groupby_iter():
     assert dfs[1][0] == (1, )
     assert dfs[1][1].g.tolist() == [1] * 5
 
-    groupby = df.groupby(['g', 's'])
+    groupby = df.groupby(['g', 's'], sort=True, assume_sparse=assume_sparse)
     assert set(groupby.groups) == {(0, '0'), (1, '1'), (0, '2'), (1, '2')}
     dfs = list(groupby)
     assert dfs[0][0] == (0, '0')

--- a/tests/internal/groupby_test.py
+++ b/tests/internal/groupby_test.py
@@ -1,0 +1,29 @@
+import pyarrow as pa
+import vaex.groupby
+
+
+
+def test_combined_grouper():
+    x = pa.array([1, 1, 2, 2])
+    y = pa.array([1, 1, 3, 4])
+    df = vaex.from_arrays(x=x, y=y)
+    grouper_x = vaex.groupby.Grouper(df.x)
+    grouper_y = vaex.groupby.Grouper(df.y)
+    groupers = [grouper_x, grouper_y]
+    assert set(df[grouper_x.binby_expression].tolist()) == {0, 1}
+    assert set(df[grouper_y.binby_expression].tolist()) == {0, 1, 2}
+    grouper = vaex.groupby._combine(df, groupers, sort=True)
+    assert set(df[grouper.binby_expression].tolist()) == {0, 1, 2}
+
+
+def test_combined_grouper_cast():
+    x = pa.array(range(127))
+    y = pa.array(range(1, 128))
+    df = vaex.from_arrays(x=x, y=y)
+    grouper_x = vaex.groupby.Grouper(df.x)
+    grouper_y = vaex.groupby.Grouper(df.y)
+    groupers = [grouper_x, grouper_y]
+    assert df[grouper_x.binby_expression].dtype.numpy.name == 'int8'
+    assert df[grouper_y.binby_expression].dtype.numpy.name == 'int8'
+    grouper = vaex.groupby._combine(df, groupers, sort=True)
+    assert set(df[grouper.binby_expression].tolist()) == set(range(127))


### PR DESCRIPTION
```python
import numpy as np
import vaex
n = 10_000
x = np.random.rand(n)
y = np.random.rand(n)
z = np.random.rand(n)
df = vaex.from_arrays(x=x, y=y, z=z)
```

before:
```python
%%time
dfg = df.groupby(['x', 'y'], agg=vaex.agg.sum('z'))
#CPU times: user 4.16 s, sys: 5.94 s, total: 10.1 s
#Wall time: 10.1 s
```

after:
```python
%%time
dfg = df.groupby(['x', 'y'], agg=vaex.agg.sum('z'))
# CPU times: user 44.7 ms, sys: 2.52 ms, total: 47.2 ms
# Wall time: 38.7 ms
```

which is about ~250 times faster. A lot of time was wasted on allocating memory as well.

There are situations where this is slower, so we may want to release this with `assume_sparse=False` first.

cc @nicolaskruchten