### PR TITLE
fix double kwargs issue in export_csv

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -6686,7 +6686,6 @@ class DataFrameLocal(DataFrame):
         :return:
         """
         import pandas as pd
-
         expressions = self.get_column_names()
         progressbar = vaex.utils.progressbars(progress)
         dtypes = self[expressions].dtypes
@@ -6694,19 +6693,22 @@ class DataFrameLocal(DataFrame):
         if chunk_size is None:
             chunk_size = len(self)
 
+        # By default vaex does not expect a csv file to have index like column so this is turned of by default
+        if 'index' not in kwargs:
+            kwargs['index'] = False
+
         for i1, i2, chunks in self.evaluate_iterator(expressions, chunk_size=chunk_size, parallel=parallel):
             progressbar( i1 / n_samples)
             chunk_dict = {col: values for col, values in zip(expressions, chunks)}
             chunk_pdf = pd.DataFrame(chunk_dict)
 
             if i1 == 0:  # Only the 1st chunk should have a header and the rest will be appended
-                mode = 'w'
-                header = True
+                kwargs['mode'] = 'w'
             else:
-                mode = 'a'
-                header = False
+                kwargs['mode'] = 'a'
+                kwargs['header'] = False
 
-            chunk_pdf.to_csv(path_or_buf=path, mode=mode, header=header, index=False, **kwargs)
+            chunk_pdf.to_csv(path_or_buf=path, **kwargs)
         progressbar(1.0)
         return
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -142,8 +142,8 @@ def test_export_string_mask(tmpdir):
 
 def test_export_unicode_column_name_hdf5(tmpdir):
     # prepare many columns for multithreaded export
-    src_dict = {"あ": [1, 2, 3], "a": [1, 2, 3], "b": [1, 2, 3], 
-            "c": [1, 2, 3], "d": [1, 2, 3], "a1": [1, 2, 3], 
+    src_dict = {"あ": [1, 2, 3], "a": [1, 2, 3], "b": [1, 2, 3],
+            "c": [1, 2, 3], "d": [1, 2, 3], "a1": [1, 2, 3],
             "b2": [1, 2, 3], "c3": [1, 2, 3], "d4": [1, 2, 3]}
     path = str(tmpdir.join('test.hdf5'))
     df = vaex.from_dict(src_dict)
@@ -202,6 +202,6 @@ def test_multi_file_naive_read_convert_export(tmpdir, dtypes):
 def test_export_csv(df_local, tmpdir):
     df = df_local
     path = str(tmpdir.join('test.csv'))
-    df.export_csv(path)
+    df.export_csv(path, index=False)
 
     assert '123456' in vaex.open(path)


### PR DESCRIPTION
This fixes #1063 

`df.export_csv(..)` was crashing if `header`, `mode`, or `index` where specified by the user. 

This PR fixes that

- [x] Adjust the unit-test to capture this
- [x] Make the fix 