### PR TITLE
concat with the virtual column when not exist in the other dataframe

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5853,7 +5853,8 @@ class DataFrameLocal(DataFrame):
                     # we have a mismatching virtual column, materialize it
                     for df in dfs:
                         # upgrade to a column, so Dataset's concat can concat
-                        dfs[dfs.index(df)] = df._lazy_materialize(name)
+                        if name in df.get_column_names(virtual=True, hidden=True):
+                            dfs[dfs.index(df)] = df._lazy_materialize(name)
 
         first, *tail = dfs
         # concatenate all datasets

--- a/tests/concat_test.py
+++ b/tests/concat_test.py
@@ -185,6 +185,18 @@ def test_concat_virtual_column_names():
     assert list(df) == ['x', 'z']
 
 
+def test_concat_virtual_column_name_with_column():
+    df1 = vaex.from_arrays(x=np.arange(3))
+    df2 = vaex.from_arrays(x=np.arange(4))
+    df1['z'] = df1.x ** 2
+    df = df1.concat(df2)
+    # test that virtual column with missing column name 
+    assert df.get_column_names() == ['x', 'z']
+    assert list(df) == ['x', 'z']
+    assert df.x.tolist() == [0, 1, 2, 0, 1, 2, 3]
+    assert df.z.tolist() == [0, 1, 4, None, None, None, None]
+
+
 def test_concat_missing_values():
     df1 = vaex.from_arrays(x=[1, 2, 3], y=[np.nan, 'b', 'c'])
     df2 = vaex.from_arrays(x=[4, 5, np.nan], y=['d', 'e', 'f'])


### PR DESCRIPTION
Hi, this is my first PR to vaex.
This solves the issues raised in:  #1361
I want to fix vaex so that concat will succeed even if the name of the virtual column exists on one side and the column with that name does not exist on the other side. 
For example,
```python
df1 = vaex.from_arrays(x=np.arange(3))
df2 = vaex.from_arrays(x=np.arange(3))
df1['z'] = df1.x ** 2

df = df1.concat(df2)
#  -> KeyError: "Virtual column not found: 'z'"
```
In above example, df1 is
| # | x |  z
| ---- | ---- | ---- | 
| 0 | 0  |  0  |
| 1 |  1  |  1  | 
| 2 |  2  | 4  |

df2 is 

| # | x |  
| ---- | ---- | 
| 0| 0  |  
| 1|  1  |  
| 2|  2  |  

so, I expected df will be

| # | x |  z
| ---- | ---- | ---- | 
| 0  | 0  |  0  |
| 1 |  1  |  1  | 
| 2 |  2  | 4  |
| 3 | 0  |  --  |   
| 4 |  1  | -- |   
| 5 |  2  | -- |  

but, it ends in  KeyError: "Virtual column not found: 'z'".  

As I read the source of concat method in dataframe.py, I found that df._lazy_materialize(name) was called with an argument that does not exist in the df. So, I modified to check whether the column name exists in the Dataframe, in concat processing of virtual column.

Please let me know if I'm wrong, because I may not have the right way to fix it.

Cheers.



