### PR TITLE
fix(core): fix str.rsplit() when an explicit split pattern is specified

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -1934,7 +1934,7 @@ def str_rsplit(x, pattern=None, max_splits=-1):
     if pattern is None:
         return pc.utf8_split_whitespace(x, reverse=True, max_splits=max_splits)
     else:
-        return pc.split_pattern(x, reverse=True, max_splits=max_splits)
+        return pc.split_pattern(x, pattern=pattern, reverse=True, max_splits=max_splits)
 
 
 @register_function(scope='str')

--- a/tests/strings_test.py
+++ b/tests/strings_test.py
@@ -496,6 +496,12 @@ def test_string_split():
     assert df.s.str.split(max_splits=1).tolist() == [["aap", "noot  mies"], None, ["kees"], [""]]
 
 
+def test_string_rsplit():
+    df = vaex.from_arrays(s=["aap noot  mies", None, "kees", ""])
+    assert df.s.str.rsplit(pattern='noot').tolist() == [['aap ', '  mies'], None, ['kees'], ['']]
+    assert df.s.str.rsplit(pattern='noot', max_splits=1).tolist() == [['aap ', '  mies'], None, ['kees'], ['']]
+
+
 def test_string_split_upper():
     df = vaex.from_arrays(s=["aap noot  mies", None, "kees", ""])
     assert df.s.str.split().str.upper().tolist() == [["AAP", "NOOT", "MIES"], None, ["KEES"], [""]]


### PR DESCRIPTION
Addresses the issue raised in #1697

Checklist:
- [x] Make a test
- [x] Make the test pass

 