### PR TITLE
ML metrics

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -410,19 +410,6 @@ Clustering
 Metrics
 ~~~~~~~
 
-.. autosummary::
-
-     vaex.ml.metrics.DataFrameAccessorMetrics.accuracy_score
-     vaex.ml.metrics.DataFrameAccessorMetrics.precision_score
-     vaex.ml.metrics.DataFrameAccessorMetrics.recall_score
-     vaex.ml.metrics.DataFrameAccessorMetrics.f1_score
-     vaex.ml.metrics.DataFrameAccessorMetrics.confusion_matrix
-     vaex.ml.metrics.DataFrameAccessorMetrics.precision_recall_fscore
-     vaex.ml.metrics.DataFrameAccessorMetrics.matthews_correlation_coefficient
-     vaex.ml.metrics.DataFrameAccessorMetrics.classification_report
-     vaex.ml.metrics.DataFrameAccessorMetrics.mean_absolute_error
-     vaex.ml.metrics.DataFrameAccessorMetrics.mean_squared_error
-     vaex.ml.metrics.DataFrameAccessorMetrics.r2_score
 
 .. autoclass:: vaex.ml.metrics.DataFrameAccessorMetrics
      :members:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -336,31 +336,7 @@ Machine learning with vaex.ml
 See the `ML tutorial <tutorial_ml.ipynb>`_ an introduction, and the `ML examples <examples.rst>`_ for more advanced usage.
 
 
-Scikit-learn
-~~~~~~~~~~~~
-
-.. autosummary::
-
-    vaex.ml.sklearn.IncrementalPredictor
-    vaex.ml.sklearn.Predictor
-
-.. automodule:: vaex.ml.sklearn
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-Clustering
-~~~~~~~~~~
-
-.. autosummary::
-
-    vaex.ml.cluster.KMeans
-
-.. autoclass:: vaex.ml.cluster.KMeans
-     :members:
-
-Transformers/encoders
+Transformers & Encoders
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
@@ -420,6 +396,52 @@ Transformers/encoders
      :members:
 
 
+Clustering
+~~~~~~~~~~
+
+.. autosummary::
+
+    vaex.ml.cluster.KMeans
+
+.. autoclass:: vaex.ml.cluster.KMeans
+     :members:
+
+
+Metrics
+~~~~~~~
+
+.. autosummary::
+
+     vaex.ml.metrics.DataFrameAccessorMetrics.accuracy_score
+     vaex.ml.metrics.DataFrameAccessorMetrics.precision_score
+     vaex.ml.metrics.DataFrameAccessorMetrics.recall_score
+     vaex.ml.metrics.DataFrameAccessorMetrics.f1_score
+     vaex.ml.metrics.DataFrameAccessorMetrics.confusion_matrix
+     vaex.ml.metrics.DataFrameAccessorMetrics.precision_recall_fscore
+     vaex.ml.metrics.DataFrameAccessorMetrics.matthews_correlation_coefficient
+     vaex.ml.metrics.DataFrameAccessorMetrics.classification_report
+     vaex.ml.metrics.DataFrameAccessorMetrics.mean_absolute_error
+     vaex.ml.metrics.DataFrameAccessorMetrics.mean_squared_error
+     vaex.ml.metrics.DataFrameAccessorMetrics.r2_score
+
+.. autoclass:: vaex.ml.metrics.DataFrameAccessorMetrics
+     :members:
+
+
+Scikit-learn
+~~~~~~~~~~~~
+
+.. autosummary::
+
+    vaex.ml.sklearn.IncrementalPredictor
+    vaex.ml.sklearn.Predictor
+
+.. automodule:: vaex.ml.sklearn
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Boosted trees
 ~~~~~~~~~~~~~
 
@@ -439,6 +461,20 @@ Boosted trees
 .. autoclass:: vaex.ml.catboost.CatBoostModel
      :members:
 
+Tensorflow
+~~~~~~~~~~
+
+.. autosummary::
+
+     vaex.ml.tensorflow.KerasModel
+
+.. autoclass:: vaex.ml.tensorflow.KerasModel
+     :members:
+
+.. autoclass:: vaex.ml.tensorflow.DataFrameAccessorTensorflow
+     :members:
+
+
 Incubator/experimental
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -448,4 +484,7 @@ These models are in the incubator phase and may disappear in the future
 ..      :members:
 
 .. autoclass:: vaex.ml.incubator.annoy.ANNOYModel
+     :members:
+
+.. autoclass:: vaex.ml.incubator.river.RiverModel
      :members:

--- a/docs/source/tutorial_ml.ipynb
+++ b/docs/source/tutorial_ml.ipynb
@@ -1843,6 +1843,82 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Metrics\n",
+    "\n",
+    "`vaex-ml` also provides several of the most common evaluation metrics for classification and regression tasks. These metrics are implemented in `vaex-ml` and thus are evaluated out-of-core, so you do not need to materialize the target and predicted columns. \n",
+    "\n",
+    "Here is a list of the currently supported metrics:\n",
+    "\n",
+    "- Classification (binary, and macro-average for multiclass problems):\n",
+    "    - Accuracy\n",
+    "    - Precision\n",
+    "    - Recall\n",
+    "    - F1-score\n",
+    "    - Confusion matrix\n",
+    "    - Classification report (a convenience method, which prints out the accuracy, precision, recall, and F1-score at the same time)\n",
+    "    - Matthews Correlation Coeficient\n",
+    "- Regression\n",
+    "    - Mean Absolute Error\n",
+    "    - Mean Squared Error\n",
+    "    - R<sup>2</sup> Correlation Score\n",
+    "\n",
+    "Here is a simple example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "        Classification report:\n",
+      "\n",
+      "        Accuracy:  0.933\n",
+      "        Precision: 0.928\n",
+      "        Recall:    0.928\n",
+      "        F1:        0.928\n",
+      "        \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jovan/vaex/packages/vaex-core/vaex/dataframe.py:5516: UserWarning: It seems your column class_ is already ordinal encoded (values between 0 and 2), automatically switching to use df.categorize\n",
+      "  warnings.warn(f'It seems your column {column} is already ordinal encoded (values between {min_value} and {max_value}), automatically switching to use df.categorize')\n",
+      "/home/jovan/vaex/packages/vaex-core/vaex/dataframe.py:5516: UserWarning: It seems your column pred is already ordinal encoded (values between 0 and 2), automatically switching to use df.categorize\n",
+      "  warnings.warn(f'It seems your column {column} is already ordinal encoded (values between {min_value} and {max_value}), automatically switching to use df.categorize')\n"
+     ]
+    }
+   ],
+   "source": [
+    "import vaex.ml.metrics\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "df = vaex.ml.datasets.load_iris()\n",
+    "df_train, df_test = df.split_random([0.8, 0.2], random_state=55)\n",
+    "\n",
+    "features = ['petal_length', 'petal_width', 'sepal_length', 'sepal_width']\n",
+    "target = 'class_'\n",
+    "\n",
+    "model = LogisticRegression(random_state=42)\n",
+    "vaex_model = Predictor(features=features, target=target, model=model, prediction_name='pred')\n",
+    "\n",
+    "vaex_model.fit(df=df_train)\n",
+    "\n",
+    "df_test = vaex_model.transform(df_test)\n",
+    "\n",
+    "print(df_test.ml.metrics.classification_report(df_test.class_, df_test.pred, average='macro'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## State transfer - pipelines made easy\n",
     "\n",
     "Each `vaex` DataFrame consists of two parts: _data_ and _state_. The _data_ is immutable, and any operation such as filtering, adding new columns, or applying transformers or predictive models just modifies the _state_. This is extremely powerful concept and can completely redefine how we imagine machine learning pipelines. \n",
@@ -1852,7 +1928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:19.919524Z",
@@ -1897,7 +1973,7 @@
        "119  6.2             2.9            4.3             1.3            1         3.3076923076923075  2.137931034482759   -1.2988229958748452  0.06960434514054464  -0.0012167985718341268  -0.24072255219180883  0.05282732890885841     -0.032459999314411514"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1929,7 +2005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:22.228285Z",
@@ -1974,7 +2050,7 @@
        "119  6.2             2.9            4.3             1.3            1         3.3076923076923075  2.137931034482759   -1.2988229958748452  0.06960434514054464  -0.0012167985718341268  -0.24072255219180883  0.05282732890885841     -0.032459999314411514   1"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2003,7 +2079,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:25.031158Z",
@@ -2048,7 +2124,7 @@
        "29   6.9             3.2            5.7             2.3            2         2.4782608695652177  2.15625             -2.963110301521378   -0.924626055589704    0.44833006106219797   0.20994670504662372   -0.2012725506779131   -0.018900414287719353  2"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2069,7 +2145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-07-14T16:10:27.647113Z",
@@ -2114,7 +2190,7 @@
        "29   6.9             3.2            5.7             2.3            2         2.4782608695652177  2.15625             -2.963110301521378   -0.924626055589704    0.44833006106219797   0.20994670504662372   -0.2012725506779131   -0.018900414287719353  2"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/packages/vaex-ml/setup.py
+++ b/packages/vaex-ml/setup.py
@@ -27,5 +27,6 @@ setup(name=name + '-ml',
       include_package_data=True,
       zip_safe=False,
       entry_points={'vaex.dataframe.accessor': ['ml = vaex.ml:DataFrameAccessorML',
-                                                'ml.tensorflow = vaex.ml.tensorflow:DataFrameAccessorTensorflow']}
+                                                'ml.tensorflow = vaex.ml.tensorflow:DataFrameAccessorTensorflow',
+                                                'ml.metrics = vaex.ml.metrics:DataFrameAccessorMetrics']}
 )

--- a/packages/vaex-ml/vaex/ml/incubator/river.py
+++ b/packages/vaex-ml/vaex/ml/incubator/river.py
@@ -28,6 +28,7 @@ class RiverModel(state.HasState):
     method is evaluated lazily, and no memory copies are made.
 
     Example:
+
     >>> import vaex
     >>> import vaex.ml
     >>> from vaex.ml.incubator.river import RiverModel

--- a/packages/vaex-ml/vaex/ml/metrics.py
+++ b/packages/vaex-ml/vaex/ml/metrics.py
@@ -25,6 +25,7 @@ class DataFrameAccessorMetrics():
         :returns: The accuracy score.
 
         Example:
+
         >>> import vaex
         >>> import vaex.ml.metrics
         >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0], y_pred=[1, 0, 0, 1, 1])

--- a/packages/vaex-ml/vaex/ml/metrics.py
+++ b/packages/vaex-ml/vaex/ml/metrics.py
@@ -11,6 +11,13 @@ def ensure_string_arguments(*args):
 
 
 class DataFrameAccessorMetrics():
+    '''Common metrics for evaluating machine learning tasks.
+
+    This DataFrame Accessor contains a number of common machine learning evaluation metrics.
+    The idea is that the metrics can be evaluated out-of-core, and without the need to materialize the target and predicted columns.
+
+    See https://vaex.io/docs/api.html#metrics for a list of supported evaluation metrics.
+    '''
     def __init__(self, ml):
         self.ml = ml
         self.df = self.ml.df
@@ -88,8 +95,10 @@ class DataFrameAccessorMetrics():
         if average == 'binary':
             assert set(self.df[y_true].unique()) == {0, 1}, '`y_true` must be encoded in 1s and 0s'
             assert set(self.df[y_pred].unique()) == {0, 1}, '`y_pred` must be encoded in 1s and 0s'
-            precision = self.df.count(selection=f'({y_true}==1) & ({y_pred}==1)') / self.df.count(selection=f'{y_pred}==1')
-            recall = self.df.count(selection=f'({y_true}==1) & ({y_pred}==1)') / self.df.count(selection=f'{y_true}==1')
+            selections = [f'({y_true}==1) & ({y_pred}==1)', f'{y_pred}==1', f'{y_true}==1']
+            count_y_true_y_pred, count_y_pred, count_y_true = self.df.count(selection=selections)
+            precision = count_y_true_y_pred / count_y_pred
+            recall = count_y_true_y_pred / count_y_true
             f1 = 2 * (precision * recall) / (precision + recall)
 
         else:

--- a/packages/vaex-ml/vaex/ml/metrics.py
+++ b/packages/vaex-ml/vaex/ml/metrics.py
@@ -1,0 +1,318 @@
+import numpy as np
+
+import vaex
+
+
+def ensure_string_arguments(*args):
+    result = []
+    for arg in args:
+        result.append(vaex.utils._ensure_string_from_expression(arg))
+    return result
+
+
+class DataFrameAccessorMetrics():
+    def __init__(self, ml):
+        self.ml = ml
+        self.df = self.ml.df
+
+    @vaex.docstrings.docsubst
+    def accuracy_score(self, y_true, y_pred):
+        '''
+        Calculates the accuracy classification score.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :returns: The accuracy score.
+
+        Example:
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0], y_pred=[1, 0, 0, 1, 1])
+        >>> df.ml.metrics.accuracy_score(df.y_true, df.y_pred)
+          0.6
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        return (self.df[y_true] == self.df[y_pred]).sum() / len(self.df)
+
+    @vaex.docstrings.docsubst
+    def confusion_matrix(self, y_true, y_pred, array_type=None):
+        '''
+        Docstrings
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :param array_type: {array_type}
+        :returns: The confusion matrix
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0, 1], y_pred=[1, 0, 0, 1, 1, 1])
+        >>> df.ml.metrics.confusion_matrix(df.y_true, df.y_pred)
+          array([[1, 1],
+                 [1, 3]]
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        df = self.df.copy()  # To not modify the original DataFrame
+
+        if df.is_category(y_true) is not True:
+            df = df.ordinal_encode(y_true)
+        if df.is_category(y_pred) is not True:
+            df = df.ordinal_encode(y_pred)
+
+        return df.count(binby=(y_pred, y_true), array_type=array_type).T
+
+    @vaex.docstrings.docsubst
+    def precision_recall_fscore(self, y_true, y_pred, average='binary'):
+        '''Calculates the precision, recall and f1 score for a classification problem.
+
+        These metrics are defined as follows:
+        - precision = tp / (tp + fp)
+        - recall = tp / (tp + fn)
+        - f1 = tp / (tp + 0.5 * (fp + fn))
+        where "tp" are true positives, "fp" are false positives, and "fn" are false negatives.
+
+        For a binary classification problem, `average` should be set to "binary".
+        In this case it is assumed that the input data is encoded in 0 and 1 integers, where the class of importance is labeled as 1.
+
+        For multiclass classification problems, `average` should be set to "macro".
+        The "macro" average is the unweighted mean of a metric for each label.
+        For multiclass problems the data can be ordinal encoded, but class names are also supported.
+
+        Example:
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        assert average in ['binary', 'macro']
+
+        if average == 'binary':
+            assert set(self.df[y_true].unique()) == {0, 1}, '`y_true` must be encoded in 1s and 0s'
+            assert set(self.df[y_pred].unique()) == {0, 1}, '`y_pred` must be encoded in 1s and 0s'
+            precision = self.df.count(selection=f'({y_true}==1) & ({y_pred}==1)') / self.df.count(selection=f'{y_pred}==1')
+            recall = self.df.count(selection=f'({y_true}==1) & ({y_pred}==1)') / self.df.count(selection=f'{y_true}==1')
+            f1 = 2 * (precision * recall) / (precision + recall)
+
+        else:
+            C = self.confusion_matrix(y_true=y_true, y_pred=y_pred, array_type='numpy')
+            precision_array = (np.diag(C) / np.sum(C, axis=0))
+            recall_array = (np.diag(C) / np.sum(C, axis=1))
+            f1_array = 2 * (precision_array * recall_array) / (precision_array + recall_array)
+            precision = precision_array.mean()
+            recall = recall_array.mean()
+            f1 = f1_array.mean()
+
+        return precision, recall, f1
+
+    @vaex.docstrings.docsubst
+    def precision_score(self, y_true, y_pred, average='binary'):
+        '''Calculates the precision classification score.
+
+        For a binary classification problem, `average` should be set to "binary".
+        In this case it is assumed that the input data is encoded in 0 and 1 integers, where the class of importance is labeled as 1.
+
+        For multiclass classification problems, `average` should be set to "macro".
+        The "macro" average is the unweighted mean of a metric for each label.
+        For multiclass problems the data can be ordinal encoded, but class names are also supported.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :param average: Should be either 'binary' or 'macro'.
+        :returns: The precision score
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0, 1], y_pred=[1, 0, 0, 1, 1, 1])
+        >>> df.ml.metrics.precision_score(df.y_true, df.y_pred)
+          0.75
+        '''
+
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        precision, _, _ = self.precision_recall_fscore(y_true, y_pred, average=average)
+        return precision
+
+    @vaex.docstrings.docsubst
+    def recall_score(self, y_true, y_pred, average='binary'):
+        '''
+        Calculates the recall classification score.
+
+        For a binary classification problem, `average` should be set to "binary".
+        In this case it is assumed that the input data is encoded in 0 and 1 integers, where the class of importance is labeled as 1.
+
+        For multiclass classification problems, `average` should be set to "macro".
+        The "macro" average is the unweighted mean of a metric for each label.
+        For multiclass problems the data can be ordinal encoded, but class names are also supported.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :param average: Should be either 'binary' or 'macro'.
+        :returns: The recall score
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0, 1], y_pred=[1, 0, 0, 1, 1, 1])
+        >>> df.ml.metrics.recall_score(df.y_true, df.y_pred)
+          0.75
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        _, recall, _ = self.precision_recall_fscore(y_true, y_pred, average=average)
+        return recall
+
+    def f1_score(self, y_true, y_pred, average='binary'):
+        '''Calculates the F1 score.
+
+        This is the harmonic average between the precision and the recall.
+
+        For a binary classification problem, `average` should be set to "binary".
+        In this case it is assumed that the input data is encoded in 0 and 1 integers, where the class of importance is labeled as 1.
+
+        For multiclass classification problems, `average` should be set to "macro".
+        The "macro" average is the unweighted mean of a metric for each label.
+        For multiclass problems the data can be ordinal encoded, but class names are also supported.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :param average: Should be either 'binary' or 'macro'.
+        :returns: The recall score
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0, 1], y_pred=[1, 0, 0, 1, 1, 1])
+        >>> df.ml.metrics.recall_score(df.y_true, df.y_pred)
+          0.75
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        _, _, f1 = self.precision_recall_fscore(y_true, y_pred, average=average)
+        return f1
+
+    def matthews_correlation_coefficient(self, y_true, y_pred):
+        '''Calculates the Matthews correlation coefficient.
+
+        This metric can be used for both binary and multiclass classification problems.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :returns: The Matthews correlation coefficient.
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0, 1], y_pred=[1, 0, 0, 1, 1, 1])
+        >>> df.ml.metrics.matthews_correlation_coefficient(df.y_true, df.y_pred)
+          0.25
+        '''
+        C = self.confusion_matrix(y_true=y_true, y_pred=y_pred)
+        # This is from scikit-learn
+        t_sum = C.sum(axis=1, dtype=np.float64)
+        p_sum = C.sum(axis=0, dtype=np.float64)
+        n_correct = np.trace(C, dtype=np.float64)
+        n_samples = p_sum.sum()
+        cov_ytyp = n_correct * n_samples - np.dot(t_sum, p_sum)
+        cov_ypyp = n_samples ** 2 - np.dot(p_sum, p_sum)
+        cov_ytyt = n_samples ** 2 - np.dot(t_sum, t_sum)
+
+        if cov_ypyp * cov_ytyt == 0:
+            return 0.0
+        else:
+            return cov_ytyp / np.sqrt(cov_ytyt * cov_ypyp)
+
+    @vaex.docstrings.docsubst
+    def classification_report(self, y_true, y_pred, average='binary', decimals=3):
+        '''Returns a text report showing the main classification metrics
+
+        The accuracy, precision, recall, and F1-score are shown.
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0, 1], y_pred=[1, 0, 0, 1, 1, 1])
+        >>> report = df.ml.metrics.classification_report(df.y_true, df.y_pred)
+        >>> print(report)
+        >>> print(report)
+            Classification report:
+
+            Accuracy:  0.667
+            Precision: 0.75
+            Recall:    0.75
+            F1:        0.75
+        '''
+        accuracy_score = self.accuracy_score(y_true=y_true, y_pred=y_pred)
+        precision_score, recall_score, f1_score = self.precision_recall_fscore(y_true=y_true, y_pred=y_pred, average=average)
+        report = f'''
+        Classification report:
+
+        Accuracy:  {accuracy_score:.{decimals}}
+        Precision: {precision_score:.{decimals}}
+        Recall:    {recall_score:.{decimals}}
+        F1:        {f1_score:.{decimals}}
+        '''
+        return report
+
+    @vaex.docstrings.docsubst
+    def mean_absolute_error(self, y_true, y_pred):
+        '''Calculate the mean absolute error.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :returns: The mean absolute error
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.ml.datasets.load_iris()
+        >>> df.ml.metrics.mean_absolute_error(df.sepal_length, df.petal_length)
+          2.0846666666666667
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        return (np.abs(self.df[y_true] - self.df[y_pred])).mean().item()
+
+    @vaex.docstrings.docsubst
+    def mean_squared_error(self, y_true, y_pred):
+        '''Calculates the mean squared error.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :returns: The mean squared error
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.ml.datasets.load_iris()
+        >>> df.ml.metrics.mean_squared_error(df.sepal_length, df.petal_length)
+          5.589000000000001
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+        return ((self.df[y_true] - self.df[y_pred])**2).mean().item()
+
+    @vaex.docstrings.docsubst
+    def r2_score(self, y_true, y_pred):
+        '''Calculates the R**2 (coefficient of determination) regression score function.
+
+        :param y_true: {expression_one}
+        :param y_pred: {expression_one}
+        :returns: The R**2 score
+
+        Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.ml.datasets.load_iris()
+        >>> df.ml.metrics.r2_score(df.sepal_length, df.petal_length)
+          -7.205575765485069
+        '''
+        y_true, y_pred = ensure_string_arguments(y_true, y_pred)
+
+        numerator = ((self.df[y_true] - self.df[y_pred])**2).sum()
+        denominator = ((self.df[y_true] - self.df[y_true].mean())**2).sum()
+        if denominator == 0:
+            return 0.0
+        else:
+            return 1 - (numerator / denominator)

--- a/tests/ml/metrics_test.py
+++ b/tests/ml/metrics_test.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+pytest.importorskip("sklearn.metrics")
+from sklearn import metrics
+
+import vaex.ml
+import vaex.ml.metrics
+from vaex.ml.metrics import ensure_string_arguments
+
+df_binary = vaex.from_arrays(x=[1, 0, 1, 1, 0, 0, 0],
+                             y=[1, 0, 1, 1, 0, 1, 1])
+
+df_multi_class = vaex.from_arrays(x=[1, 0, 1, 1, 0, 2, 0, 2],
+                                  y=[1, 0, 1, 1, 0, 2, 2, 1])
+
+df_multi_class_strings = vaex.from_arrays(x=['dog', 'cat', 'dog', 'dog', 'cat', 'mouse', 'cat', 'mouse'],
+                                          y=['dog', 'cat', 'dog', 'dog', 'cat', 'mouse', 'mouse', 'dog'])
+
+
+def test_ensure_string_arguments():
+    df = vaex.ml.datasets.load_iris()
+    assert ensure_string_arguments(df.class_) == ['class_']
+    set(ensure_string_arguments(df.class_, df.sepal_length)) == set(['class_', 'sepal_length'])
+    set(ensure_string_arguments('petal_width', df.sepal_length)) == set(['petal_width', 'sepal_length'])
+
+
+@pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
+def test_accuracy_score(df):
+    assert df.ml.metrics.accuracy_score(df.x, df.y) == metrics.accuracy_score(df.x.values, df.y.values)
+
+
+@pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
+def test_precision_score(df):
+    average = 'binary'
+    average = 'binary'
+    if df.x.nunique() > 2:
+        average = 'macro'
+
+    vaex_score = df.ml.metrics.precision_score(df.x, df.y, average=average)
+    sklearn_score = metrics.precision_score(df.x.values, df.y.values, average=average)
+    assert vaex_score == sklearn_score
+
+
+@pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
+def test_recall_score(df):
+    average = 'binary'
+    if df.x.nunique() > 2:
+        average = 'macro'
+
+    vaex_score = df.ml.metrics.recall_score(df.x, df.y, average=average)
+    sklearn_score = metrics.recall_score(df.x.values, df.y.values, average=average)
+    assert vaex_score == sklearn_score
+
+
+@pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
+def test_f1_score(df):
+    average = 'binary'
+    if df.x.nunique() > 2:
+        average = 'macro'
+
+    vaex_score = df.ml.metrics.f1_score(df.x, df.y, average=average)
+    sklearn_score = metrics.f1_score(df.x.values, df.y.values, average=average)
+    assert vaex_score == sklearn_score
+
+
+@pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
+def test_matthews_correlation_coefficient(df):
+    vaex_score = df.ml.metrics.matthews_correlation_coefficient(df.x, df.y)
+    sklearn_score = metrics.matthews_corrcoef(df.x.values, df.y.values)
+    assert vaex_score == sklearn_score
+
+
+@pytest.mark.parametrize('df', [df_binary, df_multi_class])
+def test_confusion_matrix(df):
+    vaex_result = df.ml.metrics.confusion_matrix(df.x, df.y)
+    sklearn_result = metrics.confusion_matrix(df.x.values, df.y.values)
+    np.testing.assert_array_equal(vaex_result, sklearn_result)
+
+
+def test_mean_absolute_error():
+    df = vaex.ml.datasets.load_iris()
+    vaex_result = df.ml.metrics.mean_absolute_error(df.petal_width, df.petal_length)
+    sklearn_result = metrics.mean_absolute_error(df.petal_width.values, df.petal_length.values)
+    assert vaex_result == sklearn_result
+
+
+def test_mean_squared_error():
+    df = vaex.ml.datasets.load_iris()
+    vaex_result = df.ml.metrics.mean_squared_error(df.petal_width, df.petal_length)
+    sklearn_result = metrics.mean_squared_error(df.petal_width.values, df.petal_length.values)
+    assert vaex_result == sklearn_result
+
+
+def test_r2_score():
+    df = vaex.ml.datasets.load_iris()
+    vaex_result = df.ml.metrics.r2_score(df.petal_width, df.petal_length)
+    sklearn_result = metrics.r2_score(df.petal_width.values, df.petal_length.values)
+    np.testing.assert_array_almost_equal(vaex_result, sklearn_result, decimal=7)
+
+
+def test_classification_report():
+    report = df_binary.ml.metrics.classification_report(df_binary.x, df_binary.y)
+    expected_result = '\n        Classification report:\n\n        Accuracy:  0.714\n        Precision: 0.6\n        Recall:    1.0\n        F1:        0.75\n        '
+    assert report == expected_result
+
+    report = df_multi_class.ml.metrics.classification_report(df_binary.x, df_binary.y, average='macro')
+    expected_result = '\n        Classification report:\n\n        Accuracy:  0.75\n        Precision: 0.75\n        Recall:    0.722\n        F1:        0.719\n        '
+    assert report == expected_result


### PR DESCRIPTION
New ml accessor, `metrics`. 

Allows for fast and out-of-core computation of some popular / common ML metrics for classification and regression.

Please see the tests, docstrings or the documentation  for examples.

- [x] Implement new accessor for computing metrics such as (accuracy, precision, recall, f1, mse, mae, confusion matrix etc..)
- [x] Implement tests for each new method
- [x] Update the API docs
- [x] Update the documentation to include some mention of this. 