### PR TITLE
feat(ml): Adding a simple class for serialization of Keras models

### DIFF
--- a/packages/vaex-ml/vaex/ml/tensorflow.py
+++ b/packages/vaex-ml/vaex/ml/tensorflow.py
@@ -55,11 +55,11 @@ class KerasModel(vaex.ml.state.HasState):
         self.model.save(filename)
         with open(filename, 'rb') as f:
             data = f.read()
-        state['keras_model'] = base64.encodebytes(data).decode('ascii')
+        state['model'] = base64.encodebytes(data).decode('ascii')
         return state
 
     def state_set(self, state, trusted=True):
-        model_data = state.pop('keras_model')
+        model_data = state.pop('model')
         super(KerasModel, self).state_set(state)
 
         data = base64.decodebytes(model_data.encode('ascii'))

--- a/packages/vaex-ml/vaex/ml/tensorflow.py
+++ b/packages/vaex-ml/vaex/ml/tensorflow.py
@@ -1,0 +1,69 @@
+import base64
+import tempfile
+
+import numpy as np
+
+from tensorflow import keras as K
+
+import traitlets
+
+import vaex
+import vaex.serialize
+import vaex.ml.state
+import vaex.ml.generate
+
+
+
+@vaex.serialize.register
+@vaex.ml.generate.register
+class KerasModel(vaex.ml.state.HasState):
+    '''A simple class that makes a Keras model serializable in the Vaex state, as well as enables lazy transformations of the preditions.
+
+    For more infromation on how to use the Keras library, please visit https://keras.io/.
+    '''
+    features = traitlets.List(traitlets.Unicode(), help='List of features to use when applying the KerasModel.')
+    prediction_name = traitlets.Unicode(default_value='keras_prediction', help='The name of the virtual column housing the predictions.')
+    model = traitlets.Any(help='A fitted Kears Model')
+
+    def __call__(self, *args):
+        data2d = np.stack([np.asarray(arg, np.float64) for arg in args], axis=-1)
+        return self.model.predict(data2d)
+
+    def fit(self, df):
+        '''Not implemented: A Placeholder method, put here for potential future developement.
+        '''
+        raise RuntimeError('The `fit` method is not implemented. To satisfy the large number of use-cases and for maximum flexiblity, please fit the model using the `tensorflow.keras` API.')
+
+    def transform(self, df):
+        '''Transform a DataFrame such that it contains the predictions of the KerasModel in form of a virtual column.
+
+        :param df: A vaex DataFrame.
+
+        :return copy: A shallow copy of the DataFrame that includes the KerasModel prediction as a virtual column.
+        :rtype: DataFrame
+        '''
+        copy = df.copy()
+        lazy_function = copy.add_function('keras_prediction_function', self, unique=True)
+        expression = lazy_function(*self.features)
+        copy.add_virtual_column(self.prediction_name, expression, unique=False)
+        return copy
+
+    def state_get(self):
+        state = super(KerasModel, self).state_get()
+
+        filename = tempfile.mktemp(".hdf5")
+        self.model.save(filename)
+        with open(filename, 'rb') as f:
+            data = f.read()
+        state['keras_model'] = base64.encodebytes(data).decode('ascii')
+        return state
+
+    def state_set(self, state, trusted=True):
+        model_data = state.pop('keras_model')
+        super(KerasModel, self).state_set(state)
+
+        data = base64.decodebytes(model_data.encode('ascii'))
+        filename = tempfile.mktemp()
+        with open(filename, 'wb') as f:
+            f.write(data)
+        self.model = K.models.load_model(filename)

--- a/packages/vaex-ml/vaex/ml/tensorflow.py
+++ b/packages/vaex-ml/vaex/ml/tensorflow.py
@@ -32,7 +32,7 @@ class KerasModel(vaex.ml.state.HasState):
     def fit(self, df):
         '''Not implemented: A Placeholder method, put here for potential future developement.
         '''
-        raise RuntimeError('The `fit` method is not implemented. To satisfy the large number of use-cases and for maximum flexiblity, please fit the model using the `tensorflow.keras` API.')
+        raise NotImplementedError('The `fit` method is not implemented. To satisfy the large number of use-cases and for maximum flexiblity, please fit the model using the `tensorflow.keras` API.')
 
     def transform(self, df):
         '''Transform a DataFrame such that it contains the predictions of the KerasModel in form of a virtual column.

--- a/packages/vaex-ml/vaex/ml/tensorflow.py
+++ b/packages/vaex-ml/vaex/ml/tensorflow.py
@@ -23,7 +23,7 @@ class KerasModel(vaex.ml.state.HasState):
     '''
     features = traitlets.List(traitlets.Unicode(), help='List of features to use when applying the KerasModel.')
     prediction_name = traitlets.Unicode(default_value='keras_prediction', help='The name of the virtual column housing the predictions.')
-    model = traitlets.Any(help='A fitted Kears Model')
+    model = traitlets.Any(help='A fitted Keras Model')
 
     def __call__(self, *args):
         data2d = np.stack([np.asarray(arg, np.float64) for arg in args], axis=-1)

--- a/tests/ml/tensorflow_test.py
+++ b/tests/ml/tensorflow_test.py
@@ -1,0 +1,51 @@
+import sys
+import pytest
+pytest.importorskip("tensorflow")
+
+import tensorflow.keras as K
+
+import vaex
+import vaex.ml
+import vaex.ml.tensorflow
+
+
+def test_kears_model(tmpdir, df_iris):
+    df = df_iris
+    copy = df.copy()
+    features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']
+    target = 'class_'
+
+    def create_neural_network():
+        inp = K.layers.Input(shape=(4,), name='input')
+        x = K.layers.Dense(4, activation='relu', name='layer')(inp)
+        x = K.layers.Dense(3, activation='softmax', name='output')(x)
+
+        nn = K.models.Model(inputs=inp, outputs=x)
+
+        nn.compile(optimizer=K.optimizers.RMSprop(learning_rate=0.01),
+                loss=K.losses.categorical_crossentropy,
+                metrics='accuracy')
+
+        return nn
+
+    nn = create_neural_network()
+
+    X = df[features].values
+    y = df[target].values
+    y_enc = K.utils.to_categorical(y)
+    nn.fit(x=X, y=y_enc, validation_split=0.05, epochs=11)
+
+    keras_model = vaex.ml.tensorflow.KerasModel(features=features,
+                                                prediction_name='pred',
+                                                model=nn)
+    df_trans = keras_model.transform(df)
+    assert df_trans.pred.shape == (150, 3)
+
+    state_path = str(tmpdir.join('state.json'))
+    df_trans.state_write(state_path)
+    copy.state_load(state_path)
+
+    assert copy.pred.shape == (150, 3)
+
+
+

--- a/tests/ml/tensorflow_test.py
+++ b/tests/ml/tensorflow_test.py
@@ -9,7 +9,7 @@ import vaex.ml
 import vaex.ml.tensorflow
 
 
-def test_kears_model(tmpdir, df_iris):
+def test_keras_model(tmpdir, df_iris):
     df = df_iris
     copy = df.copy()
     features = ['sepal_width', 'petal_length', 'sepal_length', 'petal_width']


### PR DESCRIPTION
This PR adds a simple class for serialization and lazy predictions of keras models. 

Please see the unit-test for details of intended use. In general it is quite similar to the rest of the model wrappers provided by vaex ML. The main difference is that the `fit` method is not implemented, so one is expected to fit the keras model via the `tensorflow.keras` API. This is done to maintain flexibility of having a wide spectrum of use-cases. 

This PR will be one of several smaller PRs that will eventually supersede #622, which was perhaps a bit of an ambitions step at the time. 