### PR TITLE
Fixing vaex.open for multipart parquet/arrow files

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -237,7 +237,7 @@ def open(path, convert=False, shuffle=False, fs_options={}, fs=None, *args, **kw
             else:
                 dfs = []
                 for filename in filenames:
-                    dfs.append(vaex.open(filename, convert=bool(convert), shuffle=shuffle, **kwargs))
+                    dfs.append(vaex.open(filename, fs_options=fs_options, fs=fs, convert=bool(convert), shuffle=shuffle, **kwargs))
                 df = vaex.concat(dfs)
                 if convert:
                     if shuffle:

--- a/packages/vaex-core/vaex/file/s3fs.py
+++ b/packages/vaex-core/vaex/file/s3fs.py
@@ -17,12 +17,18 @@ def translate_options(fs_options):
     # translate options of arrow to s3fs
     fs_options = fs_options.copy()
     not_supported = {
-        'role_arn', 'session_name', 'external_id', 'load_frequency', 'scheme', 'background_writes', 'profile', 'profile_name'
+        'role_arn', 'session_name', 'external_id', 'load_frequency', 'background_writes', 'profile', 'profile_name'
     }
     for key in not_supported:
         if key in fs_options:
              warnings.warn(f'The option {key} is not supported using s3fs instead of arrow, so it will be ignored')
              fs_options.pop(key)
+
+    # If scheme key is present in the fs_options use that, else default it to https
+    if 'scheme' in fs_options.keys():
+        fs_options['endpoint_override'] = fs_options.pop('scheme') + "://" + fs_options.pop('endpoint_override')
+    else:
+        fs_options['endpoint_override'] = "https://" + fs_options.pop('endpoint_override')
 
     # top level
     mapping = {

--- a/packages/vaex-core/vaex/file/s3fs.py
+++ b/packages/vaex-core/vaex/file/s3fs.py
@@ -25,10 +25,11 @@ def translate_options(fs_options):
              fs_options.pop(key)
 
     # If scheme key is present in the fs_options use that, else default it to https
-    if 'scheme' in fs_options.keys():
-        fs_options['endpoint_override'] = fs_options.pop('scheme') + "://" + fs_options.pop('endpoint_override')
-    else:
-        fs_options['endpoint_override'] = "https://" + fs_options.pop('endpoint_override')
+    if 'endpoint_override' in fs_options.keys():
+        if 'scheme' in fs_options.keys():
+            fs_options['endpoint_override'] = fs_options.pop('scheme') + "://" + fs_options.pop('endpoint_override')
+        else:
+            fs_options['endpoint_override'] = "https://" + fs_options.pop('endpoint_override')
 
     # top level
     mapping = {


### PR DESCRIPTION
Fixes issue #1714 .
Changes 
1. During recursive call of vaex.open , fs and fs_options augments passed.
2. Added new key scheme for fs_options. If not passed , it will default to https. 