### PR TITLE
Fix: Evaluate with selections

### DIFF
--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -91,7 +91,7 @@ def is_string(ar):
 
 def filter(ar, boolean_mask):
     if isinstance(ar, supported_arrow_array_types):
-        return ar.filter(pa.array(boolean_mask))
+        return ar.filter(to_arrow(boolean_mask))
     else:
         return ar[boolean_mask]
 

--- a/tests/evaluate_test.py
+++ b/tests/evaluate_test.py
@@ -145,3 +145,11 @@ def test_arrow_evaluate(parallel):
     assert df.evaluate(df.s.as_arrow(), array_type='arrow', parallel=parallel).type == pa.string()
     assert df.evaluate(df.s.as_arrow(), array_type=None, parallel=parallel).type == pa.string()
     assert df.evaluate(df.l, parallel=parallel).type == pa.list_(l.type.value_type)
+
+
+def test_evaluate_with_selection(df_factory):
+    x = np.arange(3)
+    df = df_factory(x=x)
+    assert df.x.evaluate(selection='x>0', array_type='numpy').tolist() == [1, 2]
+    assert df.x.evaluate(selection='x>0', array_type='arrow').to_pylist() == [1, 2]
+    assert df.x.evaluate(selection='x>0', array_type='python') == [1, 2]


### PR DESCRIPTION
Currently `df.x.evaluate(selection='...')` fails the underlying data of `x` is in arrow. 

This PR fixes that and adds a more stable test.

- [x] Expose issue via a test
- [ ] Make test pass