### PR TITLE
Feat: add display settings

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -559,7 +559,7 @@ def read_csv(filepath_or_buffer, **kwargs):
     '''Alias to from_csv.'''
     return from_csv(filepath_or_buffer, **kwargs)
 
-aliases = vaex.settings.main.auto_store_dict("aliases")
+aliases = vaex.settings.aliases
 
 # py2/p3 compatibility
 try:

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -411,7 +411,7 @@ def confirm_on_console(topic, msg):
 
 
 def yaml_dump(f, data):
-    yaml.safe_dump(data, f, default_flow_style=False, encoding='utf-8', allow_unicode=True)
+    yaml.safe_dump(data, f, default_flow_style=False, encoding='utf-8', allow_unicode=True, sort_keys=False)
 
 
 def yaml_load(f):
@@ -450,23 +450,6 @@ def read_json_or_yaml(file, fs_options={}, fs=None, old_style=True):
             raise ValueError("file should end in .json or .yaml (not %s)" % ext)
     finally:
         file.close()
-
-
-# from http://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts
-
-_mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
-
-
-def dict_representer(dumper, data):
-    return dumper.represent_dict(data.iteritems() if hasattr(data, "iteritems") else data.items())
-
-
-def dict_constructor(loader, node):
-    return collections.OrderedDict(loader.construct_pairs(node))
-
-
-yaml.add_representer(collections.OrderedDict, dict_representer, yaml.SafeDumper)
-yaml.add_constructor(_mapping_tag, dict_constructor, yaml.SafeLoader)
 
 
 def check_memory_usage(bytes_needed, confirm):

--- a/tests/repr_test.py
+++ b/tests/repr_test.py
@@ -74,3 +74,28 @@ def test_display_large_int(df_factory):
     df = df_factory(x=[123, large_int])
     text = repr(df)
     assert str(large_int) in text
+
+
+def test_max_columns():
+    x = np.arange(10)
+    df1 = vaex.from_dict({f'col_{i}': x for i in range(vaex.settings.display.max_columns)})
+    df2 = vaex.from_dict({f'col_{i}': x for i in range(vaex.settings.display.max_columns+1)})
+    mime_bundle = df1._repr_mimebundle_()
+    for key, value in mime_bundle.items():
+        assert "..." not in value
+    mime_bundle = df2._repr_mimebundle_()
+    for key, value in mime_bundle.items():
+        assert "..." in value
+
+
+def test_max_row():
+    x = np.arange(vaex.settings.display.max_rows)
+    x2 = np.arange(vaex.settings.display.max_rows+1)
+    df1 = vaex.from_dict({f'col_{i}': x for i in range(vaex.settings.display.max_columns)})
+    df2 = vaex.from_dict({f'col_{i}': x2 for i in range(vaex.settings.display.max_columns)})
+    mime_bundle = df1._repr_mimebundle_()
+    for key, value in mime_bundle.items():
+        assert "..." not in value
+    mime_bundle = df2._repr_mimebundle_()
+    for key, value in mime_bundle.items():
+        assert "..." in value


### PR DESCRIPTION
This PR adds the possibility for the user to control how many columns are visible when printing/displaying the dataframe. Prior to this PR, all column were always shown, resulting in show displaying when a dataframe contains thousands of columns. 

The default is now 50 columns. One can modify this via
```python
vaex.settings.display.max_columns =  20 # for example
```

There is an equivalent setting for the max number of rows
```
vaex.settings.display.max_rows =  20 # for example
```

Checklist:
- [x] Implementation
- [ ] Unit-tests
- [ ] Review

Example:
<img width="808" alt="image" src="https://user-images.githubusercontent.com/18574951/139542612-d97d3a76-0117-4152-9d63-36038845003e.png">
