### PR TITLE
handle chunked arrays in _pandas_dt_fix

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -283,7 +283,9 @@ def scalar_timedelta(amount, unit):
 def _pandas_dt_fix(x):
     # see https://github.com/pandas-dev/pandas/issues/23276
     # not sure which version this is fixed in
-    if isinstance(x, pa.lib.TimestampArray):
+    if isinstance(x, pa.lib.TimestampArray) or (
+        isinstance(x, pa.lib.ChunkedArray) and isinstance(x.type, pa.lib.TimestampType)
+    ):
         return x.to_pandas()
     if not x.flags['WRITEABLE']:
         x = x.copy()

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -283,9 +283,7 @@ def scalar_timedelta(amount, unit):
 def _pandas_dt_fix(x):
     # see https://github.com/pandas-dev/pandas/issues/23276
     # not sure which version this is fixed in
-    if isinstance(x, pa.lib.TimestampArray) or (
-        isinstance(x, pa.lib.ChunkedArray) and isinstance(x.type, pa.lib.TimestampType)
-    ):
+    if vaex.array_types.is_arrow_array(x) and isinstance(x.type, pa.lib.TimestampType):
         return x.to_pandas()
     if not x.flags['WRITEABLE']:
         x = x.copy()

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -160,11 +160,12 @@ def test_non_ns_units():
     df = vaex.from_arrays(dates=pa.array(dates))
     assert np.all(df.dates.to_numpy() == dates)
 
-def test_datetime_operations_after_astype():
-    x =  ['2009-10-12T03:31:00',
-          '2016-02-11T10:17:34',
-          '2015-11-12T11:34:22']
-    df = vaex.from_arrays(x=x)
+def test_datetime_operations_after_astype(df_factory):
+    df = df_factory(x=[
+        '2009-10-12T03:31:00',
+        '2016-02-11T10:17:34',
+        '2015-11-12T11:34:22',
+    ])
     df['x_dt'] = df.x.astype('datetime64')
     df['x_hour'] = df.x_dt.dt.hour
     assert df.x_hour.tolist() == [3, 10, 11]


### PR DESCRIPTION
When loading feather files with pyarrow 6.0.1, dt methods fail because the underlying arrays are chunked. This change modifies the test to handle chunked arrays.