### PR TITLE
Add `str_extract_regex` to dataframe str function namespace.

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -1945,6 +1945,28 @@ def str_extract_regex(x, pattern):
                         the regular expression '(?P<letter>[ab])(?P<digit>\\d)'.
     :returns: an expression containing a struct with field names corresponding to capture group identifiers.
 
+    Example:
+
+    >>> import vaex
+    >>> email = ["foo@bar.org", "bar@foo.org", "open@source.org", "invalid@address.com"]
+    >>> df = vaex.from_arrays(email=email)
+    >>> df
+    #  email
+    0  foo@bar.org
+    1  bar@foo.org
+    2  open@source.org
+    3  invalid@address.com
+
+    >>> pattern = "(?P<name>.*)@(?P<address>.*)\.org"
+    >>> df.email.str.extract_regex(pattern=pattern)
+    Expression = str_extract_regex(email, pattern='(?P<name>.*)@(?P<addres...
+    Length: 4 dtype: struct<name: string, address: string> (expression)
+    -------------------------------------------------------------------
+    0      {'name': 'foo', 'address': 'bar'}
+    1      {'name': 'bar', 'address': 'foo'}
+    2  {'name': 'open', 'address': 'source'}
+    3                                     --
+
     """
 
     if not isinstance(x, vaex.array_types.supported_arrow_array_types):

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -1936,6 +1936,22 @@ def str_split(x, pattern=None, max_splits=-1):
         return pc.split_pattern(x, pattern=pattern, max_splits=max_splits)
 
 
+@register_function(scope='str')
+@auto_str_unwrap
+def str_extract_regex(x, pattern):
+    """Extract substrings defined by a regular expression using Apache Arrow (Google RE2 library).
+
+    :param str pattern: A regular expression which needs to contain named capture groups, e.g. ‘letter’ and ‘digit’ for
+                        the regular expression '(?P<letter>[ab])(?P<digit>\\d)'.
+    :returns: an expression containing a struct with field names corresponding to capture group identifiers.
+
+    """
+
+    if not isinstance(x, vaex.array_types.supported_arrow_array_types):
+        x = pa.array(x)
+
+    return pc.extract_regex(x, pattern=pattern)
+
 
 @register_function(scope='str')
 @auto_str_unwrap

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -300,6 +300,17 @@ def test_string_replace_regex_unicode(dfs, pattern, replacement, flags):
            dfs.s.str_pandas.replace(pattern, replacement, flags=flags, regex=True).tolist()
 
 
+def test_string_extract_regex():
+    ds = vaex.from_arrays(email=["foo@bar.org", "bar@foo.org", "open@source.org", "invalid@address.com"])
+    pattern = "(?P<name>.*)@(?P<address>.*)\.org"
+
+    expr = ds.email.str.extract_regex(pattern=pattern)
+    assert expr.tolist() == [{"name": "foo", "address": "bar"},
+                             {"name": "bar", "address": "foo"},
+                             {"name": "open", "address": "source"},
+                             None]
+
+
 @pytest.mark.parametrize("sub", ["v", unicode_compat("æ")])
 @pytest.mark.parametrize("start", [0, 3, 5])
 @pytest.mark.parametrize("end", [-1, 3, 5, 10])


### PR DESCRIPTION
This PR addresses issue #1154 and #1368 and is work in progress since there are conceptual questions remaining.

Adding a wrapper for apache arrows [`extract_regex`](https://arrow.apache.org/docs/cpp/compute.html#string-extraction) under the vaex dataframe string namespace is straightforward. However, handling the returned result is somewhat more complicated because it is not a single column of a primitive type but rather a collection of primitive types (StructArray in Arrow). There may be different valid approaches here which I would like to discuss with you before going any further (creating tests):

1. **Plain Arrow StructArray**: Just keep the standard arrow struct array and do not modify it any further. Arrow's struct arrays are currently not properly converted to dask/numpy within vaex (calling `to_dask_array`/`to_numpy`). This could be solved however (using structured numpy arrays perhaps for numpy). Interestingly, conversion to pandas works fine already (via dicts). There is one big question remaining, however. How does a common vaex user access the fields of the underlying struct via the vaex expression object? For example, how to apply some further string modifications on extracted values being contained in a vaex expression? My first attempt would be to use the arrow struct array directly instead of using the vaex expression layer (this may be due to my lack of familiarity with vaex).

2. **Decompose/flatten**: Instead of returning a single expression, provide a python dictionary where names correspond to capture groups identifiers and values refer to vaex expressions of primitive types. This would solve the issue of having complex data types being contained in a single vaex expression. However, this would break the common usage patterns of most string functions which return a single vaex expression instead of a dictionary of vaex expressions.

3. **Support both** - plain struct array and flattening via function parameter or separate functions: In my opinion both approaches serve valid use cases and should be supported. The default behaviour could be the plain struct array being contained in a single vaex expression. Additionally, there could be parameter like `flatten` or a separate utility function to flatten/decompose a expression holding a complex data type into multiple expressions containing only primitive types.

What is your opinion?

