### PR TITLE
ci: avoid uvicorn 0.16 for windows/3.8,3.9

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -40,5 +40,6 @@ dependencies:
 - scikit-learn
 - scipy
 - tornado
+- uvicorn<0.16
 - xarray
 - myst-parser


### PR DESCRIPTION
Remote dataframe seems to not do the progress/cancel part on these two platforms, only difference seems unicorn 0.16, although that does work on windows/3.7.