### PR TITLE
✨ support getting i-th element of 2d columns

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2785,3 +2785,9 @@ def stack(arrays, strict=False):
     arrays = [vaex.arrow.numpy_dispatch.unwrap(k) for k in arrays]
     arrays = [vaex.array_types.to_numpy(k) for k in arrays]
     return np.ma.stack(arrays, axis=1)
+
+
+@register_function()
+def getitem(ar, item):
+    slicer = (slice(None), item)
+    return ar.__getitem__(slicer)

--- a/tests/slice_test.py
+++ b/tests/slice_test.py
@@ -74,3 +74,16 @@ def test_slice_negative(df):
     df2 = df[:-1]
     assert df2.x.tolist() == df.x.to_numpy()[:-1].tolist()
     assert len(df2) == len(df)-1
+
+
+def test_getitem():
+    x = np.array([[1, 7], [2, 8], [3, 9]])
+    df = vaex.from_arrays(x=x)
+    assert len(df) == 3
+    assert df.x[:,0].tolist() == [1, 2, 3]
+    assert df.x[:,1].tolist() == [7, 8, 9]
+    assert df.x[:,-1].tolist() == [7, 8, 9]
+
+    assert df.x[1:,0].tolist() == [2, 3]
+    assert df.x[:2,1].tolist() == [7, 8]
+    assert df.x[1:-1,-1].tolist() == [8,]


### PR DESCRIPTION
e.g: `df.x[:,0]`

This will likely conflict (as in merge conflict) with #1447 (cc @mansenfranzen) I've make `__getitem__` nearly the same.