### PR TITLE
Explicit `ascending` check in `sort` function

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2,6 +2,7 @@
 from __future__ import division, print_function
 import difflib
 import base64
+from typing import Iterable
 import os
 import math
 import time
@@ -4514,9 +4515,11 @@ class DataFrame(object):
           3  b      2  0.04
 
         :param str or expression by: expression to sort by
-        :param bool ascending: ascending (default, True) or descending (False)
+        :param bool ascending: ascending (default, True) or descending (False). Cannot apply different sorting orders to different columns. 
         :param str kind: kind of algorithm to use (passed to numpy.argsort)
         '''
+        if isinstance(ascending, Iterable):
+            raise ValueError("Cannot sort differently by multiple columns. Param ascending must be a single boolean value.")
         self = self.trim()
         if not isinstance(by, list):
             values = self.evaluate(by)


### PR DESCRIPTION
Explicitly only allow single boolean value sorting in `sort` function.

In numpy you can pass in a list to sort and the sort function will sort by each column independently based on the list. Since vaex does not support this, it should be explicit, to avoid unexpected results by the user. 


https://github.com/vaexio/vaex/issues/1631
https://github.com/vaexio/vaex/issues/815