### PR TITLE
fix: delete column name in delete_virtual_column

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3634,6 +3634,8 @@ class DataFrame(object):
         """Deletes a virtual column from a DataFrame."""
         del self.virtual_columns[name]
         del self._virtual_expressions[name]
+        if name in self.column_names:
+            self.column_names.remove(name)
         self.signal_column_changed.emit(self, name, "delete")
 
     def add_variable(self, name, expression, overwrite=True, unique=True):

--- a/tests/virtual_columns_test.py
+++ b/tests/virtual_columns_test.py
@@ -21,3 +21,11 @@ def test_add_virtual_columns_polar_velocities_to_cartesian():
     ds['L_'] = np.sqrt(ds.Lx_**2. + ds.Ly_**2. + ds.Lz_**2.)
     np.testing.assert_almost_equal(ds.Lz.values, ds.Lz_.values, err_msg='error when calculating Lz', decimal=3)
     np.testing.assert_almost_equal(ds.L.values, ds.L_.values, err_msg='error when calculating the Ltotal', decimal=3)
+
+def test_add_and_delete_virtual_column():
+    # add and delete
+    ds = vaex.example()
+    ds.add_virtual_column("double_x", 'x * 2')
+    assert "double_x" in ds.get_column_names()
+    ds.delete_virtual_column("double_x")
+    assert "double_x" not in ds.get_column_names()


### PR DESCRIPTION
This solves a bug that I noticed while checking at the #1382 issue.
The reproduced code is as follows. After adding a virtual column and then removing it, print(df) will throw an error and the value is an error.(I'll add the output at the bottom.)
```python
import vaex
df = vaex.example()
df.add_virtual_column("w", 'x * 2')
df.delete_virtual_column("w")
print(df.get_column_names())
# ↓ raise exception ↓
print(df)
```
This is due to the fact that the virtual column was deleted but the column name was not. Therefore, in this PR, we added a process to delete the column name when deleting it.


The error **before** the fix is as follows,
```
syureneko@MBP ~/p/vaex (fix_delete_virtual_column)> python -m pytest tests/virtual_columns_test.py -s
====================================================================================================== test session starts =======================================================================================================
platform darwin -- Python 3.8.7, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /Users/syureneko/preprocessing-learn/vaex
collected 1 item                                                                                                                                                                                                                 

tests/virtual_columns_test.py ERROR:MainThread:vaex:error evaluating: double_x at rows 0-5
Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2049, in data_type
    data = self.evaluate(expression, 0, 1, filtered=False, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 3863, in table_part
    values = dict(zip(column_names, df.evaluate(column_names)))
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6070, in _evaluate_implementation
    dtypes[expression] = dtype = df.data_type(expression).internal
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2051, in data_type
    data = self.evaluate(expression, 0, 1, filtered=True, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2049, in data_type
    data = self.evaluate(expression, 0, 1, filtered=False, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 3868, in table_part
    values[name] = df.evaluate(name)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6070, in _evaluate_implementation
    dtypes[expression] = dtype = df.data_type(expression).internal
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2051, in data_type
    data = self.evaluate(expression, 0, 1, filtered=True, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined
ERROR:MainThread:vaex:error evaluating: double_x at rows 329995-330000
Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2049, in data_type
    data = self.evaluate(expression, 0, 1, filtered=False, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 3863, in table_part
    values = dict(zip(column_names, df.evaluate(column_names)))
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6070, in _evaluate_implementation
    dtypes[expression] = dtype = df.data_type(expression).internal
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2051, in data_type
    data = self.evaluate(expression, 0, 1, filtered=True, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2049, in data_type
    data = self.evaluate(expression, 0, 1, filtered=False, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 106, in evaluate
    result = self[expression]
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 166, in __getitem__
    raise KeyError("Unknown variables or column: %r" % (variable,))
KeyError: "Unknown variables or column: 'double_x'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 3868, in table_part
    values[name] = df.evaluate(name)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6070, in _evaluate_implementation
    dtypes[expression] = dtype = df.data_type(expression).internal
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2051, in data_type
    data = self.evaluate(expression, 0, 1, filtered=True, array_type=array_type, parallel=False)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 2897, in evaluate
    return self._evaluate_implementation(expression, i1=i1, i2=i2, out=out, selection=selection, filtered=filtered, array_type=array_type, parallel=parallel, chunk_size=chunk_size)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/dataframe.py", line 6158, in _evaluate_implementation
    value = scope.evaluate(expression)
  File "/Users/syureneko/preprocessing-learn/vaex/packages/vaex-core/vaex/scopes.py", line 112, in evaluate
    result = eval(expression, expression_namespace, self)
  File "<string>", line 1, in <module>
NameError: name 'double_x' is not defined
#        id    x             y            z            vx          vy           vz          E           L          Lz          FeH         vr_polar    vphi_polar    r_polar    phi_polar    vx_         vy_          Lx_         Ly_         Lz_         L_         double_x
0        0     1.2318684     -0.39692867  -0.59805775  301.15527   174.05948    27.427546   -149431.4   407.38898  333.95554   -1.0053853  233.2604    258.03256     1.294238   -17.85981    301.15527   174.05951    93.21084    -213.89537  333.95554   407.38898  error
1        23    -0.16370061   3.6542213    -0.25490645  -195.00023  170.47217    142.53023   -124247.95  890.24115  684.6676    -1.708667   179.02817   187.17575     3.6578863  92.565       -195.00024  170.47215    564.29144   73.0391     684.6676    890.2411   error
2        32    -2.120256     3.3260527    1.7078403    -48.63423   171.6473     -2.0794373  -138500.55  372.2411   -202.17618  -1.8336141  170.88248   -51.256805    3.9443772  122.51626    -48.634254  171.64728    -300.0625   -87.468445  -202.17618  372.2411   error
3        8     4.715589      4.585251     2.2515438    -232.42084  -294.85083   62.85865    -60037.04   1297.6304  -324.6875   -1.4786882  -372.18216  -49.364613    6.577333   44.197136    -232.4208   -294.8508    952.0923    -819.7212   -324.6875   1297.6304  error
4        16    7.217187      11.994717    -1.0645622   -1.6891745  181.32935    -11.333611  -83206.84   1332.799   1328.949    -1.8570484  154.5013    94.93437      13.998608  58.964798    -1.6891785  181.32935    57.09291    83.59502    1328.949    1332.799   error
...      ...   ...           ...          ...          ...         ...          ...         ...         ...        ...         ...         ...         ...           ...        ...          ...         ...          ...         ...         ...         ...        ...
329,995  21    1.9938701     0.7892761    0.2220599    -216.9299   16.12442     -211.24438  -146457.44  457.72247  203.36758   -1.7451677  -195.7668   94.83634      2.1444056  21.5962      -216.92987  16.124413    -170.31073  373.02246   203.36758   457.72247  error
329,996  25    3.7180912     0.7213376    1.6415337    -185.9216   -117.250824  -105.49866  -126627.11  335.00256  -301.837    -0.9822322  -204.84961  -79.69468     3.7874174  10.979417    -185.92162  -117.250824  116.371025  87.05707    -301.837    335.00256  error
329,997  14    0.36885077    13.029609    -3.6339347   -53.677147  -145.15771   76.7091     -84912.26   817.1376   645.8507    -1.7645613  -146.61852  49.54808      13.034828  88.37846     -53.677166  -145.15771   471.9959    166.76505   645.8507    817.13763  error
329,998  18    -0.112592645  1.4529126    2.1689527    179.30865   205.7971     -68.75873   -133498.47  724.00024  -283.69104  -1.8808953  191.32802   -194.67311    1.4572687  94.43124     179.30869   205.79704    -546.26465  381.17026   -283.69104  724.0003   error
329,999  4     20.79622      -3.3313878   12.188416    42.690002   69.204796    29.542751   -65519.33   1843.0747  1581.4152   -1.1231084  31.206087   75.08608      21.061361  -9.101002    42.690002   69.20479     -941.91516  -94.05408   1581.4152   1843.0747  error
.

======================================================================================================== warnings summary ========================================================================================================
tests/virtual_columns_test.py::test_add_virtual_columns_polar_velocities_to_cartesian
  <frozen importlib._bootstrap>:219: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility. Expected 80 from C header, got 88 from PyObject

tests/virtual_columns_test.py: 178 warnings
  /Users/syureneko/.pyenv/versions/3.8.7/Python.framework/Versions/3.8/lib/python3.8/ast.py:371: PendingDeprecationWarning: visit_Num is deprecated; add visit_Constant
    return visitor(node)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================================ 1 passed, 179 warnings in 0.97s =================================================================================================
syureneko@MBP ~/p/vaex (fix_delete_virtual_column)> 
```

thanks!