### PR TITLE
fix: export dataframe to hdf5 when it includes multibyte named column (on Windows OS) 

### DIFF
--- a/packages/vaex-hdf5/vaex/hdf5/writer.py
+++ b/packages/vaex-hdf5/vaex/hdf5/writer.py
@@ -29,11 +29,11 @@ class Writer:
         self._layout_called = False
 
     def close(self):
-        self.h5.close()
         if self.mmap is not None:
             self.mmap.close()
             self.file.close()
-
+        self.h5.close()
+        
     def __enter__(self):
         return self
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -116,6 +116,16 @@ def test_export_string_mask(tmpdir):
     df_arrow = vaex.open(path)
     assert df.s.tolist() == df_arrow.s.tolist()
 
+def test_export_unicode_column_name_hdf5(tmpdir):
+    # prepare many columns for multithreaded export
+    src_dict = {"あ": [1, 2, 3], "a": [1, 2, 3], "b": [1, 2, 3], 
+            "c": [1, 2, 3], "d": [1, 2, 3], "a1": [1, 2, 3], 
+            "b2": [1, 2, 3], "c3": [1, 2, 3], "d4": [1, 2, 3]}
+    path = str(tmpdir.join('test.hdf5'))
+    df = vaex.from_dict(src_dict)
+    df.export(path)
+    df_open = vaex.open(path)
+    assert df_open["あ"].tolist() == [1, 2, 3]
 
 # N = 2**32+2
 # @pytest.mark.skipif(not os.environ.get('VAEX_EXPORT_BIG', False),


### PR DESCRIPTION
Hi👋
This solves the issues raised in: #1478 
In export_hdf5 method, the procedure **was** as follows. 
1. Create/Open hdf5 file (in init function at Writer class)  
2. Open mmap file (in layout method)
3. Close hdf5 file (in close method)
4. Close mmap (in close method)

I made a hypothesis that this procedure might be not a good in windows environment and I read vaex/h5py/hdf5 source code. I didn't found the bug logic on the h5py/hdf5 source, but I was able to reproduce this bug in small scripts without vaex. 

```python
import h5py
import mmap

path = "mytestfile.hdf5"
f = h5py.File(path, "w") # Open HDF5 File =================
file = open(path, "rb+")  # Open mmap file ------------------------
fileno = file.fileno()
cg = f.require_group("column")

kwargs = {}
kwargs["access"] = mmap.ACCESS_READ 
mmap = mmap.mmap(fileno, 0, **kwargs)

for i in range(100):
    g = cg.require_group("東京"+str(i)) # create group hdf5 using multibyte name
    dset = g.create_dataset("mydataset", (100,), dtype='i')

file.close() #  Close HDF5 File =================
f.close()
mmap.close() # mmap close ------------------------
```
```
(on windows execution)
Traceback (most recent call last):
  File "C:\Users\heya\vaex-test\hf.py", line 21, in <module>
    f.close()
  File "C:\Users\heya\miniconda3\lib\site-packages\h5py\_hl\files.py", line 466, in close
    self.id._close_open_objects(h5f.OBJ_LOCAL | h5f.OBJ_FILE)
  File "h5py\_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py\_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py\h5f.pyx", line 352, in h5py.h5f.FileID._close_open_objects
RuntimeError: Can't decrement id ref count (unable to extend file properly)
```
H5py or hdf5 driver might be responsible for this bug, but this way we can avoid it .
1. Create/Open hdf5 file (in init function at Writer class)  
2. Open mmap file (in layout method)
3. Close mmap (in close method)
4. Close hdf5 file (in close method)

Please give me any advice for furthering the investigation or better solution.

Cheers.
