### PR TITLE
🐎 running df.ordinal_encode can be replaced by df.categorize

### DIFF
--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -26,6 +26,10 @@ def is_numpy_array(ar):
     return isinstance(ar, np.ndarray)
 
 
+def is_array(ar):
+    return is_arrow_array(ar) or is_numpy_array(ar)
+
+
 def filter(ar, boolean_mask):
     if isinstance(ar, supported_arrow_array_types):
         return ar.filter(pa.array(boolean_mask))
@@ -152,11 +156,10 @@ def convert(x, type, default_type="numpy"):
         else:
             return to_numpy(x, strict=True)
     if type == "numpy-arrow":  # used internally, numpy if possible, otherwise arrow
-        if isinstance(x, (list, tuple)):
+        if isinstance(x, (list, tuple)) and len(x) > 0 and is_array(x[0]):
             return concat([convert(k, type) for k in x])
         else:
             return to_numpy(x, strict=False)
-
     elif type == "arrow":
         if isinstance(x, (list, tuple)):
             chunks = [convert(k, type) for k in x]

--- a/tests/category_test.py
+++ b/tests/category_test.py
@@ -114,3 +114,10 @@ def test_index_values(df_factory_arrow):
     # assert df.c.index_values().tolist() == [0, 0, 1, 2]
     with small_buffer(df, 2):
         assert df[df.c == 'aap'].c.index_values().tolist() == [0, 0]
+
+
+def test_ordinal_encode_optimize():
+    x = np.random.choice(2, 10, replace=True)
+    df = vaex.from_arrays(x=x)
+    with pytest.warns(UserWarning, match='.*categorize.*'):
+        df.ordinal_encode(df.x)


### PR DESCRIPTION
Going ordinal encode on already numerical columns between `[0, N]` should use df.categorize, warn the user and take the categorize path.