### PR TITLE
Fix: groupby on `np.uint8` type

### DIFF
--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -583,3 +583,12 @@ def test_groupby_limited_with_nan(df_factory):
     # we don't check, because comparing nan is always false
     # assert dfg['type'].tolist() == [a, b,  None, others]
     assert dfg['sum'].tolist() == [1+2+2, 3+3, 9+9, 4]
+
+
+def test_groupby_int8():
+    df = vaex.example()
+    assert df.id.dtype ==  np.uint8  # Just a consistency check
+
+    df_group = df.groupby('id').agg({'x': 'sum'})
+
+    assert df_group.shape == (33, 2)


### PR DESCRIPTION
Note sure when this was introduced, but this bug was not present in vaex-core 4.4.0.

- [ ] Make test exposing bug
- [ ] Make test pass