### PR TITLE
feat(core): Method to add virtual columns having constant values.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,6 +18,8 @@ Opening/reading in your data.
     vaex.from_ascii
     vaex.from_pandas
     vaex.from_astropy_table
+    vaex.vrange
+    vaex.vconstant
 
 Visualization.
 ~~~~~~~~~~~~~~
@@ -58,7 +60,7 @@ vaex-core
 ---------
 
 .. automodule:: vaex
-    :members: open, concat, from_arrays, from_dict, from_items, from_arrow_table, from_csv, from_ascii, from_pandas, from_astropy_table, from_samp, open_many, register_function, server, example, app, delayed
+    :members: open, concat, from_arrays, from_dict, from_items, from_arrow_table, from_csv, from_ascii, from_pandas, from_astropy_table, from_samp, open_many, register_function, server, example, app, delayed, vrange, vconstant
     :undoc-members:
     :show-inheritance:
 

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -773,12 +773,24 @@ def concat(dfs, resolver='flexible') -> vaex.dataframe.DataFrame:
     return df.concat(*tail, resolver=resolver)
 
 def vrange(start, stop, step=1, dtype='f8'):
-    """Creates a virtual column which is the equivalent of numpy.arange, but uses 0 memory"""
+    """Creates a virtual column which is the equivalent of numpy.arange, but uses 0 memory
+
+    :param int start: Start of interval. The interval includes this value.
+    :param int stop: End of interval. The interval does not include this value,
+    :param int step: Spacing between values.
+    :dtype: The preferred dtype for the column.
+    """
     from .column import ColumnVirtualRange
     return ColumnVirtualRange(start, stop, step, dtype)
 
 def vconstant(value, length, dtype=None, chunk_size=1024):
-    """Creates a virtual column with constant values. This uses 0 memory."""
+    """Creates a virtual column with constant values, which uses 0 memory.
+
+    :param value: The value with which to fill the column
+    :param length: The length of the column, i.e. the number of rows it should contain.
+    :param dtype: The preferred dtype for the column.
+    :param chunk_size: Could be used to optimize the performance (evaluation) of this column.
+    """
     from .column import ColumnVirtualConstant
     return ColumnVirtualConstant(value=value, length=length, dtype=dtype, chunk_size=chunk_size)
 

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -777,6 +777,11 @@ def vrange(start, stop, step=1, dtype='f8'):
     from .column import ColumnVirtualRange
     return ColumnVirtualRange(start, stop, step, dtype)
 
+def vconstant(value, length, dtype=None, chunk_size=1024):
+    """Creates a virtual column with constant values. This uses 0 memory."""
+    from .column import ColumnVirtualConstant
+    return ColumnVirtualConstant(value=value, length=length, dtype=dtype, chunk_size=chunk_size)
+
 def string_column(strings):
     import pyarrow as pa
     return pa.array(strings)

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -79,10 +79,9 @@ class ColumnVirtualConstant(Column):
         return self.length
 
     def __getitem__(self, slice):
-        template = pa.array([self.value] * self.chunk_size, type=self.dtype)
+        template = pa.array([self.value] * self.chunk_size, type=self.dtype.arrow)
         n_chunks = (self.length + self.chunk_size - 1) // self.chunk_size
-        ar = pa.chunked_array([template] * n_chunks)
-        ar = ar.slice(length=self.length)
+        ar = pa.chunked_array([template] * n_chunks)[slice]
         return ar
 
     def _fingerprint(self):
@@ -91,9 +90,9 @@ class ColumnVirtualConstant(Column):
 
     def _get_dtype(self, dtype):
         if dtype is None:
-            return pa.array([self.value]).type
+            return vaex.datatype.DataType(pa.array([self.value]).type)
         else:
-            vaex.datatype.DataType(dtype).arrow
+            return vaex.datatype.DataType(dtype)
 
     def trim(self, i1, i2):
         length = i2 - i1

--- a/tests/column_test.py
+++ b/tests/column_test.py
@@ -19,6 +19,21 @@ def test_vrange():
     assert df[1:11].y.tolist()== (np.arange(1, 11)**2).tolist()
 
 
+@pytest.mark.parametrize('value', [10, 'word', [1, 2]])
+def test_vconstant(value):
+    length = 100
+    df = vaex.from_arrays(x=vaex.vconstant(value=value, length=length),
+                          y=vaex.vrange(0, length))
+
+
+    assert len(df.columns['x']) == length
+    assert df.x[:3].tolist() == [value] * 3
+
+    df_filter = df[df.y < 31]
+    assert len(df_filter) == 31
+    assert df_filter.x[:3].tolist() == [value] * 3
+
+
 def test_arrow_strings():
     N = 4
     x = ['a', 'bb', 'ccc', 'dddd']


### PR DESCRIPTION
This PR adds a vaex method to add virtual columns having constant values. 
The method is called `vaex.vconstant`
This was requested a few of times in the past, example #1019, #1557

This is how for instance one can create a fully virtual dataframe:
```python

import vaex

N = 100_000_000
df = vaex.from_arrays(x=vaex.vconstant(value=10, length=N),
                      y=vaex.vconstant(value='Vaex', length=N),
                      z=vaex.vrange(0, N)
                     )
```


Checklist:
- [x] Implementation
- [x] Unit-tests
- [x] API docs update
- [ ] Code review  