### PR TITLE
🐎 avoid falling back to eval to get the dtype

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -461,7 +461,8 @@ class DataFrame(object):
     def _set(self, expression, progress=False, selection=None, flatten=True, delay=False, unique_limit=None):
         if selection is not None:
             selection = str(selection)
-        task = vaex.tasks.TaskSetCreate(self, str(expression), flatten, unique_limit=unique_limit, selection=selection)
+        expression = _ensure_string_from_expression(expression)
+        task = vaex.tasks.TaskSetCreate(self, expression, flatten, unique_limit=unique_limit, selection=selection)
         task = self.executor.schedule(task)
         return self._delay(delay, task)
 

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import os
 import base64
 import cloudpickle as pickle
@@ -475,11 +476,11 @@ class Expression(with_metaclass(Meta)):
 
     @property
     def dtype(self):
-        return self.df.data_type(self.expression)
+        return self.df.data_type(self)
 
     # TODO: remove this method?
     def data_type(self, array_type=None, axis=0):
-        return self.df.data_type(self.expression, axis=axis)
+        return self.df.data_type(self, axis=axis)
 
     @property
     def shape(self):
@@ -1042,7 +1043,7 @@ class Expression(with_metaclass(Meta)):
         :param bool axis: Axis over which to determine the unique elements (None will flatten arrays or lists)
         :param bool array_type: {array_type}
         """
-        return self.ds.unique(self.expression, dropna=dropna, dropnan=dropnan, dropmissing=dropmissing, selection=selection, array_type=array_type, axis=axis, delay=delay)
+        return self.ds.unique(self, dropna=dropna, dropnan=dropnan, dropmissing=dropmissing, selection=selection, array_type=array_type, axis=axis, delay=delay)
 
     def nunique(self, dropna=False, dropnan=False, dropmissing=False, selection=None, axis=None, delay=False):
         """Counts number of unique values, i.e. `len(df.x.unique()) == df.x.nunique()`.

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -7,6 +7,7 @@ import collections
 import six
 
 import pyarrow as pa
+from vaex.utils import _ensure_string_from_expression
 
 try:
     collections_abc = collections.abc
@@ -103,7 +104,7 @@ class Grouper(BinnerBase):
         self.sort = sort
         self.expression = expression
         # make sure it's an expression
-        self.expression = self.df[str(self.expression)]
+        self.expression = self.df[_ensure_string_from_expression(self.expression)]
         self.label = self.expression._label
         set = df_original._set(self.expression, unique_limit=row_limit)
         keys = set.keys()
@@ -276,9 +277,9 @@ class GroupByBase(object):
         for by_value in by:
             if not isinstance(by_value, BinnerBase):
                 if df.is_category(by_value):
-                    by_value = GrouperCategory(df[str(by_value)], sort=sort, row_limit=row_limit)
+                    by_value = GrouperCategory(df[_ensure_string_from_expression(by_value)], sort=sort, row_limit=row_limit)
                 else:
-                    by_value = Grouper(df[str(by_value)], sort=sort, row_limit=row_limit, df_original=df_original)
+                    by_value = Grouper(df[_ensure_string_from_expression(by_value)], sort=sort, row_limit=row_limit, df_original=df_original)
             self.by.append(by_value)
         if combine is True and  len(self.by) >= 2:
             self.by = [_combine(self.df, self.by, sort=sort, row_limit=row_limit)]

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -770,7 +770,7 @@ def _ensure_string_from_expression(expression):
     elif isinstance(expression, six.string_types):
         return expression
     elif isinstance(expression, vaex.expression.Expression):
-        return expression.expression
+        return expression._label
     else:
         raise ValueError('%r is not of string or Expression type, but %r' % (expression, type(expression)))
 


### PR DESCRIPTION
this avoids df['Invalid identifier'] entering df.data_type()
triggering an evaluation phase