### PR TITLE
Better dot_product

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2741,3 +2741,18 @@ def stack(arrays, strict=False):
 def getitem(ar, item):
     slicer = (slice(None), item)
     return ar.__getitem__(slicer)
+
+
+@register_function()
+def dot_product(a, b):
+    '''Compute the dot product between `a` and `b`.
+
+    :param a: A list of Expressions or a list of values (e.g. a vector)
+    :param b: A list of Expressions or a list of values (e.g. a vector)
+    :return: Vaex expression
+    '''
+    assert len(a) == len(b), 'The lenghts of `a` and `b` must be the same.'
+    result = a[0] * b[0]
+    for an, bn in zip(a[1:], b[1:]):
+        result += an * bn
+    return result

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -19,11 +19,6 @@ help_features = 'List of features to transform.'
 help_prefix = 'Prefix for the names of the transformed features.'
 
 
-def dot_product(a, b):
-    products = ['%s * %s' % (ai, bi) for ai, bi in zip(a, b)]
-    return ' + '.join(products)
-
-
 @register
 class StateTransfer(HasState):
     state = traitlets.Dict()
@@ -127,19 +122,13 @@ class PCA(Transformer):
         for i in range(n_components):
             vector = eigen_vectors[:, i]
             if self.whiten:
-                expr = dot_product(expressions, vector)
+                expr = copy.func.dot_product(expressions, vector)
                 expr = f'({expr}) / {np.sqrt(self.explained_variance_[i])}'
             else:
-                expr = dot_product(expressions, vector)
+                expr = copy.func.dot_product(expressions, vector)
             name = self.prefix + str(i + name_prefix_offset)
             copy[name] = expr
         return copy
-
-def dot_product(a, b):
-    products = ['%s * %s' % (ai, bi) for ai, bi in zip(a, b)]
-    return ' + '.join(products)
-
-help_prefix = 'Prefix for the names of the transformed features.'
 
 
 @register
@@ -302,7 +291,8 @@ class RandomProjections(Transformer):
 
         for component in range(self.n_components):
             vector = random_matrix[component]
-            expr = dot_product(self.features, vector)
+            feature_expressions = [copy[feat] for feat in self.features]
+            expr = copy.func.dot_product(feature_expressions, vector)
             name = self.prefix + str(component + name_prefix_offset)
             copy[name] = expr
 

--- a/packages/vaex-ml/vaex/ml/transformations.py
+++ b/packages/vaex-ml/vaex/ml/transformations.py
@@ -121,11 +121,9 @@ class PCA(Transformer):
         expressions = [copy[feature]-mean for feature, mean in zip(self.features, self.means_)]
         for i in range(n_components):
             vector = eigen_vectors[:, i]
+            expr = copy.func.dot_product(expressions, vector)
             if self.whiten:
-                expr = copy.func.dot_product(expressions, vector)
                 expr = f'({expr}) / {np.sqrt(self.explained_variance_[i])}'
-            else:
-                expr = copy.func.dot_product(expressions, vector)
             name = self.prefix + str(i + name_prefix_offset)
             copy[name] = expr
         return copy

--- a/tests/dot_product_test.py
+++ b/tests/dot_product_test.py
@@ -1,0 +1,12 @@
+import vaex
+import numpy as np
+from common import *
+
+def test_dot_prodict(ds_local):
+    df = ds_local
+    result = df.func.dot_product([df.x, df.y], [2, 3])
+
+    X = df['x', 'y'].values
+    expected_result = np.dot(X, [2, 3])
+
+    np.testing.assert_array_almost_equal(result.values, expected_result)

--- a/tests/ml/pipeline_test.py
+++ b/tests/ml/pipeline_test.py
@@ -11,7 +11,7 @@ def test_pca(df_iris):
     pca.fit(ds)
     ds1 = pca.transform(ds)
 
-    path = tempfile.mktemp('.yaml')
+    path = tempfile.mktemp('.json')
     pipeline = vaex.ml.Pipeline([pca])
     pipeline.save(path)
 
@@ -20,7 +20,7 @@ def test_pca(df_iris):
     ds2 = pipeline.transform(ds)
     assert ds1.virtual_columns['PCA_1'] == ds2.virtual_columns['PCA_1']
 
-    path = tempfile.mktemp('.yaml')
+    path = tempfile.mktemp('.json')
     pipeline = vaex.ml.Pipeline([ds1.ml.state_transfer()])
     pipeline.save(path)
 
@@ -35,7 +35,7 @@ def test_selections(df_iris):
     ds.select('class_ == 1')
     count1 = ds.count(selection=True)
 
-    path = tempfile.mktemp('.yaml')
+    path = tempfile.mktemp('.json')
     pipeline = vaex.ml.Pipeline([ds.ml.state_transfer()])
     pipeline.save(path)
     print(path)
@@ -61,6 +61,6 @@ def test_state_transfer(df_iris):
     ds1, ds2 = ds.split(0.5)
     state_transfer = ds1.ml.state_transfer()
 
-    path = tempfile.mktemp('.yaml')
+    path = tempfile.mktemp('.json')
     pipeline = vaex.ml.Pipeline([state_transfer])
     pipeline.save(path)


### PR DESCRIPTION
This PR improves the dot_product. Before there was a limitation of the size of the vectors one can use to calculate a dot product. Now that limitation is lifted. So things like PCA, and Incremental PCA can be used with hundreds of dimensions. 

The dot product is made available more generally in `df.func.dot_product`.

