### PR TITLE
Allow dataframe.nop to accept both a single and a list of expressions

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -439,9 +439,16 @@ class DataFrame(object):
         arguments = _ensure_strings_from_expressions(arguments)
         return lazy_function(*arguments)
 
+    @docsubst
     def nop(self, expression=None, progress=False, delay=False):
-        """Evaluates expression, and drop the result, usefull for benchmarking, since vaex is usually lazy"""
-        expressions = _ensure_strings_from_expressions(expression) or self.get_column_names()
+        """Evaluates expression or a list of expressions, and drops the result. Usefull for benchmarking, since vaex is usually lazy.
+
+        :param expression: {expression}
+        :param progress: {progress}
+        :param delay: {delay}
+        :returns: None
+        """
+        expressions = _ensure_list(_ensure_strings_from_expressions(expression)) or self.get_column_names()
         def map(*ar):
             pass
         def reduce(a, b):

--- a/tests/nop_test.py
+++ b/tests/nop_test.py
@@ -1,0 +1,14 @@
+from common import ds_local
+
+
+def test_nop(ds_local):
+    df = ds_local
+    column_names = df.column_names
+
+    # Try a nop on a single column
+    result = df.nop(column_names[1])
+    assert result is None
+
+    # Try a  nop on a list of columns
+    result = df.nop(column_names)
+    assert result is None


### PR DESCRIPTION
This fix was raised by https://github.com/vaexio/dash-120million-taxi-app/issues/3

- [x] Unit-test exposing the issue
- [x] Allow `dataframe.nop` to accept both a single and a list of expressions