### PR TITLE
✨ avoid using nest_asyncio

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -23,7 +23,7 @@ url = 'https://www.github.com/maartenbreddels/vaex'
 install_requires_core = ["numpy>=1.16", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2",
                          "requests", "six", "cloudpickle", "pandas", "dask",
-                         "nest-asyncio>=1.3.3", "pyarrow>=3.0", "frozendict",
+                         "pyarrow>=3.0", "frozendict",
                          "blake3", "filelock",
                         ]
 if sys.version_info[0] == 2:

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -23,7 +23,7 @@ url = 'https://www.github.com/maartenbreddels/vaex'
 install_requires_core = ["numpy>=1.16", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2",
                          "requests", "six", "cloudpickle", "pandas", "dask",
-                         "pyarrow>=3.0", "frozendict",
+                         "nest-asyncio>=1.3.3", "pyarrow>=3.0", "frozendict",
                          "blake3", "filelock",
                         ]
 if sys.version_info[0] == 2:

--- a/packages/vaex-core/vaex/asyncio.py
+++ b/packages/vaex-core/vaex/asyncio.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import sys
 
 
 @contextlib.contextmanager
@@ -16,3 +17,38 @@ def with_event_loop(event_loop=None):
         yield
     finally:
         asyncio.set_event_loop(loop_previous)
+
+def check_ipython():
+    IPython = sys.modules.get('IPython')
+    if IPython:
+        IPython_version = tuple(map(int, IPython.__version__.split('.')[:3]))
+        if IPython_version < (7, 0, 0):
+            raise RuntimeError(f'You are using IPython {IPython.__version__} while we require 7.0.0, please update IPython')
+
+def check_patch_tornado():
+    '''If tornado is imported, add the patched asyncio.Future to its tuple of acceptable Futures'''
+    if 'tornado' in sys.modules:
+        import tornado.concurrent
+        if asyncio.Future not in tornado.concurrent.FUTURES:
+            tornado.concurrent.FUTURES = tornado.concurrent.FUTURES + (asyncio.Future, )            
+
+
+def just_run(coro):
+    '''Make the coroutine run, even if there is already an event loop running (using nest_asyncio)'''
+    try:
+        loop = asyncio.get_event_loop()
+        had_loop = True
+    except RuntimeError:
+        had_loop = False
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    try:
+        if had_loop:
+            check_ipython()
+            import nest_asyncio
+            nest_asyncio.apply()
+            check_patch_tornado()
+        return loop.run_until_complete(coro)
+    finally:
+        if not had_loop:  # remove loop if we did not have one
+            asyncio.set_event_loop(None)

--- a/packages/vaex-core/vaex/asyncio.py
+++ b/packages/vaex-core/vaex/asyncio.py
@@ -1,38 +1,18 @@
 import asyncio
-import sys
+import contextlib
 
 
-def check_ipython():
-    IPython = sys.modules.get('IPython')
-    if IPython:
-        IPython_version = tuple(map(int, IPython.__version__.split('.')[:3]))
-        if IPython_version < (7, 0, 0):
-            raise RuntimeError(f'You are using IPython {IPython.__version__} while we require 7.0.0, please update IPython')
-
-def check_patch_tornado():
-    '''If tornado is imported, add the patched asyncio.Future to its tuple of acceptable Futures'''
-    if 'tornado' in sys.modules:
-        import tornado.concurrent
-        if asyncio.Future not in tornado.concurrent.FUTURES:
-            tornado.concurrent.FUTURES = tornado.concurrent.FUTURES + (asyncio.Future, )            
-
-
-def just_run(coro):
-    '''Make the coroutine run, even if there is already an event loop running (using nest_asyncio)'''
+@contextlib.contextmanager
+def with_event_loop(event_loop=None):
+    loop_previous = asyncio.get_event_loop()
+    if event_loop is None:
+        loop_new = asyncio.new_event_loop()
+    else:
+        loop_new = event_loop
+    asyncio.set_event_loop(loop_new)
+    # private API, but present from CPython 3.3ish-3.10+
+    asyncio.events._set_running_loop(None)
     try:
-        loop = asyncio.get_event_loop()
-        had_loop = True
-    except RuntimeError:
-        had_loop = False
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    try:
-        if had_loop:
-            check_ipython()
-            import nest_asyncio
-            nest_asyncio.apply()
-            check_patch_tornado()
-        return loop.run_until_complete(coro)
+        yield
     finally:
-        if not had_loop:  # remove loop if we did not have one
-            asyncio.set_event_loop(None)
+        asyncio.set_event_loop(loop_previous)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -398,11 +398,8 @@ class DataFrame(object):
             print("Tasks:")
             for task in self.executor.tasks:
                 print(repr(task))
-        from .asyncio import just_run
         if self.executor.tasks:
-            # we only run when there are tasks, since we may trigger this
-            # call in an async loop context that cannot be patched (like uvloop)
-            just_run(self.execute_async())
+            self.executor.execute()
 
     async def execute_async(self):
         '''Async version of execute'''

--- a/packages/vaex-server/vaex/server/client.py
+++ b/packages/vaex-server/vaex/server/client.py
@@ -4,6 +4,7 @@ import warnings
 
 import vaex
 from .dataframe import DataFrameRemote
+from .executor import Executor
 
 
 def create_df(name, info, executor):
@@ -21,7 +22,7 @@ class Client:
     def __init__(self, secure=False):
         self.secure = secure
         self.df_map = {}
-        self.executor = None
+        self.executor = Executor(self)
         self._msg_id_to_tasks = {}
 
     def _check_version(self):

--- a/packages/vaex-server/vaex/server/tornado_client.py
+++ b/packages/vaex-server/vaex/server/tornado_client.py
@@ -37,6 +37,7 @@ class Client(client.Client):
 
 class ClientWebsocket(Client):
     def _send_and_forget(self, msg, msg_id=None):
+        vaex.asyncio.check_patch_tornado()
         if msg_id is None:
             msg_id = str(uuid.uuid4())
         self.msg_reply_futures[msg_id] = asyncio.Future()

--- a/packages/vaex-server/vaex/server/tornado_client.py
+++ b/packages/vaex-server/vaex/server/tornado_client.py
@@ -10,7 +10,6 @@ import vaex
 import vaex.asyncio
 import vaex.server.utils
 from vaex.server import client
-from .executor import Executor
 
 logger = logging.getLogger("vaex.server.tornado_client")
 
@@ -29,11 +28,6 @@ class Client(client.Client):
         self.jobs = {}
         self.msg_reply_futures = {}
 
-        self.event_loop_main = asyncio.get_event_loop()
-        if self.event_loop_main is None:
-            raise RuntimeError('The client cannot work without a running event loop')
-
-        self.executor = Executor(self)
         logger.debug("connect")
         self.connect()
         logger.debug("connected")
@@ -43,7 +37,6 @@ class Client(client.Client):
 
 class ClientWebsocket(Client):
     def _send_and_forget(self, msg, msg_id=None):
-        vaex.asyncio.check_patch_tornado()
         if msg_id is None:
             msg_id = str(uuid.uuid4())
         self.msg_reply_futures[msg_id] = asyncio.Future()
@@ -51,7 +44,6 @@ class ClientWebsocket(Client):
 
         msg_encoding = vaex.encoding.Encoding()
         data = vaex.encoding.serialize({'msg_id': msg_id, 'msg': msg, 'auth': auth}, msg_encoding)
-        assert self.event_loop_main is asyncio.get_event_loop()
 
         self.websocket.write_message(data, binary=True)
         return msg_id
@@ -64,8 +56,7 @@ class ClientWebsocket(Client):
             return reply_msg['result'], reply_encoding
 
     def _send(self, msg, msg_id=None, wait_for_reply=True, add_promise=None):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self._send_async(msg, msg_id))
+        return self.executor.run(self._send_async(msg, msg_id))
 
     def close(self):
         self.websocket.close()
@@ -119,7 +110,7 @@ class ClientWebsocket(Client):
         self.websocket = await tornado.websocket.websocket_connect(self._url, on_message_callback=self._on_websocket_message)
 
     def connect(self):
-        vaex.asyncio.just_run(self.connect_async())
+        return self.executor.run(self.connect_async())
 
 
 def connect(url, **kwargs):

--- a/packages/vaex-server/vaex/server/websocket.py
+++ b/packages/vaex-server/vaex/server/websocket.py
@@ -62,6 +62,7 @@ class WebSocketHandler:
                 nonlocal last_progress
 
                 async def send_progress():
+                    vaex.asyncio.check_patch_tornado() # during testing asyncio might be patched
                     nonlocal last_progress
                     logger.debug("progress: %r", f)
                     last_progress = f

--- a/packages/vaex-server/vaex/server/websocket.py
+++ b/packages/vaex-server/vaex/server/websocket.py
@@ -62,7 +62,6 @@ class WebSocketHandler:
                 nonlocal last_progress
 
                 async def send_progress():
-                    vaex.asyncio.check_patch_tornado()  # during testing asyncio might be patched
                     nonlocal last_progress
                     logger.debug("progress: %r", f)
                     last_progress = f


### PR DESCRIPTION
This avoids the use of nest_asyncio, where we have instead of 'shared-nested' ioloops, we make 'new-nested' ioloops. This means that if we do a async->sync->async call, the deepest async code will pause the ioloop of the parent. Note that this not work with vaex-jupyter, because that requires the jupyter ioloop to continue running (hence the WIP).

This idea was discussed in private with @SylvainCorlay, putting the PR out as a potential fix for https://github.com/spyder-ide/spyder/issues/16183