### PR TITLE
Fix version compare when running development IPython which has versions like 8.0.0.dev. #1388

### DIFF
--- a/packages/vaex-core/vaex/asyncio.py
+++ b/packages/vaex-core/vaex/asyncio.py
@@ -5,7 +5,7 @@ import sys
 def check_ipython():
     IPython = sys.modules.get('IPython')
     if IPython:
-        IPython_version = tuple(map(int, IPython.__version__.split('.')))
+        IPython_version = tuple(map(int, IPython.__version__.split('.')[:3]))
         if IPython_version < (7, 0, 0):
             raise RuntimeError(f'You are using IPython {IPython.__version__} while we require 7.0.0, please update IPython')
 


### PR DESCRIPTION
Simple fix to handle dev versions like 8.0.0.dev. Assume we only want the first 3 version bits.