### PR TITLE
Proposed correction for category_values()

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -343,7 +343,7 @@ class DataFrame(object):
 
     def category_values(self, column):
         column = _ensure_string_from_expression(column)
-        return self._categories[column]['values']
+        return self.columns[column]
 
     def category_count(self, column):
         column = _ensure_string_from_expression(column)


### PR DESCRIPTION
Thi PR is a proposed correction for `category_values()` function on the dataframe class. When using `df.category_values(column)` an error accurs while accessing a list item that doesn't exist (list `_category`, item `'values'`)

```python
df = vaex.from_arrays(year=[2012, 2015, 2019], weekday=[0, 4, 6])
df = df.categorize('year', min_value=2012, max_value=2019)
df = df.categorize('weekday', labels=['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'])

from vaex.utils import _ensure_string_from_expression
column = _ensure_string_from_expression(df.year)

df._categories[column]
```
gives the list as an output
```
{'labels': [2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019],
 'N': 8,
 'min_value': 2012}
```
and calling `category_values()` function

```python
df.category_values(column)
```
result in an error
```
    348     def category_values(self, column):
    349         column = _ensure_string_from_expression(column)
--> 350         return self._categories[column]['values']
    351 
    352     def category_count(self, column):

KeyError: 'values'
```
I suggest using `self.columns[column]` instead of `self._categories[column]['values']` in the `category_values` function.

<sub>
Versions used: </br>
Python 3.9.5, 
vaex-core: 4.3.0.post1, 
vaex-viz: 0.5.0, 
vaex-hdf5: 0.8.0, 
vaex-server: 0.5.0, 
vaex-astro: 0.8.2, 
vaex-jupyter: 0.6.0, 
vaex-ml: 0.12.0 </sub>