### PR TITLE
Docs: Keras + Struct docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -139,6 +139,13 @@ Timedelta operations
      :members:
      :special-members:
 
+Struct (arrow) operations
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: vaex.expression.StructOperations
+     :members:
+     :special-members:
+
 Geo operations
 ~~~~~~~~~~~~~~
 

--- a/docs/source/example_io.ipynb
+++ b/docs/source/example_io.ipynb
@@ -1458,7 +1458,7 @@
     "\n",
     "    - DataFrames:\n",
     "    \n",
-    "         - [panads](https://pandas.pydata.org/) DataFrame\n",
+    "         - [pandas](https://pandas.pydata.org/) DataFrame\n",
     "         - [Apache Arrow](https://arrow.apache.org/) Table\n",
     "         - [numpy](https://numpy.org/) arrays\n",
     "         - [Dask](https://dask.org/) arrays\n",
@@ -1467,7 +1467,7 @@
     "\n",
     "    - Expressions:\n",
     "    \n",
-    "         - [panads](https://pandas.pydata.org/) Series\n",
+    "         - [pandas](https://pandas.pydata.org/) Series\n",
     "         - [numpy](https://numpy.org/) array\n",
     "         - [Dask](https://dask.org/) array\n",
     "         - Python list"
@@ -2420,12 +2420,21 @@
    "hash": "500dc3966e7e937a0613915994105d5dcf363e507b58bfdc5ab9493874bc0e2c"
   },
   "kernelspec": {
-   "display_name": "Python 3.7.8 64-bit ('base': conda)",
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": ""
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/tutorial_ml.ipynb
+++ b/docs/source/tutorial_ml.ipynb
@@ -1574,6 +1574,176 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### `Keras` example\n",
+    "\n",
+    "`Keras` is the most popular high-level API to building neural network models with tensorflow as its backend. Neural networks can have very diverse and complicated architectures, and their training loops can be both simple and sophisticated. This is why, at least for now, we leave the users to train their `keras` models as they normaly would, and in `vaex-ml` provides a simple wrapper for serialization and lazy evaluation of those models. In addition, `vaex-ml` also provides a convenience method to turn a DataFrame into a generator, suitable for training of `Keras` models. See the example below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-08-14 23:47:55.800260: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:55.800282: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recommended \"steps_per_epoch\" arg: 516.0\n",
+      "Recommended \"steps_per_epoch\" arg: 65.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-08-14 23:47:57.111408: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:937] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2021-08-14 23:47:57.111910: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.111974: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcublas.so.11'; dlerror: libcublas.so.11: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.112032: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcublasLt.so.11'; dlerror: libcublasLt.so.11: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.112093: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcufft.so.10'; dlerror: libcufft.so.10: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.112150: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcurand.so.10'; dlerror: libcurand.so.10: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.112206: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcusolver.so.11'; dlerror: libcusolver.so.11: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.112261: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcusparse.so.11'; dlerror: libcusparse.so.11: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.112317: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudnn.so.8'; dlerror: libcudnn.so.8: cannot open shared object file: No such file or directory\n",
+      "2021-08-14 23:47:57.112327: W tensorflow/core/common_runtime/gpu/gpu_device.cc:1835] Cannot dlopen some GPU libraries. Please make sure the missing libraries mentioned above are installed properly if you would like to use GPU. Follow the guide at https://www.tensorflow.org/install/gpu for how to download and setup the required libraries for your platform.\n",
+      "Skipping registering GPU devices...\n",
+      "2021-08-14 23:47:57.112682: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/11\n",
+      " 11/516 [..............................] - ETA: 2s - loss: 1.7922  "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-08-14 23:47:57.326751: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:185] None of the MLIR Optimization Passes are enabled (registered 2)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.2172 - val_loss: 0.1724\n",
+      "Epoch 2/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1736 - val_loss: 0.1715\n",
+      "Epoch 3/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1729 - val_loss: 0.1705\n",
+      "Epoch 4/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1725 - val_loss: 0.1707\n",
+      "Epoch 5/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1722 - val_loss: 0.1708\n",
+      "Epoch 6/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1720 - val_loss: 0.1701\n",
+      "Epoch 7/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1718 - val_loss: 0.1697\n",
+      "Epoch 8/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1717 - val_loss: 0.1706\n",
+      "Epoch 9/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1715 - val_loss: 0.1698\n",
+      "Epoch 10/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1714 - val_loss: 0.1702\n",
+      "Epoch 11/11\n",
+      "516/516 [==============================] - 3s 6ms/step - loss: 0.1713 - val_loss: 0.1701\n",
+      "INFO:tensorflow:Assets written to: /tmp/tmp14gsptzz/assets\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-08-14 23:48:31.519641: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>#                            </th><th style=\"text-align: right;\">  id</th><th style=\"text-align: right;\">        x</th><th style=\"text-align: right;\">        y</th><th style=\"text-align: right;\">         z</th><th style=\"text-align: right;\">       vx</th><th style=\"text-align: right;\">      vy</th><th style=\"text-align: right;\">       vz</th><th style=\"text-align: right;\">        E</th><th style=\"text-align: right;\">      L</th><th style=\"text-align: right;\">      Lz</th><th style=\"text-align: right;\">      FeH</th><th style=\"text-align: right;\">  minmax_scaled_x</th><th style=\"text-align: right;\">  minmax_scaled_y</th><th style=\"text-align: right;\">  minmax_scaled_z</th><th style=\"text-align: right;\">  minmax_scaled_vx</th><th style=\"text-align: right;\">  minmax_scaled_vy</th><th style=\"text-align: right;\">  minmax_scaled_vz</th><th>keras_pred                        </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td><i style='opacity: 0.6'>0</i></td><td style=\"text-align: right;\">  23</td><td style=\"text-align: right;\"> 0.137403</td><td style=\"text-align: right;\">-5.07974 </td><td style=\"text-align: right;\"> 1.40165  </td><td style=\"text-align: right;\"> 111.828 </td><td style=\"text-align: right;\"> 62.8776</td><td style=\"text-align: right;\"> -88.121 </td><td style=\"text-align: right;\">-134786  </td><td style=\"text-align: right;\">700.236</td><td style=\"text-align: right;\"> 576.698</td><td style=\"text-align: right;\">-1.7935  </td><td style=\"text-align: right;\">         0.375163</td><td style=\"text-align: right;\">         0.72055 </td><td style=\"text-align: right;\">         0.397008</td><td style=\"text-align: right;\">          0.570648</td><td style=\"text-align: right;\">          0.56065 </td><td style=\"text-align: right;\">          0.414253</td><td>array([-1.6143968], dtype=float32)</td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>1</i></td><td style=\"text-align: right;\">  31</td><td style=\"text-align: right;\">-1.95543 </td><td style=\"text-align: right;\">-0.840676</td><td style=\"text-align: right;\"> 1.26239  </td><td style=\"text-align: right;\">-259.282 </td><td style=\"text-align: right;\"> 20.8279</td><td style=\"text-align: right;\">-148.457 </td><td style=\"text-align: right;\">-134990  </td><td style=\"text-align: right;\">676.813</td><td style=\"text-align: right;\">-258.7  </td><td style=\"text-align: right;\">-0.623007</td><td style=\"text-align: right;\">         0.365132</td><td style=\"text-align: right;\">         0.738746</td><td style=\"text-align: right;\">         0.395427</td><td style=\"text-align: right;\">          0.266912</td><td style=\"text-align: right;\">          0.5249  </td><td style=\"text-align: right;\">          0.357964</td><td>array([-1.509573], dtype=float32) </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>2</i></td><td style=\"text-align: right;\">  22</td><td style=\"text-align: right;\"> 2.33077 </td><td style=\"text-align: right;\">-0.570014</td><td style=\"text-align: right;\"> 0.761285 </td><td style=\"text-align: right;\"> -53.4566</td><td style=\"text-align: right;\">-43.377 </td><td style=\"text-align: right;\"> -71.3196</td><td style=\"text-align: right;\">-177062  </td><td style=\"text-align: right;\">196.209</td><td style=\"text-align: right;\">-131.573</td><td style=\"text-align: right;\">-0.889463</td><td style=\"text-align: right;\">         0.385676</td><td style=\"text-align: right;\">         0.739908</td><td style=\"text-align: right;\">         0.389737</td><td style=\"text-align: right;\">          0.43537 </td><td style=\"text-align: right;\">          0.470313</td><td style=\"text-align: right;\">          0.429927</td><td>array([-1.5752358], dtype=float32)</td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>3</i></td><td style=\"text-align: right;\">  26</td><td style=\"text-align: right;\"> 0.777881</td><td style=\"text-align: right;\">-2.83258 </td><td style=\"text-align: right;\"> 0.0797214</td><td style=\"text-align: right;\"> 256.427 </td><td style=\"text-align: right;\">202.451 </td><td style=\"text-align: right;\"> -12.76  </td><td style=\"text-align: right;\">-125176  </td><td style=\"text-align: right;\">884.581</td><td style=\"text-align: right;\"> 883.833</td><td style=\"text-align: right;\">-1.65996 </td><td style=\"text-align: right;\">         0.378233</td><td style=\"text-align: right;\">         0.730196</td><td style=\"text-align: right;\">         0.381998</td><td style=\"text-align: right;\">          0.688994</td><td style=\"text-align: right;\">          0.679314</td><td style=\"text-align: right;\">          0.484558</td><td>array([-1.6558373], dtype=float32)</td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>4</i></td><td style=\"text-align: right;\">   1</td><td style=\"text-align: right;\"> 3.37429 </td><td style=\"text-align: right;\"> 2.62885 </td><td style=\"text-align: right;\">-0.797169 </td><td style=\"text-align: right;\"> 300.697 </td><td style=\"text-align: right;\">153.772 </td><td style=\"text-align: right;\">  83.9173</td><td style=\"text-align: right;\"> -97150.4</td><td style=\"text-align: right;\">681.868</td><td style=\"text-align: right;\">-271.616</td><td style=\"text-align: right;\">-1.6496  </td><td style=\"text-align: right;\">         0.390678</td><td style=\"text-align: right;\">         0.753639</td><td style=\"text-align: right;\">         0.372041</td><td style=\"text-align: right;\">          0.725228</td><td style=\"text-align: right;\">          0.637928</td><td style=\"text-align: right;\">          0.574749</td><td>array([-1.6719546], dtype=float32)</td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "  #    id          x          y           z         vx        vy         vz          E        L        Lz        FeH    minmax_scaled_x    minmax_scaled_y    minmax_scaled_z    minmax_scaled_vx    minmax_scaled_vy    minmax_scaled_vz  keras_pred\n",
+       "  0    23   0.137403  -5.07974    1.40165     111.828    62.8776   -88.121   -134786    700.236   576.698  -1.7935             0.375163           0.72055            0.397008            0.570648            0.56065             0.414253  array([-1.6143968], dtype=float32)\n",
+       "  1    31  -1.95543   -0.840676   1.26239    -259.282    20.8279  -148.457   -134990    676.813  -258.7    -0.623007           0.365132           0.738746           0.395427            0.266912            0.5249              0.357964  array([-1.509573], dtype=float32)\n",
+       "  2    22   2.33077   -0.570014   0.761285    -53.4566  -43.377    -71.3196  -177062    196.209  -131.573  -0.889463           0.385676           0.739908           0.389737            0.43537             0.470313            0.429927  array([-1.5752358], dtype=float32)\n",
+       "  3    26   0.777881  -2.83258    0.0797214   256.427   202.451    -12.76    -125176    884.581   883.833  -1.65996            0.378233           0.730196           0.381998            0.688994            0.679314            0.484558  array([-1.6558373], dtype=float32)\n",
+       "  4     1   3.37429    2.62885   -0.797169    300.697   153.772     83.9173   -97150.4  681.868  -271.616  -1.6496             0.390678           0.753639           0.372041            0.725228            0.637928            0.574749  array([-1.6719546], dtype=float32)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import vaex.ml.tensorflow\n",
+    "import tensorflow.keras as K\n",
+    "\n",
+    "df = vaex.example()\n",
+    "df_train, df_valid, df_test = df.split_random([0.8, 0.1, 0.1], random_state=42)\n",
+    "\n",
+    "features = ['x', 'y', 'z', 'vx', 'vy', 'vz']\n",
+    "target = 'FeH'\n",
+    "\n",
+    "# Scaling the features\n",
+    "df_train = df_train.ml.minmax_scaler(features=features)\n",
+    "features = df_train.get_column_names(regex='^minmax_')\n",
+    "\n",
+    "# Apply preprocessing to the validation\n",
+    "state_prep = df_train.state_get()\n",
+    "df_valid.state_set(state_prep)\n",
+    "\n",
+    "# Generators for the train and validation sets\n",
+    "gen_train = df_train.ml.tensorflow.to_keras_generator(features=features, target=target, batch_size=512)\n",
+    "gen_valid = df_valid.ml.tensorflow.to_keras_generator(features=features, target=target, batch_size=512)\n",
+    "\n",
+    "# Create and fit a simple Sequential Keras model\n",
+    "nn_model = K.Sequential()\n",
+    "nn_model.add(K.layers.Dense(3, activation='tanh'))\n",
+    "nn_model.add(K.layers.Dense(1, activation='linear'))\n",
+    "nn_model.compile(optimizer='sgd', loss='mse')\n",
+    "nn_model.fit(x=gen_train, validation_data=gen_valid, epochs=11, steps_per_epoch=516, validation_steps=65)\n",
+    "\n",
+    "# Serialize the model\n",
+    "keras_model = vaex.ml.tensorflow.KerasModel(features=features, prediction_name='keras_pred', model=nn_model)\n",
+    "df_train = keras_model.transform(df_train)\n",
+    "\n",
+    "# Apply all the transformations to the test set\n",
+    "state = df_train.state_get()\n",
+    "df_test.state_set(state)\n",
+    "\n",
+    "# Preview the results\n",
+    "df_test.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### `River` example\n",
     "\n",
     "`River` is an up-and-coming library for online learning, and provides a variety of models that can learn incrementally. While most of the `river` models currently support per-sample training, few do support mini-batch training which is extremely fast - a great synergy to do machine learning with vaex."
@@ -1581,7 +1751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-13T11:12:20.713420Z",
@@ -1643,7 +1813,7 @@
        "200,999,999  6.2             2.9            4.3             1.3            1         1.2171097577656713"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1682,7 +1852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:19.919524Z",
@@ -1727,7 +1897,7 @@
        "119  6.2             2.9            4.3             1.3            1         3.3076923076923075  2.137931034482759   -1.2988229958748452  0.06960434514054464  -0.0012167985718341268  -0.24072255219180883  0.05282732890885841     -0.032459999314411514"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1759,7 +1929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:22.228285Z",
@@ -1804,7 +1974,7 @@
        "119  6.2             2.9            4.3             1.3            1         3.3076923076923075  2.137931034482759   -1.2988229958748452  0.06960434514054464  -0.0012167985718341268  -0.24072255219180883  0.05282732890885841     -0.032459999314411514   1"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1833,7 +2003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:25.031158Z",
@@ -1878,7 +2048,7 @@
        "29   6.9             3.2            5.7             2.3            2         2.4782608695652177  2.15625             -2.963110301521378   -0.924626055589704    0.44833006106219797   0.20994670504662372   -0.2012725506779131   -0.018900414287719353  2"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1899,7 +2069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:27.647113Z",
@@ -1944,7 +2114,7 @@
        "29   6.9             3.2            5.7             2.3            2         2.4782608695652177  2.15625             -2.963110301521378   -0.924626055589704    0.44833006106219797   0.20994670504662372   -0.2012725506779131   -0.018900414287719353  2"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/packages/vaex-ml/vaex/ml/tensorflow.py
+++ b/packages/vaex-ml/vaex/ml/tensorflow.py
@@ -117,6 +117,35 @@ class KerasModel(vaex.ml.state.HasState):
     '''A simple class that makes a Keras model serializable in the Vaex state, as well as enables lazy transformations of the preditions.
 
     For more infromation on how to use the Keras library, please visit https://keras.io/.
+
+    Example:
+
+    >>> import vaex
+    >>> import vaex.ml.tensorflow
+    >>> import tensorflow.keras as K
+
+    >>> df = vaex.example()
+    >>> df_train, df_test = df.ml.train_test_split(0.2)
+
+    >>> features = ['vx', 'vy', 'vz']
+    >>> target = 'FeH'
+
+    >>> gen_train = df_train.ml.tensorflow.to_keras_generator(features=features, target=target, batch_size=512)
+    Recommended "steps_per_epoch" arg: 516.0
+
+    >>> nn_model = K.Sequential()
+    >>> nn_model.add(K.layers.Dense(3, activation='tanh'))
+    >>> nn_model.add(K.layers.Dense(1, activation='linear'))
+    >>> nn_model.compile(optimizer='sgd', loss='mse')
+    >>> nn_model.fit(x=gen_train, epochs=11, steps_per_epoch=516, verbose=0)
+
+    >>> keras_model = vaex.ml.tensorflow.KerasModel(features=features, prediction_name='pred', model=nn_model)
+    >>> df_test = keras_model.transform(df_test)
+    >>> print(df_test.head(3)['vx', 'vy', 'vz', 'FeH', 'pred'])
+    #         vx       vy         vz       FeH  pred
+    0   301.155   174.059   27.4275   -1.00539  array([-1.5861175], dtype=float32)
+    1  -195       170.472  142.53     -1.70867  array([-1.6035867], dtype=float32)
+    2   -48.6342  171.647   -2.07944  -1.83361  array([-1.5978462], dtype=float32)
     '''
     features = traitlets.List(traitlets.Unicode(), help='List of features to use when applying the KerasModel.')
     prediction_name = traitlets.Unicode(default_value='keras_prediction', help='The name of the virtual column housing the predictions.')


### PR DESCRIPTION
Small update to the documentation pages:

- Added the `struct` methods to the API documentation
- Added a `Keras` example to the documentation
- Added a simplified example in the docstrings of `ml.tensorflow.KerasModel`
- Fixed typo found by #1492 

To do: probably later on in a separate PR, we should update the main tutorial, or gave an additional page explaining the usage of the arrow `struct` types. 