### PR TITLE
CI: few improvements to better the CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -55,13 +55,8 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
         conda activate vaex-dev
-        mamba install -c conda-forge py-xgboost tensorflow
+        mamba install -c conda-forge tensorflow
         # xgboost is not available on windows on conda-forge
-    - name: Extra installs
-      if: matrix.python-version != '3.9' && matrix.python-version != '3.7'
-      run: |
-        conda activate vaex-dev
-        mamba install -y -q --file ci/conda-env-extra.yml
     - name: Extra windows installs
       if: matrix.os == 'windows-latest'
       run: |

--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -1,4 +1,5 @@
 astropy
+catboost
 cython
 fsspec <0.9
 geopandas
@@ -14,7 +15,7 @@ pandas
 pcre
 pip
 python-annoy
-# py-xgboost
+py-xgboost
 pyarrow
 pyqt
 pytest


### PR DESCRIPTION
Few improvements to better the CI (testing, etc..)

- [ ] Adding markers to improve testing speed for local dev (see usage below)
- [ ] Attempt to simplify the github action script

pytest parkers are added in the `pytest.ini` file.
Currently we have one custom marker "slow", to mark tests as slow, so you can choose not to run them during local development for example.

You can mark a test by:
```python

@pytest.mark.slow
def test_something():
    assert x == y
```

Then to run all test *except* those marked as slow, you can do
`pytest tests -m "not slow"`

To run only the slow tests:
`pytest tests -m slow`

@maartenbreddels Please add (or tell me) which ones do you want to be added as slow. I have added some that I know to be quite slow. 
