### PR TITLE
✨ allow caching of tasks outputs

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -116,6 +116,11 @@ jobs:
       shell: bash
       run: |
         ./ci/04-run-test-suite.sh
+    - name: Test with pytest (with cache on)
+      if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        VAEX_CACHE_RESULTS=1 ./ci/04-run-test-suite.sh
     - name: Check ml spec
       # no catboost for py39
       if: matrix.python-version != '3.9' && matrix.os != 'windows-latest'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - activate vaex-dev
   - "mamba install -c conda-forge --file ci/conda-env.yml --file ci/conda-env-notebooks.yml"
   - pip install -r requirements-ml.txt
-  - pip install "ipython>=7" "dask>=1" xgboost  # similar to GHA
+  - pip install "ipython>=7" "dask>=1" xgboost blake3 # similar to GHA
   - pip uninstall -y xgboost  # seems to crash, tests will be skipped
   - pushd packages\vaex-core   && pip install . && popd
   - pushd packages\vaex-hdf5   && pip install . && popd

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -99,6 +99,14 @@ Aggregation and statistics
 .. .. autoclass:: vaex.stat.Statistic
 ..     :members:
 
+Caching
+~~~~~~~
+
+.. automodule:: vaex.cache
+    :members: is_on, off, get, set, memory_infinite, disk_infinite, redis
+    :undoc-members:
+    :show-inheritance:
+
 
 Extensions
 ----------

--- a/packages/vaex-astro/vaex/astro/gadget.py
+++ b/packages/vaex-astro/vaex/astro/gadget.py
@@ -50,6 +50,7 @@ def getinfo(filename, seek=None):
 
 
 class MemoryMappedGadget(DatasetMemoryMapped):
+	snake_name = 'gadget'
 	def __init__(self, filename, fs_options={}, fs=None):
 		super(MemoryMappedGadget, self).__init__(filename)
 		#h5file = h5py.File(self.filename)

--- a/packages/vaex-astro/vaex/astro/votable.py
+++ b/packages/vaex-astro/vaex/astro/votable.py
@@ -5,6 +5,7 @@ from vaex.dataset import DatasetFile
 from vaex.dataset_misc import _try_unit
 
 class VOTable(DatasetFile):
+	snake_name = "votable"
 	def __init__(self, filename, fs_options={}, fs=None):
 		super().__init__(filename)
 		self.ucds = {}

--- a/packages/vaex-core/src/hash_object.cpp
+++ b/packages/vaex-core/src/hash_object.cpp
@@ -297,8 +297,11 @@ void init_hash_object(py::module &m) {
             .def("update", &Type::update_with_mask)
             .def("merge", &Type::merge)
             .def("extract", &Type::extract)
+            .def_property_readonly("count", [](const Type &c) { return c.count; })
             .def_property_readonly("nan_count", [](const Type &c) { return c.nan_count; })
             .def_property_readonly("null_count", [](const Type &c) { return c.null_count; })
+            .def_property_readonly("has_nan", [](const Type &c) { return c.nan_count > 0; })
+            .def_property_readonly("has_null", [](const Type &c) { return c.null_count > 0; })
         ;
     }
     {
@@ -314,6 +317,7 @@ void init_hash_object(py::module &m) {
             .def("keys", &Type::keys)
             .def("map_ordinal", &Type::map_ordinal)
             .def("map_ordinal", &Type::map_ordinal_with_mask)
+            .def_property_readonly("count", [](const Type &c) { return c.count; })
             .def_property_readonly("nan_count", [](const Type &c) { return c.nan_count; })
             .def_property_readonly("null_count", [](const Type &c) { return c.null_count; })
             .def_property_readonly("has_nan", [](const Type &c) { return c.nan_count > 0; })

--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 
 import dask.base
+from vaex.expression import Expression
 
 from .stat import _Statistic
 from vaex import encoding
@@ -79,7 +80,7 @@ class AggregatorDescriptorBasic(AggregatorDescriptor):
         else:
             spec['expression'] = [str(k) for k in self.expressions]
         if self.selection is not None:
-            spec['selection'] = self.selection
+            spec['selection'] = str(self.selection) if isinstance(self.selection, Expression) else self.selection
         if self.edges:
             spec['edges'] = True
         if self.agg_args:

--- a/packages/vaex-core/vaex/cache.py
+++ b/packages/vaex-core/vaex/cache.py
@@ -46,12 +46,13 @@ def _with_cleanup(f):
 
 
 @_with_cleanup
-def infinite():
+def infinite(reset=False):
     '''Sets the cache as a dictionary, creating an infinite cache'''
     global cache
     log.debug("set cache to infinite")
     old_cache = cache
-    cache = {}
+    if reset or (not isinstance(old_cache, dict)):
+        cache = {}
     yield
     log.debug("restore old cache")
     cache = old_cache

--- a/packages/vaex-core/vaex/cache.py
+++ b/packages/vaex-core/vaex/cache.py
@@ -11,6 +11,8 @@ import functools
 
 
 log = logging.getLogger('vaex.cache')
+_enable_cache_results = vaex.utils.get_env_type(bool, 'VAEX_CACHE_RESULTS', False)
+
 
 dask.base.normalize_token.register(pa.DataType, repr)
 
@@ -130,3 +132,6 @@ def output_file(callable=None, path_input=None, fs_options_input={}, fs_input=No
             return call
         return wrapper2
     return wrapper1()
+
+if _enable_cache_results:
+    infinite()

--- a/packages/vaex-core/vaex/cache.py
+++ b/packages/vaex-core/vaex/cache.py
@@ -61,9 +61,13 @@ def is_on():
     return cache is not None
 
 
+@_with_cleanup
 def off():
     global cache
+    old_cache = cache
     cache = None
+    yield
+    cache = old_cache
 
 
 def get(key):

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -103,7 +103,7 @@ class TaskPartFilterFill:
 class TaskPartSetCreate:
     name = "set_create"
 
-    def __init__(self, df, expression, dtype, dtype_item, flatten, unique_limit):
+    def __init__(self, df, expression, dtype, dtype_item, flatten, unique_limit, selection):
         expression = str(expression)
         self.df = df
         self.dtype = dtype
@@ -111,6 +111,7 @@ class TaskPartSetCreate:
         self.flatten = flatten
         self.expression = expression
         self.unique_limit = unique_limit
+        self.selection = selection
 
         transient = False
         # TODO: revive non-transient optimization
@@ -136,6 +137,9 @@ class TaskPartSetCreate:
         from vaex.column import _to_string_sequence
         if self.set is None:
             self.set = self.ordered_set_type()
+        if self.selection:
+            selection_mask = self.df.evaluate_selection_mask(self.selection, i1=i1, i2=i2, cache=True)
+            ar = filter(ar, selection_mask)
         if self.dtype.is_list and self.flatten:
             ar = ar.values
         if self.dtype_item.is_string:
@@ -173,7 +177,7 @@ class TaskPartSetCreate:
     @classmethod
     def decode(cls, encoding, spec, df):
         return cls(df, spec['expression'], encoding.decode('dtype', spec['dtype']), encoding.decode('dtype', spec['dtype_item']),
-                   flatten=spec['flatten'], unique_limit=spec['unique_limit'])
+                   flatten=spec['flatten'], unique_limit=spec['unique_limit'], selection=spec['selection'])
 
 
 

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -72,6 +72,33 @@ class TaskPartSum:
         return cls(spec['expression'])
 
 
+
+@register
+class TaskPartFilterFill:
+    name = "filter_fill"
+
+    def __init__(self):
+        pass
+
+    @property
+    def expressions(self):
+        return []
+
+    def get_result(self):
+        return None
+
+    def process(self, thread_index, i1, i2, filter_mask):
+        assert filter_mask is not None, f'{filter_mask}'
+
+    def reduce(self, others):
+        pass
+
+    @classmethod
+    def decode(cls, encoding, spec, df):
+        assert spec == {'task': 'filter_fill'}, f'{spec}'
+        return cls()
+
+
 @register
 class TaskPartMapReduce(TaskPart):
     name = "map_reduce"

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4106,7 +4106,7 @@ class DataFrame(object):
         df.dataset = self.dataset[self._index_start:self._index_end]
         if df.filtered:
             # we're gonna copy the mask from our parent
-            parent_mask = self._selection_masks[FILTER_SELECTION_NAME].view(self._index_start, self._index_end)
+            parent_mask = self._selection_masks[FILTER_SELECTION_NAME].view(0, self._index_end - self._index_start)
             mask = df._selection_masks[FILTER_SELECTION_NAME]
             np.copyto(np.asarray(mask), np.asarray(parent_mask))
             selection = df.get_selection(FILTER_SELECTION_NAME)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5367,10 +5367,14 @@ class DataFrameLocal(DataFrame):
         self.mask = None
         self.columns = ColumnProxy(self)
 
-    def fingerprint(self):
-        '''id that uniquely identifies a dataframe (cross runtime)'''
-        state = self._future().state_get(skip=[self.dataset])
-        fp = vaex.cache.fingerprint(state, self.dataset.fingerprint)
+    def fingerprint(self, treeshake=False):
+        '''Id that uniquely identifies a dataframe (cross runtime).
+
+        :param bool treeshake: Get rid of unused variables before calculating the fingerprint.
+        '''
+        df = self.copy(treeshake=True) if treeshake else self
+        state = df._future().state_get(skip=[df.dataset])
+        fp = vaex.cache.fingerprint(state, df.dataset.fingerprint)
         return f'dataframe-{fp}'
 
     def __getstate__(self):
@@ -5594,9 +5598,15 @@ class DataFrameLocal(DataFrame):
             setattr(datas, name, array[:])
         return datas
 
-    def copy(self, column_names=None):
+    def copy(self, column_names=None, treeshake=False):
+        '''Make a shallow copy of a dataframe, or a subset of columns.
+
+        Note that this is a fairly cheap operation, since no memory copies of the underlying data are made.
+
+        :param bool treeshake: Get rid of variables not used.
+        '''
         copy_all = column_names is None
-        if copy_all:  # fast path
+        if copy_all and not treeshake:  # fast path
             df = vaex.from_dataset(self.dataset)
             df.column_names = list(self.column_names)
             df.virtual_columns = self.virtual_columns.copy()
@@ -5625,7 +5635,9 @@ class DataFrameLocal(DataFrame):
                     required.add(name)
                 else:
                     if name in self.variables:
-                        return  # we don't track variables, we copy all
+                        if treeshake:
+                            required.add(name)
+                        return
                     elif name in self.virtual_columns:
                         required.add(name)
                         expr = self._virtual_expressions[name]
@@ -5664,8 +5676,9 @@ class DataFrameLocal(DataFrame):
                     valid_name = vaex.utils.find_valid_name(name)
                     df.add_virtual_column(valid_name, self.virtual_columns[name])
                 elif name in self.variables:
-                    # no need to do this, since we copy all variables
-                    # df.variables[name] = self.variables[name]
+                    # if we treeshake, we copy only what we require
+                    if treeshake:
+                        df.variables[name] = self.variables[name]
                     pass
                 else:
                     raise RuntimeError(f'Oops {name} is not a virtual column or variable??')
@@ -5684,7 +5697,8 @@ class DataFrameLocal(DataFrame):
         df._active_fraction = self._active_fraction
         df._renamed_columns = list(self._renamed_columns)
         df.units.update(self.units)
-        df.variables.update(self.variables)  # we add all, could maybe only copy used
+        if not treeshake:
+            df.variables.update(self.variables)
         df._categories.update(self._categories)
         df._future_behaviour = self._future_behaviour
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2913,6 +2913,7 @@ class DataFrame(object):
         """
         offset = 0
         import concurrent.futures
+        self._fill_filter_mask()
         if not prefetch:
             # this is the simple implementation
             for l1, l2, i1, i2 in self._unfiltered_chunk_slices(chunk_size):
@@ -4164,7 +4165,7 @@ class DataFrame(object):
         if df.filtered and filtered:
             # we translate the indices that refer to filters row indices to
             # indices of the unfiltered row indices
-            df.count() # make sure the mask is filled
+            df._fill_filter_mask()
             max_index = indices.max()
             mask = df._selection_masks[FILTER_SELECTION_NAME]
             filtered_indices = mask.first(max_index+1)
@@ -5982,7 +5983,6 @@ class DataFrameLocal(DataFrame):
 
     def _unfiltered_chunk_slices(self, chunk_size):
         logical_length = len(self)
-        self._fill_filter_mask()
         if self.filtered:
             full_mask = self._selection_masks[FILTER_SELECTION_NAME]
             # TODO: python 3, use yield from

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -443,8 +443,7 @@ class DataFrame(object):
         return self.map_reduce(map, reduce, expressions, delay=delay, progress=progress, name='nop', to_numpy=False)
 
     def _set(self, expression, progress=False, selection=None, flatten=True, delay=False, unique_limit=None):
-        assert selection is None
-        task = vaex.tasks.TaskSetCreate(self, str(expression), flatten, unique_limit=unique_limit)
+        task = vaex.tasks.TaskSetCreate(self, str(expression), flatten, unique_limit=unique_limit, selection=selection)
         self.executor.schedule(task)
         return self._delay(delay, task)
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5373,7 +5373,7 @@ class DataFrameLocal(DataFrame):
         :param bool treeshake: Get rid of unused variables before calculating the fingerprint.
         '''
         df = self.copy(treeshake=True) if treeshake else self
-        state = df._future().state_get(skip=[df.dataset])
+        state = df._state_get_vaex_5(skip=[df.dataset])
         fp = vaex.cache.fingerprint(state, df.dataset.fingerprint)
         return f'dataframe-{fp}'
 

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -443,6 +443,8 @@ class DataFrame(object):
         return self.map_reduce(map, reduce, expressions, delay=delay, progress=progress, name='nop', to_numpy=False)
 
     def _set(self, expression, progress=False, selection=None, flatten=True, delay=False, unique_limit=None):
+        if selection is not None:
+            selection = str(selection)
         task = vaex.tasks.TaskSetCreate(self, str(expression), flatten, unique_limit=unique_limit, selection=selection)
         self.executor.schedule(task)
         return self._delay(delay, task)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5896,7 +5896,8 @@ class DataFrameLocal(DataFrame):
 
     def _filtered_range_to_unfiltered_indices(self, i1, i2):
         assert self.filtered
-        count = self.count()  # force the cache to be filled
+        self._fill_filter_mask()
+        count = len(self)
         assert i2 <= count
         cache = self._selection_mask_caches[FILTER_SELECTION_NAME]
         mask_blocks = iter(sorted(
@@ -6065,7 +6066,7 @@ class DataFrameLocal(DataFrame):
             return result
         else:
             if not raw and self.filtered and filtered:
-                count_check = len(self)  # fill caches and masks
+                self._fill_filter_mask()  # fill caches and masks
                 mask = self._selection_masks[FILTER_SELECTION_NAME]
                 if _DEBUG:
                     if i1 == 0 and i2 == count_check:

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4188,7 +4188,7 @@ class DataFrame(object):
 
     def _push_down_filter(self):
         '''Push the filter down the dataset layer'''
-        self.count()  # make sure the mask is filled
+        self._fill_filter_mask()  # make sure the mask is filled
         mask = self._selection_masks[FILTER_SELECTION_NAME]
         mask = np.asarray(mask)
         # indices = mask.first(len(self))
@@ -5043,7 +5043,7 @@ class DataFrame(object):
             stop = min(stop, len(self))
             assert step in [None, 1]
             if self.filtered:
-                len(self)  # fill caches and masks
+                self._fill_filter_mask()
                 mask = self._selection_masks[FILTER_SELECTION_NAME]
                 startf, stopf = mask.indices(start, stop-1) # -1 since it is inclusive
                 assert startf != -1
@@ -5366,6 +5366,12 @@ class DataFrameLocal(DataFrame):
         # self.path = dataset.path
         self.mask = None
         self.columns = ColumnProxy(self)
+
+    def _fill_filter_mask(self):
+        if self.filtered:
+            task = vaex.tasks.TaskFilterFill(self)
+            self.executor.schedule(task)
+            self.execute()
 
     def fingerprint(self, treeshake=False):
         '''Id that uniquely identifies a dataframe (cross runtime).
@@ -6008,7 +6014,7 @@ class DataFrameLocal(DataFrame):
                 df = df.drop_filter()
             if i1 != 0 or i2 != max_stop:
                 if not raw and self.filtered and filtered:
-                    count_check = len(self)  # fill caches and masks
+                    self._fill_filter_mask()
                     mask = self._selection_masks[FILTER_SELECTION_NAME]
                     i1, i2 = mask.indices(i1, i2-1)
                     assert i1 != -1

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5982,6 +5982,7 @@ class DataFrameLocal(DataFrame):
 
     def _unfiltered_chunk_slices(self, chunk_size):
         logical_length = len(self)
+        self._fill_filter_mask()
         if self.filtered:
             full_mask = self._selection_masks[FILTER_SELECTION_NAME]
             # TODO: python 3, use yield from

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -220,6 +220,16 @@ class DataFrame(object):
         self._binners = {}
         self._grids = {}
 
+    def fingerprint(self, treeshake=False):
+        '''Id that uniquely identifies a dataframe (cross runtime).
+
+        :param bool treeshake: Get rid of unused variables before calculating the fingerprint.
+        '''
+        df = self.copy(treeshake=True) if treeshake else self
+        state = df._state_get_vaex_5(skip=[df.dataset])
+        fp = vaex.cache.fingerprint(state, df.dataset.fingerprint)
+        return f'dataframe-{fp}'
+
     def _future(self, version=5, inplace=False):
         '''Act like a Vaex dataframe version 5.
 
@@ -5372,16 +5382,6 @@ class DataFrameLocal(DataFrame):
             task = vaex.tasks.TaskFilterFill(self)
             self.executor.schedule(task)
             self.execute()
-
-    def fingerprint(self, treeshake=False):
-        '''Id that uniquely identifies a dataframe (cross runtime).
-
-        :param bool treeshake: Get rid of unused variables before calculating the fingerprint.
-        '''
-        df = self.copy(treeshake=True) if treeshake else self
-        state = df._state_get_vaex_5(skip=[df.dataset])
-        fp = vaex.cache.fingerprint(state, df.dataset.fingerprint)
-        return f'dataframe-{fp}'
 
     def __getstate__(self):
         state = self.state_get(skip=[self.dataset])

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4106,7 +4106,7 @@ class DataFrame(object):
         df.dataset = self.dataset[self._index_start:self._index_end]
         if df.filtered:
             # we're gonna copy the mask from our parent
-            parent_mask = self._selection_masks[FILTER_SELECTION_NAME].view(0, self._index_end - self._index_start)
+            parent_mask = self._selection_masks[FILTER_SELECTION_NAME].view(self._index_start, self._index_end)
             mask = df._selection_masks[FILTER_SELECTION_NAME]
             np.copyto(np.asarray(mask), np.asarray(parent_mask))
             selection = df.get_selection(FILTER_SELECTION_NAME)

--- a/packages/vaex-core/vaex/encoding.py
+++ b/packages/vaex-core/vaex/encoding.py
@@ -532,5 +532,12 @@ class binary:
         return data
 
 
+def fingerprint(typename, object):
+    '''Use the encoding framework to calculate a fingerprint'''
+    encoding = vaex.encoding.Encoding()
+    jsonable = encoding.encode(typename, object)
+    blob_keys = list(encoding.blobs)  # blob keys are hashes, so they are unique and enough for a fingerprint
+    return vaex.cache.fingerprint(jsonable, blob_keys)
+
 serialize = binary.serialize
 deserialize = binary.deserialize

--- a/packages/vaex-core/vaex/encoding.py
+++ b/packages/vaex-core/vaex/encoding.py
@@ -222,11 +222,20 @@ class numpy_scalar_encoding:
 class dtype_encoding:
     @staticmethod
     def encode(encoding, dtype):
+        dtype = DataType(dtype)
+        if dtype.is_list:
+            return {'type': 'list', 'value_type': encoding.encode('dtype', dtype.value_type)}
         dtype = DataType(dtype).internal
         return str(dtype)
 
     @staticmethod
     def decode(encoding, type_spec):
+        if isinstance(type_spec, dict):
+            if type_spec['type'] == 'list':
+                sub = encoding.decode('dtype', type_spec['value_type']).arrow
+                return DataType(pa.list_(sub))
+            else:
+                raise ValueError(f'Do not understand type {type_spec}')
         if type_spec == 'string':
             return DataType(pa.string())
         if type_spec == 'large_string':

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -59,7 +59,7 @@ class Executor:
                 key_task = task.fingerprint()
                 key_df = task.df.fingerprint()
                 # tasks' fingerprints don't include the dataframe
-                key = f'task-{key_task}-df-{key_df}'
+                key = f'{key_task}-{key_df}'
                 logger.debug("task fingerprint: %r", key)
                 result = vaex.cache.get(key)
                 if result is not None:
@@ -221,7 +221,7 @@ class ExecutorLocal(Executor):
                                 if vaex.cache.is_on():
                                     key_task = task.fingerprint()
                                     # tasks' fingerprints don't include the dataframe
-                                    key = f'task-{key_task}-df-{key_df}'
+                                    key = f'{key_task}-{key_df}'
                                     previous_result = vaex.cache.cache.get(key)
                                     if (previous_result is not None) and (previous_result != task._result):
                                         # this can happen with multithreading, where two threads enter the same tasks in parallel (IF using different executors)

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -57,7 +57,7 @@ class Executor:
             # if we refactor task 'merging' we can avoid this
             if vaex.cache.is_on():
                 key_task = task.fingerprint()
-                key_df = task.df.fingerprint(treeshake=True)
+                key_df = task.df.fingerprint()
                 # tasks' fingerprints don't include the dataframe
                 key = f'task-{key_task}-df-{key_df}'
                 logger.debug("task fingerprint: %r", key)
@@ -176,7 +176,8 @@ class ExecutorLocal(Executor):
                     task._parts = [encoding.decode('task-part-cpu', spec, df=run.df) for i in range(self.thread_pool.nthreads)]
 
                 length = run.df.active_length()
-                key_df = run.df.fingerprint(treeshake=True)
+                if vaex.cache.is_on():
+                    key_df = run.df.fingerprint()
                 # TODO: in the future we might want to enable the zigzagging again, but this requires all datasets to implement it
                 # if self.zigzag:
                 #     self.zig = not self.zig
@@ -227,7 +228,7 @@ class ExecutorLocal(Executor):
                                         logger.warning("calculated new result: %r, while cache had value: %r", previous_result, task._result)
                                     else:
                                         vaex.cache.cache[key] = task._result
-                                        logger.warning("added result: %r in cache under key: %r", task._result, key)
+                                        logger.info("added result: %r in cache under key: %r", task._result, key)
 
                             task.end()
                             task.fulfill(task._result)

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -55,7 +55,7 @@ class Executor:
         with self.lock:
             # _compute_agg can add a task that another thread already added
             # if we refactor task 'merging' we can avoid this
-            if vaex.cache.is_on():
+            if vaex.cache.is_on() and task.cacheable:
                 key_task = task.fingerprint()
                 key_df = task.df.fingerprint()
                 # tasks' fingerprints don't include the dataframe
@@ -217,7 +217,7 @@ class ExecutorLocal(Executor):
                             logger.debug("wait for task: %r", task)
                             task._result = parts[0].get_result()
                             logger.debug("got result for: %r", task)
-                            if task._result is not None:  # we don't want to store None
+                            if task._result is not None and task.cacheable:  # we don't want to store None
                                 if vaex.cache.is_on():
                                     key_task = task.fingerprint()
                                     # tasks' fingerprints don't include the dataframe

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -919,7 +919,7 @@ def f({0}):
             return self.df['isin_set(%s, %s)' % (self, var)]
         else:
             if self.is_string():
-                values = vaex.column._to_string_sequence(values)
+                values = pa.array(values)
             else:
                 values = np.array(values, dtype=self.dtype.numpy)
             var = self.df.add_variable('isin_values', values, unique=True)

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2526,6 +2526,7 @@ def _astype(x, dtype):
 def _isin(x, values):
     if vaex.column._is_stringy(x):
         x = vaex.column._to_string_column(x)
+        values = vaex.column._to_string_sequence(values)
         return x.string_sequence.isin(values)
     else:
         # TODO: this happens when a column is of dtype=object

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -267,6 +267,9 @@ def _combine(df, groupers, sort, row_limit=None):
 class GroupByBase(object):
     def __init__(self, df, by, sort=False, combine=False, expand=True, row_limit=None):
         '''Note that row_limit only works in combination with combine=True'''
+        # TODO: the original dataframe should be used to compute the hashmaps, since we mutate self.df
+        # leading to a different hashmap
+        df = df.copy()  # we're gonna mutate, so create a shallow copy
         self.df = df
         self.sort = sort
         self.expand = expand  # keep as pyarrow struct?

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -114,16 +114,18 @@ class TaskFilterFill(Task):
 @register
 class TaskSetCreate(Task):
     name = "set_create"
-    def __init__(self, df, expression, flatten, unique_limit=None):
+    def __init__(self, df, expression, flatten, unique_limit=None, selection=None):
         super().__init__(df=df, expressions=[expression], pre_filter=df.filtered, name=self.name)
         self.flatten = flatten
         self.dtype = self.df.data_type(expression)
         self.dtype_item = self.df.data_type(expression, axis=-1 if flatten else 0)
         self.unique_limit = unique_limit
+        self.selection = selection
 
     def encode(self, encoding):
         return {'task': type(self).name, 'expression': self.expressions[0], 'dtype': encoding.encode('dtype', self.dtype),
-                'dtype_item': encoding.encode('dtype', self.dtype_item), 'flatten': self.flatten, 'unique_limit': self.unique_limit}
+                'dtype_item': encoding.encode('dtype', self.dtype_item), 'flatten': self.flatten, 'unique_limit': self.unique_limit,
+                'selection': self.selection}
 
     @classmethod
     def decode(cls, encoding, spec, df):

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -33,6 +33,7 @@ class Task(vaex.promise.Promise):
     :type: signal_progress: Signal
     """
     _fingerprint = None
+    cacheable = True
 
     def __init__(self, df=None, expressions=[], pre_filter=False, name="task"):
         vaex.promise.Promise.__init__(self)
@@ -97,8 +98,24 @@ class TaskSum(Task):
 
 
 @register
+class TaskFilterFill(Task):
+    cacheable = False
+    name = "filter_fill"
+    def __init__(self, df):
+        super().__init__(df=df, pre_filter=True)
+
+    def encode(self, encoding):
+        return {'task': type(self).name}
+
+    @classmethod
+    def decode(cls, encoding, spec, df):
+        return cls(df)
+
+
+@register
 class TaskMapReduce(Task):
     name = "map_reduce"
+    cacheable = False  # in general this is used with side effects
 
     def __init__(self, df, expressions, map, reduce, info=False, to_float=False,
                  to_numpy=True, skip_masked=False, ignore_filter=False, selection=None, pre_filter=False, name="task"):

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -102,7 +102,7 @@ class TaskFilterFill(Task):
     cacheable = False
     name = "filter_fill"
     def __init__(self, df):
-        super().__init__(df=df, pre_filter=True)
+        super().__init__(df=df, pre_filter=True, name=self.name)
 
     def encode(self, encoding):
         return {'task': type(self).name}
@@ -111,6 +111,23 @@ class TaskFilterFill(Task):
     def decode(cls, encoding, spec, df):
         return cls(df)
 
+@register
+class TaskSetCreate(Task):
+    name = "set_create"
+    def __init__(self, df, expression, flatten, unique_limit=None):
+        super().__init__(df=df, expressions=[expression], pre_filter=df.filtered, name=self.name)
+        self.flatten = flatten
+        self.dtype = self.df.data_type(expression)
+        self.dtype_item = self.df.data_type(expression, axis=-1 if flatten else 0)
+        self.unique_limit = unique_limit
+
+    def encode(self, encoding):
+        return {'task': type(self).name, 'expression': self.expressions[0], 'dtype': encoding.encode('dtype', self.dtype),
+                'dtype_item': encoding.encode('dtype', self.dtype_item), 'flatten': self.flatten, 'unique_limit': self.unique_limit}
+
+    @classmethod
+    def decode(cls, encoding, spec, df):
+        return cls(df, expression=spec['expression'])
 
 @register
 class TaskMapReduce(Task):

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -32,6 +32,7 @@ class Task(vaex.promise.Promise):
     """
     :type: signal_progress: Signal
     """
+    _fingerprint = None
 
     def __init__(self, df=None, expressions=[], pre_filter=False, name="task"):
         vaex.promise.Promise.__init__(self)
@@ -45,6 +46,11 @@ class Task(vaex.promise.Promise):
         self.name = name
         self.pre_filter = pre_filter
         self.result = None
+
+    def fingerprint(self):
+        if self._fingerprint is None:
+            self._fingerprint = vaex.encoding.fingerprint('task', self)
+        return f'task-{self.name}-{self._fingerprint}'
 
     def _set_progress(self, fraction):
         self.progress_fraction = fraction

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -5,7 +5,7 @@ def passes(df):
     return df.executor.passes if df.is_local() else df.executor.remote_calls
 
 def test_cached_result(df_local):
-    with vaex.cache.infinite():
+    with vaex.cache.memory_infinite(clear=True):
         assert vaex.cache.is_on()
         df = df_local
         len(df)  # trigger a first pass (filtering) TODO: why is this needed?
@@ -42,7 +42,7 @@ def test_cached_result(df_local):
 
 def test_cache_length_without_messing_up_filter_mask(df_local):
     df = df_local
-    with vaex.cache.infinite():
+    with vaex.cache.memory_infinite(clear=True):
         dff = df[df.x < 4]
         passes0 = passes(df)
         len(dff)
@@ -58,7 +58,7 @@ def test_cache_length_without_messing_up_filter_mask(df_local):
 
 def test_cache_set():
     df = vaex.from_arrays(x=[0, 1, 2, 2])
-    with vaex.cache.infinite():
+    with vaex.cache.memory_infinite(clear=True):
         passes0 = passes(df)
         df._set('x')
         assert passes(df) == passes0 + 1

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -65,3 +65,50 @@ def test_cache_set():
         # now should use the cache
         df._set('x')
         assert passes(df) == passes0 + 1
+
+
+def test_cache_groupby():
+    df = vaex.from_arrays(x=[0, 1, 2, 2], y=['a', 'b', 'c', 'd'])
+    df2 = vaex.from_arrays(x=[0, 1, 2, 2], y=['a', 'b', 'c', 'd'])
+    fp = df.fingerprint()  # we also want to be sure we don't modify the fingerprint
+    with vaex.cache.memory_infinite(clear=True):
+        passes0 = passes(df)
+
+        df.groupby('x', agg='count')
+        # we do two passes, one for the set, and 1 for the aggregation
+        assert passes(df) == passes0 + 2
+        assert df.fingerprint() == fp
+
+        df.groupby('y', agg='count')
+        # we do two passes, one for the set, and 1 for the aggregation
+        assert passes(df) == passes0 + 4
+        assert df.fingerprint() == fp
+
+        df2.groupby('y', agg='count')
+        # different dataframe, same data, no extra passes
+        assert passes(df) == passes0 + 4
+        assert df.fingerprint() == fp
+
+        # now should use the cache
+        df.groupby('x', agg='count')
+        assert passes(df) == passes0 + 4
+        df.groupby('y', agg='count')
+        assert passes(df) == passes0 + 4
+        assert df.fingerprint() == fp
+
+        # 1 time for combining the two sets, 1 pass for aggregation
+        df.groupby(['x', 'y'], agg='count')
+        assert passes(df) == passes0 + 6
+        assert df.fingerprint() == fp
+
+        # but that should be reused the second time
+        # TODO: but the labels use map_reduce, which we cannot yet avoid
+        df.groupby(['x', 'y'], agg='count')
+        assert passes(df) == passes0 + 6 + 1
+        assert df.fingerprint() == fp
+
+        # different order triggers a new pass(combining the sets in a different way)
+        # and the aggregation phase, which includes the labeling
+        df.groupby(['y', 'x'], agg='count')
+        assert passes(df) == passes0 + 6 + 1 + 2
+        assert df.fingerprint() == fp

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -56,3 +56,12 @@ def test_cache_length_without_messing_up_filter_mask(df_local):
         dffs = dff[1:2]
         assert passes(df) == passes0 + 2
 
+def test_cache_set():
+    df = vaex.from_arrays(x=[0, 1, 2, 2])
+    with vaex.cache.infinite():
+        passes0 = passes(df)
+        df._set('x')
+        assert passes(df) == passes0 + 1
+        # now should use the cache
+        df._set('x')
+        assert passes(df) == passes0 + 1

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -1,0 +1,58 @@
+import numpy as np
+import vaex.cache
+
+def passes(df):
+    return df.executor.passes if df.is_local() else df.executor.remote_calls
+
+def test_cached_result(df_local):
+    with vaex.cache.infinite():
+        assert vaex.cache.is_on()
+        df = df_local
+        len(df)  # trigger a first pass (filtering) TODO: why is this needed?
+        passes0 = passes(df)
+        sum0 = df.sum('x')
+        passes1 = passes(df)
+        assert passes1 == passes0 + 1
+        
+        # now it should be cached, ...
+        sum0b = df.sum('x')
+        assert sum0 == sum0b
+        # so no extra passes
+        passes1b = passes(df)
+        assert passes1 == passes1b
+
+
+        df = df[df.x < 4]
+        len(df)  # trigger a filter pass
+        passes0 = passes(df)
+        total = 1 + 2 + 3        
+
+        # this should be a new result
+        sum1_filtered = df.sum('x')
+        passes1 = passes(df)
+        assert passes1 == passes0 + 1
+        assert sum1_filtered == total
+
+        # now it should be cached
+        sum1b_filtered = df.sum('x')
+        passes1b = passes(df)
+        assert passes1b == passes1
+        assert sum1b_filtered == sum1_filtered
+
+
+def test_cache_length_without_messing_up_filter_mask(df_local):
+    df = df_local
+    with vaex.cache.infinite():
+        dff = df[df.x < 4]
+        passes0 = passes(df)
+        len(dff)
+        assert passes(df) == passes0 + 1
+        # create a new df, that should re-use the results of the filter
+        dff = df[df.x < 4]
+        # this should not trigger a computation (due to cache)
+        len(dff)
+        assert passes(df) == passes0 + 1
+        # slicing needs the mask, so it should trigger
+        dffs = dff[1:2]
+        assert passes(df) == passes0 + 2
+

--- a/tests/common.py
+++ b/tests/common.py
@@ -198,12 +198,12 @@ def df_executor(request, df_trimmed, df_remote):
 
 
 if os.environ.get('VAEX_TEST_SKIP_REMOTE'):
-    @pytest.fixture(params=['ds_filtered', 'ds_half', 'ds_trimmed', 'df_concat', 'df_arrow', 'df_parquet'])
+    @pytest.fixture(params=['ds_filtered', 'ds_trimmed', 'df_concat', 'df_arrow', 'df_parquet'])
     def ds(request, ds_filtered, ds_half, ds_trimmed, df_concat, df_arrow, df_parquet):
         named = dict(ds_filtered=ds_filtered, ds_half=ds_half, ds_trimmed=ds_trimmed, df_concat=df_concat, df_arrow=df_arrow, df_parquet=df_parquet)
         return named[request.param]
 else:
-    @pytest.fixture(params=['ds_filtered', 'ds_half', 'ds_trimmed', 'ds_remote', 'df_concat', 'df_arrow', 'df_parquet'])
+    @pytest.fixture(params=['ds_filtered', 'ds_trimmed', 'ds_remote', 'df_concat', 'df_arrow', 'df_parquet'])
     def ds(request, ds_filtered, ds_half, ds_trimmed, ds_remote, df_concat, df_arrow, df_parquet):
         named = dict(ds_filtered=ds_filtered, ds_half=ds_half, ds_trimmed=ds_trimmed, ds_remote=ds_remote, df_concat=df_concat, df_arrow=df_arrow, df_parquet=df_parquet)
         return named[request.param]
@@ -214,14 +214,14 @@ def df(ds):
     return ds
 
 
-@pytest.fixture(params=['ds_filtered', 'ds_half', 'ds_trimmed', 'df_concat', 'df_arrow'])
+@pytest.fixture(params=['ds_filtered', 'ds_trimmed', 'df_concat', 'df_arrow'])
 def ds_local(request, ds_filtered, ds_half, ds_trimmed, df_concat, df_arrow):
     named = dict(ds_filtered=ds_filtered, ds_half=ds_half, ds_trimmed=ds_trimmed, df_concat=df_concat, df_arrow=df_arrow)
     return named[request.param]
 
 
 # in some cases it is not worth testing with the arrow version
-@pytest.fixture(params=['ds_filtered', 'ds_half', 'ds_trimmed', 'df_concat'])
+@pytest.fixture(params=['ds_filtered', 'ds_trimmed', 'df_concat'])
 def df_local_non_arrow(request, ds_filtered, ds_half, ds_trimmed, df_concat):
     named = dict(ds_filtered=ds_filtered, ds_half=ds_half, ds_trimmed=ds_trimmed, df_concat=df_concat)
     return named[request.param]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,3 +51,9 @@ def rebuild_dataframe_vaex(df):
 def rebuild_dataframe(request):
     named = dict(rebuild_dataframe_pickle=rebuild_dataframe_pickle, rebuild_dataframe_vaex=rebuild_dataframe_vaex)
     return named[request.param]
+
+
+@pytest.fixture
+def no_vaex_cache():
+    with vaex.cache.off():
+        yield

--- a/tests/copy_test.py
+++ b/tests/copy_test.py
@@ -14,6 +14,7 @@ def test_copy(df):
     assert 'myvar' in dfc.variables
     dfc.x.values
 
+
 def test_non_existing_column(df_local):
     df = df_local
     with pytest.raises(NameError, match='.*Did you.*'):

--- a/tests/copy_test.py
+++ b/tests/copy_test.py
@@ -84,3 +84,19 @@ def test_copy_selection():
     dfc = df.copy(['z'])  # only the selection depends on x
     dfc._invalidate_caches()
     assert dfc.z.sum(selection='selection_a') == 5
+
+
+def test_copy_tree_shake():
+    df = vaex.from_arrays(x=[0, 1, 2], y=[2, 3, 4])
+    df.add_variable('t', 1)
+    assert 't' in df.copy().variables
+
+    df.add_variable('t', 1)
+    assert 't' not in df.copy(treeshake=True).variables
+
+    # once we depend on it, we always copy
+    df.add_virtual_column('z', 'x*t')
+    assert 't' in df.copy().variables
+    assert 't' in df.copy(treeshake=True).variables
+    assert 't' in df.copy(['y']).variables
+    assert 't' not in df.copy(['y'], treeshake=True).variables

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -11,65 +11,69 @@ import vaex
 
 
 def test_signals(df):
-    mock_begin = MagicMock()
-    mock_progress = MagicMock()
-    mock_end = MagicMock()
-    len(df)  # ensure we have the filter precomputed
-    df.executor.signal_begin.connect(mock_begin)
-    df.executor.signal_progress.connect(mock_progress)
-    df.executor.signal_end.connect(mock_end)
-    df.sum(df.x, delay=True)
-    df.sum(df.y, delay=True)
-    df.execute()
-    mock_begin.assert_called_once()
-    mock_progress.assert_called_with(1.0)
-    mock_end.assert_called_once()
+    with vaex.cache.off():
+        mock_begin = MagicMock()
+        mock_progress = MagicMock()
+        mock_end = MagicMock()
+        len(df)  # ensure we have the filter precomputed
+        df.executor.signal_begin.connect(mock_begin)
+        df.executor.signal_progress.connect(mock_progress)
+        df.executor.signal_end.connect(mock_end)
+        df.sum(df.x, delay=True)
+        df.sum(df.y, delay=True)
+        df.execute()
+        mock_begin.assert_called_once()
+        mock_progress.assert_called_with(1.0)
+        mock_end.assert_called_once()
 
 
 def test_reentrant_catch(df_local):
-    df = df_local
+    with vaex.cache.off():
+        df = df_local
 
-    # a 'worker' thread should not be allowed to trigger a new computation
-    def progress(fraction):
-        print('progress', fraction)
-        df.count(df.x)  # enters the executor again
+        # a 'worker' thread should not be allowed to trigger a new computation
+        def progress(fraction):
+            print('progress', fraction)
+            df.count(df.x)  # enters the executor again
 
-    with pytest.raises(RuntimeError) as exc:
-        df.count(df.x, progress=progress)
-    assert 'nested' in str(exc.value)
+        with pytest.raises(RuntimeError) as exc:
+            df.count(df.x, progress=progress)
+        assert 'nested' in str(exc.value)
 
 
 @pytest.mark.skipif(platform.system().lower() == 'windows', reason="hangs appveyor very often, bug?")
 def test_thread_safe(df_local):
-    df = df_local
+    with vaex.cache.off():
+        df = df_local
 
-    # but an executor should be thread save
-    def do():
-        return df_local.count(df.x)  # enters the executor from a thread
+        # but an executor should be thread save
+        def do():
+            return df_local.count(df.x)  # enters the executor from a thread
 
-    count = df_local.count(df.x)
-    tpe = ThreadPoolExecutor(4)
-    futures = []
+        count = df_local.count(df.x)
+        tpe = ThreadPoolExecutor(4)
+        futures = []
 
-    passes = df.executor.passes
-    N = 100
-    with small_buffer(df):
-        for i in range(N):
-            futures.append(tpe.submit(do))
+        passes = df.executor.passes
+        N = 100
+        with small_buffer(df):
+            for i in range(N):
+                futures.append(tpe.submit(do))
 
-    done, not_done = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_EXCEPTION)
-    for future in done:
-        assert count == future.result()
-    assert df.executor.passes <= passes + N
+        done, not_done = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_EXCEPTION)
+        for future in done:
+            assert count == future.result()
+        assert df.executor.passes <= passes + N
 
 
 def test_delayed(df):
-    @vaex.delayed
-    def add(a, b):
-        return a + b
-    total_promise = add(df.sum(df.x, delay=True), 1)
-    df.execute()
-    assert total_promise.get() == df.sum(df.x) + 1
+    with vaex.cache.off():
+        @vaex.delayed
+        def add(a, b):
+            return a + b
+        total_promise = add(df.sum(df.x, delay=True), 1)
+        df.execute()
+        assert total_promise.get() == df.sum(df.x) + 1
 
 
 def test_nested_task(df):
@@ -93,17 +97,18 @@ def test_nested_task(df):
 
 
 def test_executor_from_other_thread():
-    df = vaex.from_arrays(x=[1, 2])
-    def execute():
-        # but call execute from a different thread
-        df.execute()
-    # we add a tasks from the main thread, we use binby without limits to force
-    # a double computation.
-    c = df.count('x', binby='x', delay=True, edges=True)
-    thread = threading.Thread(target=execute)
-    thread.start()
-    thread.join()
-    assert sum(c.get()) == 2
+    with vaex.cache.off():
+        df = vaex.from_arrays(x=[1, 2])
+        def execute():
+            # but call execute from a different thread
+            df.execute()
+        # we add a tasks from the main thread, we use binby without limits to force
+        # a double computation.
+        c = df.count('x', binby='x', delay=True, edges=True)
+        thread = threading.Thread(target=execute)
+        thread.start()
+        thread.join()
+        assert sum(c.get()) == 2
 # def test_add_and_cancel_tasks(df_executor):
 #     df = df_executor
 

--- a/tests/fingerprint_test.py
+++ b/tests/fingerprint_test.py
@@ -14,6 +14,8 @@ def test_dataframe(df_factory):
     assert df1.fingerprint() == df1b.fingerprint()
     df1.add_variable('q', 1)  # this changes the state
     assert df1.fingerprint() != df1b.fingerprint()
+    # but if we treeshake, it does not
+    assert df1.fingerprint(treeshake=True) != df1b.fingerprint()
 
 
 def test_groupby(df_factory):

--- a/tests/internal/filecache_test.py
+++ b/tests/internal/filecache_test.py
@@ -4,32 +4,34 @@ import os
 
 
 def test_hdf5(tmpdir):
-    path = str(tmpdir.join('test.hdf5'))
-    s = ['aap', 'noot']
-    df = vaex.from_arrays(x=[1,2], y=[3,4], s=s)
-    df.export(path)
-    fake_path = 's3://vaex/test.hdf5?profile=foo'
-    length = os.stat(path).st_size
-    with open(path, 'rb') as fp:
-        fp.seek(0, 2)
-        cache = vaex.file.cache.CachedFile(vaex.file.dup(fp), fake_path, str(tmpdir), block_size=2)
-        ds = vaex.hdf5.dataset.Hdf5MemoryMapped(cache)
-        df = vaex.dataframe.DataFrameLocal(ds)
-        assert df.x.tolist() == [1, 2]
-        assert df.y.tolist() == [3, 4]
-        assert df.s.tolist() == s
-        assert df.sum('x') == 3
-        cache = vaex.file.dup(cache)
-        cache.seek(0)
-        data_cache = cache.read()
-        # del df
-    with open(path, 'rb') as f:
-        length2 = f.seek(0, 2)
-        length2 = f.tell()
-        assert length == length2
-        f.seek(0, 0)
-        data = f.read()
-        assert data_cache == data
+    # we cannot use this with cache, otherwise the fingerprint code will try to access the s3 path
+    with vaex.cache.off():
+        path = str(tmpdir.join('test.hdf5'))
+        s = ['aap', 'noot']
+        df = vaex.from_arrays(x=[1,2], y=[3,4], s=s)
+        df.export(path)
+        fake_path = 's3://vaex/test.hdf5?profile=foo'
+        length = os.stat(path).st_size
+        with open(path, 'rb') as fp:
+            fp.seek(0, 2)
+            cache = vaex.file.cache.CachedFile(vaex.file.dup(fp), fake_path, str(tmpdir), block_size=2)
+            ds = vaex.hdf5.dataset.Hdf5MemoryMapped(cache)
+            df = vaex.dataframe.DataFrameLocal(ds)
+            assert df.x.tolist() == [1, 2]
+            assert df.y.tolist() == [3, 4]
+            assert df.s.tolist() == s
+            assert df.sum('x') == 3
+            cache = vaex.file.dup(cache)
+            cache.seek(0)
+            data_cache = cache.read()
+            # del df
+        with open(path, 'rb') as f:
+            length2 = f.seek(0, 2)
+            length2 = f.tell()
+            assert length == length2
+            f.seek(0, 0)
+            data = f.read()
+            assert data_cache == data
 
 
 def test_cache(tmpdir):

--- a/tests/internal/filecache_test.py
+++ b/tests/internal/filecache_test.py
@@ -1,4 +1,5 @@
 import vaex.file.cache
+import vaex.hdf5.dataset
 import os
 
 
@@ -7,7 +8,7 @@ def test_hdf5(tmpdir):
     s = ['aap', 'noot']
     df = vaex.from_arrays(x=[1,2], y=[3,4], s=s)
     df.export(path)
-    fake_path = 's3://vaex/test.hdf5?profile_name=foo'
+    fake_path = 's3://vaex/test.hdf5?profile=foo'
     length = os.stat(path).st_size
     with open(path, 'rb') as fp:
         fp.seek(0, 2)

--- a/tests/jupyter/model_test.py
+++ b/tests/jupyter/model_test.py
@@ -143,7 +143,7 @@ def test_axis_minmax(df, flush_guard):
 
 
 @pytest.mark.asyncio
-async def test_model_status(df_executor, flush_guard, server_latency):
+async def test_model_status(df_executor, flush_guard, server_latency, no_vaex_cache):
     df = df_executor
     x = vaex.jupyter.model.Axis(df=df, expression='x', min=0, max=1)
     assert x.status == x.Status.READY
@@ -396,7 +396,7 @@ async def test_model_status(df_executor, flush_guard, server_latency):
     await model._allow_state_change_to(model.Status.READY)
 
 
-def test_histogram_model_passes(df, flush_guard):
+def test_histogram_model_passes(df, flush_guard, no_vaex_cache):
     passes = df.executor.passes
     x = vaex.jupyter.model.Axis(df=df, expression='x')
     model = vaex.jupyter.model.Histogram(df=df, x=x)
@@ -418,7 +418,7 @@ def test_histogram_model_passes(df, flush_guard):
     assert df.executor.passes == passes + 2 + 2
 
 
-def test_two_model_passes(df, flush_guard):
+def test_two_model_passes(df, flush_guard, no_vaex_cache):
     passes = df.executor.passes
     x1 = vaex.jupyter.model.Axis(df=df, expression='x')
     x2 = vaex.jupyter.model.Axis(df=df, expression='x')
@@ -440,7 +440,7 @@ def test_two_model_passes(df, flush_guard):
     assert df.executor.passes == passes + 1 + 1
 
 
-def test_heatmap_model_passes(df, flush_guard):
+def test_heatmap_model_passes(df, flush_guard, no_vaex_cache):
     passes = df.executor.passes
     x = vaex.jupyter.model.Axis(df=df, expression='x')
     y = vaex.jupyter.model.Axis(df=df, expression='y')
@@ -588,7 +588,7 @@ def test_heatmap_model_basics(df, flush_guard):
 
 
 @pytest.mark.asyncio
-async def test_grid_exception_handling(df, flush_guard):
+async def test_grid_exception_handling(df, flush_guard, no_vaex_cache):
     # since exception can occur doing debounced/async execution, we will not
     # see stack traces, so we need to carefully track those
     x = vaex.jupyter.model.Axis(df=df, expression='x')

--- a/tests/jupyter/plot_widget_test.py
+++ b/tests/jupyter/plot_widget_test.py
@@ -18,7 +18,7 @@ def test_selection_event_calls(df, flush_guard):
     df.select(df.x > 3, name='bla')
 
 
-def test_widget_selection(flush_guard):
+def test_widget_selection(flush_guard, no_vaex_cache):
     df = vaex.example()
     with pytest.raises(ValueError) as e:
         selection_widget_default = df.widget.selection_expression()
@@ -56,7 +56,7 @@ def test_data_array_view(flush_guard):
     assert view.model.grid is not None
 
 
-def test_widget_histogram(flush_guard):
+def test_widget_histogram(flush_guard, no_vaex_cache):
     df = vaex.example()
     assert df.widget is df.widget
     df.select_box(['x'], [[-10, 20]], name='check')
@@ -93,7 +93,7 @@ def test_widget_histogram(flush_guard):
     assert histogram.plot.mark.y.tolist() != vizdata
 
 
-def test_widget_heatmap(flush_guard):
+def test_widget_heatmap(flush_guard, no_vaex_cache):
     df = vaex.example()
     df.select_rectangle('x', 'y', [[-10, 10], [-50, 50]], name='check')
     check_rectangle = df.count(selection='check')
@@ -137,7 +137,7 @@ def test_widget_heatmap(flush_guard):
 #     flush()
 
 
-def test_widget_process_circular(flush_guard):
+def test_widget_process_circular(flush_guard, no_vaex_cache):
     df = vaex.example()
     p = df.widget.progress_circular()
     df.sum(df.x)
@@ -145,7 +145,7 @@ def test_widget_process_circular(flush_guard):
     assert p.value == 100
 
 
-def test_widget_counter(flush_guard):
+def test_widget_counter(flush_guard, no_vaex_cache):
     df = vaex.example()
     c = df.widget.counter_processed()
     assert c.value == 0
@@ -153,7 +153,7 @@ def test_widget_counter(flush_guard):
     assert c.value == len(df)
 
 
-def test_widget_counter_selection(flush_guard):
+def test_widget_counter_selection(flush_guard, no_vaex_cache):
     df = vaex.example()
     c = df.widget.counter_selection('test', lazy=True)
     assert c.value == 0

--- a/tests/progress_test.py
+++ b/tests/progress_test.py
@@ -41,15 +41,16 @@ def test_progress_calls(df, event_loop):
 
 @pytest.mark.asyncio
 async def test_progress_calls_async(df):
-    x, y = df.sum([df.x, df.y], progress=True)
-    counter = CallbackCounter(True)
-    task = df.sum([df.x, df.y], delay=True, progress=counter)
-    await df.executor.execute_async()
-    x2, y2 = await task
-    assert x == x2
-    assert y == y2
-    assert counter.counter > 0
-    assert counter.last_args[0], 1.0
+    with vaex.cache.off():
+        x, y = df.sum([df.x, df.y], progress=True)
+        counter = CallbackCounter(True)
+        task = df.sum([df.x, df.y], delay=True, progress=counter)
+        await df.executor.execute_async()
+        x2, y2 = await task
+        assert x == x2
+        assert y == y2
+        assert counter.counter > 0
+        assert counter.last_args[0], 1.0
 
 
 def test_cancel(df):

--- a/tests/progress_test.py
+++ b/tests/progress_test.py
@@ -77,28 +77,30 @@ async def test_cancel_async(df):
 
 # @pytest.mark.timeout(1)
 def test_cancel_huge(client):
-    df = client['huge']
-    import threading
-    main_thread = threading.current_thread()
-    def progress(f):
-        assert threading.current_thread() == main_thread
-        return f > 0.01
-    with pytest.raises(vaex.execution.UserAbort):
-        assert df.x.min(progress=progress) is None
-    assert df.x.min() is not None
+    with vaex.cache.off():
+        df = client['huge']
+        import threading
+        main_thread = threading.current_thread()
+        def progress(f):
+            assert threading.current_thread() == main_thread
+            return f > 0.01
+        with pytest.raises(vaex.execution.UserAbort):
+            assert df.x.min(progress=progress) is None
+        assert df.x.min() is not None
 
 
 @pytest.mark.asyncio
 async def test_cancel_huge_async(client):
-    df = client['huge']
-    import threading
-    main_thread = threading.current_thread()
+    with vaex.cache.off():
+        df = client['huge']
+        import threading
+        main_thread = threading.current_thread()
 
-    def progress(f):
-        print("progress", f)
-        assert threading.current_thread() == main_thread
-        return f > 0.01
-    with pytest.raises(vaex.execution.UserAbort):
-        df.x.min(progress=progress, delay=True)
-        await df.execute_async()
-    assert df.x.min() is not None
+        def progress(f):
+            print("progress", f)
+            assert threading.current_thread() == main_thread
+            return f > 0.01
+        with pytest.raises(vaex.execution.UserAbort):
+            df.x.min(progress=progress, delay=True)
+            await df.execute_async()
+        assert df.x.min() is not None


### PR DESCRIPTION
Since we can calculate fingerprints of almost all things in vaex now, we can start adding in global caching:
![image](https://user-images.githubusercontent.com/1765949/121411535-0738af00-c964-11eb-82f1-435298d00327.png)

Note that only the first time we do the calculation, even after we open the dataframe again, and do the same calculation, we still find it in the cache (look at the timings), because the dataset fingerprint (and thus dataframe fingerprint) are the same.

This does not work yet for groupby, which is due to the sets in the variables dict that is modifying the input dataframe, which we should not do I think.

cc @nicolaskruchten @xdssio 

TODO:
 * [ ] docstrings
 * [ ] groupby test