### PR TITLE
Fix export (hdf5) of joined dataframe which contains missing values

### DIFF
--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -171,3 +171,15 @@ def test_export_csv(df_local, tmpdir):
     df.export_csv(path)
 
     assert '123456' in vaex.open(path)
+
+@pytest.mark.parametrize("filename", ["test.hdf5", "test.arrow", "test.parquet", "test.csv"])
+def test_export_joined_dataframe(tmpdir, filename):
+    df1 = vaex.from_dict({'x': [1, 2, 3]})
+    df2 = vaex.from_dict({'x':[1, 6, 7], 't1': [0, 0, 0]})
+    df = df1.join(df2, how='left', on='x', rsuffix='_y')
+    path = str(tmpdir.join(filename))
+    df.export(path)
+    df = vaex.open(path)
+    assert df.x.tolist() == [1, 2, 3]
+    assert df.x_y.tolist() == [1, None, None]
+    assert df.t1.tolist() == [0, None, None]


### PR DESCRIPTION
This PR address the issue raised in https://github.com/vaexio/vaex/issues/1413

Notes:
- The added test checks the export against hdf5, arrow, parquet and csv. Only hdf5 and csv report problems, but for different reasons;
- HDF5 test fails because the data seems to be saved incorrectly;
- The csv file is exported correctly. However when the data is read, the missing values are converted do `nan`. I think this should now automatically be turned into a missing (masked) values, not `np.nan`. What do you think @maartenbreddels @xdssio. This might be more tricky tho.. so I am happy to leave it as is and adjust the test. Just wondering what the ideal case should be - in my opinion missing values.

Checklist:
- [x] Add tests
- [ ] Make tests pass