### PR TITLE
fix: astropy doesn't like left aligned data

### DIFF
--- a/packages/vaex-astro/vaex/astro/fits.py
+++ b/packages/vaex-astro/vaex/astro/fits.py
@@ -170,7 +170,7 @@ def empty(filename, length, column_names, data_types, data_shapes, ucds, units, 
 			pass
 
 		def write(key, value, comment=""):
-			first_part = "{key:8}= {value:20} / ".format(key=key, value=value)
+			first_part = "{key:8}= {value:>20} / ".format(key=key, value=value)
 			f.write(first_part.encode("ascii"))
 			leftover = 80 - len(first_part)
 			f.write(("{comment:"+str(leftover) +"}").format(comment=comment).encode("ascii"))


### PR DESCRIPTION
Caused CI to fail with the latest astropy (4.3), triggering:
```
OSError: No SIMPLE card found, this file does not appear to be a valid FITS file
```
Introduced in https://github.com/astropy/astropy/pull/10895