### PR TITLE
Fixes for shift related methods

### DIFF
--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -174,7 +174,7 @@ class ExecutorLocal(Executor):
                 for expression in run.expressions:
                     variables |= run.df._expr(expression).expand().variables(ourself=True)
                 columns = list(variables - set(run.df.variables) - set(run.df.virtual_columns))
-                logger.debug('Using columns %r from dataset', columns)
+                logger.debug('Using columns %r from dataset, chunk_size=%r', columns, chunk_size)
                 for column in columns:
                     if column not in dataset:
                         raise RuntimeError(f'Oops, requesting column {column} from dataset, but it does not exist')


### PR DESCRIPTION
This contains fixes for various shift related issues:

- [ ] fix issues when `diff` is used for certain hdf5 files
