### PR TITLE
🐎 sparse groupby passed over original dataframe, this is faster

### DIFF
--- a/packages/vaex-core/vaex/datatype.py
+++ b/packages/vaex-core/vaex/datatype.py
@@ -42,6 +42,8 @@ class DataType:
             return self.is_integer
         if other == list:
             return self.is_list
+        if other == dict:
+            return self.is_struct
         if isinstance(other, str):
             tester = 'is_' + other
             if hasattr(self, tester):
@@ -323,6 +325,19 @@ class DataType:
         True
         '''
         return self.is_arrow and (pa.types.is_list(self.internal) or pa.types.is_large_list(self.internal))
+
+    @property
+    def is_struct(self):
+        '''Test if an (arrow) struct
+
+        >>> DataType(pa.struct([pa.field('a', pa.utf8())])) == dict
+        True
+        >>> DataType(pa.struct([pa.field('a', pa.utf8())])).is_struct
+        True
+        >>> DataType(pa.struct([pa.field('a', pa.utf8())])) == 'struct'
+        True
+        '''
+        return self.is_arrow and pa.types.is_struct(self.internal)
 
     @property
     def is_encoded(self):

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -230,7 +230,7 @@ def _combine(df, groupers, sort, row_limit=None):
 
     counts.append(1)
     # decreasing [40, 4, 1] for 2 groupers (N=10 and N=4)
-    cumulative_counts = np.cumproduct(counts[::-1]).tolist()[::-1]
+    cumulative_counts = np.cumproduct(counts[::-1], dtype='i8').tolist()[::-1]
     assert len(combine_now) >= 2
     combine_later = ([next] if next else []) + groupers
 

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -96,19 +96,18 @@ def test_cache_groupby():
         assert passes(df) == passes0 + 4
         assert df.fingerprint() == fp
 
-        # 1 time for combining the two sets, 1 pass for aggregation
+        # 1 time for combining the two sets, 1 for finding the labels (smaller dataframe), 1 pass for aggregation
         df.groupby(['x', 'y'], agg='count')
-        assert passes(df) == passes0 + 6
+        assert passes(df) == passes0 + 7
         assert df.fingerprint() == fp
 
-        # but that should be reused the second time
-        # TODO: but the labels use map_reduce, which we cannot yet avoid
+        # but that should be reused the second time, just 1 pass for the evaluations of the labels
         df.groupby(['x', 'y'], agg='count')
-        assert passes(df) == passes0 + 6 + 1
+        assert passes(df) == passes0 + 7 + 1
         assert df.fingerprint() == fp
 
         # different order triggers a new pass(combining the sets in a different way)
         # and the aggregation phase, which includes the labeling
         df.groupby(['y', 'x'], agg='count')
-        assert passes(df) == passes0 + 6 + 1 + 2
+        assert passes(df) == passes0 + 7 + 1 + 3
         assert df.fingerprint() == fp

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -237,6 +237,9 @@ def test_combined_grouper_over64bit():
     for i, bit in enumerate(bits):
         xi = dfg[f'x_{i}'].to_numpy()
         assert len(xi) == N
+        xiu = np.unique(xi)
+        Ni = 2**bits[i]
+        assert len(xiu) == Ni
     assert dfg['count'].sum() == N
     with pytest.raises(vaex.RowLimitException, match='.* >= 2 .*'):
         df.groupby(names, row_limit=2)


### PR DESCRIPTION
before, this could take 1m50s: `df.groupby(['passenger_count', 'vendor_id'], sort=True, agg='count')`
Now takes 5 seconds