### PR TITLE
🐛 too much noise when exceptions occurred in the executor.

### DIFF
--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -318,7 +318,6 @@ class ExecutorLocal(Executor):
                     self.signal_end.emit()
         except:  # noqa
             self.signal_cancel.emit()
-            logger.exception("error in task, flush task queue")
             raise
         finally:
             self.local.executing = False


### PR DESCRIPTION
If we had N threads, all throwing the same exception, N-1
warnings of un-awaited exceptions. We also always put the
exception in the log.