### PR TITLE
✨ limit rows in groupby using early stop.

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -787,3 +787,7 @@ def dtype_of(ar):
         return dtype(ar.dtype)
     else:
         raise TypeError(f'{ar} is not a an Arrow or NumPy array')
+
+
+class RowLimitException(ValueError):
+    pass

--- a/tests/common.py
+++ b/tests/common.py
@@ -55,6 +55,10 @@ def small_buffer(ds, size=3):
     else:
         yield # for remote datasets we don't support this ... or should we?
 
+@pytest.fixture(scope='session')
+def buffer_size():
+    return small_buffer
+
 
 @pytest.fixture(scope='session')
 def webserver():

--- a/tests/internal/hash_test.py
+++ b/tests/internal/hash_test.py
@@ -278,3 +278,12 @@ def test_index_write():
     mask = np.zeros(3, dtype=bool)
     index.map_index_masked(ints, mask, indices)
     assert indices.tolist() == [0, 1, 2]
+
+
+def test_set_max_unique(buffer_size):
+    df = vaex.from_arrays(x=np.arange(1000))
+    with buffer_size(df):
+        with pytest.raises(vaex.RowLimitException, match='.* >= 2 .*'):
+            df._set('x', unique_limit=2)
+        with pytest.raises(vaex.RowLimitException, match='.*larger than.*'):
+            df._set('x', unique_limit=len(df)-1)


### PR DESCRIPTION
This can be useful if you only want to do a groupby when the result
is small and otherwise don't care about the result.

cc @nicolaskruchten

See usage:
![image](https://user-images.githubusercontent.com/1765949/121378494-89fd4200-c943-11eb-8bbd-7f95c956ce04.png)
