### PR TITLE
🐛 protect file creation parts with lock files

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -24,7 +24,7 @@ install_requires_core = ["numpy>=1.16", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2",
                          "requests", "six", "cloudpickle", "pandas", "dask",
                          "nest-asyncio>=1.3.3", "pyarrow>=3.0", "frozendict",
-                         "blake3"
+                         "blake3", "filelock",
                         ]
 if sys.version_info[0] == 2:
     install_requires_core.append("futures>=2.2.0")

--- a/packages/vaex-core/vaex/cache.py
+++ b/packages/vaex-core/vaex/cache.py
@@ -50,8 +50,10 @@ import uuid
 import pickle
 import threading
 
+
 import dask.base
 import pyarrow as pa
+from filelock import FileLock
 
 import vaex.utils
 diskcache = vaex.utils.optional_import('diskcache')
@@ -312,7 +314,8 @@ def output_file(callable=None, path_input=None, fs_options_input={}, fs_input=No
 
                 if not vaex.file.exists(path_output, fs_options=fs_options_output_, fs=fs_output):
                     log.info('file %s does not exist yet, running conversion %s → %s', path_output_meta, path_input, path_output)
-                    value = callable(*args, **kwargs)
+                    with FileLock(f"{fp}.lock"):
+                        value = callable(*args, **kwargs)
                     write_fingerprint()
                     return value
 

--- a/packages/vaex-core/vaex/file/cache.py
+++ b/packages/vaex-core/vaex/file/cache.py
@@ -6,8 +6,12 @@ import logging
 import os
 import mmap
 
+
 import numpy as np
 from pyarrow.fs import FileSystemHandler
+from filelock import FileLock
+
+
 import vaex.utils
 import vaex.file
 
@@ -109,11 +113,12 @@ class MMappedFile:
     def __init__(self, path, length, dtype=np.uint8):
         self.path = path
         self.length = length
-        if not os.path.exists(path):
-            with open(self.path, 'wb') as fp:
-                fp.seek(self.length-1)
-                fp.write(b'\00')
-                fp.flush()
+        with FileLock(f'{path}.lock'):
+            if not os.path.exists(path):
+                with open(self.path, 'wb') as fp:
+                    fp.seek(self.length-1)
+                    fp.write(b'\00')
+                    fp.flush()
 
         self.fp = open(self.path, 'rb+')
         kwargs = {}

--- a/tests/open_test.py
+++ b/tests/open_test.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 import glob
 import tempfile
 import os
@@ -36,6 +37,20 @@ def test_open_convert_kwargs():
 def test_open_convert_non_hdf5():
     csv2 = os.path.join(path, 'data', 'smæll2.csv')
     df = vaex.open(csv2, convert='smæll2.parquet')
+
+
+def test_open_convert_multithreaded():
+    def do(i):
+        fn = os.path.join(path, 'data', 'smæll2.csv')
+        df = vaex.open(csv2, convert='smæll2.hdf5')
+        df = vaex.open(csv2, convert='smæll2.parquet')
+        df = vaex.open(csv2, convert='smæll2.arrow')
+    for i in range(10):
+        with ThreadPoolExecutor(4) as tpe:
+            values = list(tpe.map(do, range(5)))
+            assert values == [None] * 5
+        for ext in ['hdf5', 'parquet', 'arrow']:
+            os.remove(os.path.join(f'smæll2.{ext}'))
 
 
 def test_open_convert_explicit_path():


### PR DESCRIPTION
This shows up when multiple threads or processes try to do a conversion
or create a cache file.