### PR TITLE
CI: fix the latest CI issues

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -10,7 +10,7 @@ matplotlib-base
 notebook
 numba
 numpy<1.21
-pandas
+pandas<1.3.0
 pcre
 pip
 python-annoy


### PR DESCRIPTION
This PR tries to figure out the reason behind the latest failures in the CI. 

I suspect this is due to the recent new release of pandas, and it's releases on conda-forge. 
Here we try to verify that by not allowing the latest verion of pandas.