### PR TITLE
Handle empty arrow files

### DIFF
--- a/packages/vaex-core/vaex/arrow/dataset.py
+++ b/packages/vaex-core/vaex/arrow/dataset.py
@@ -311,7 +311,7 @@ class DatasetArrowIPCFile(DatasetArrowFileBase):
         self._source = vaex.file.open(path=self.path, mode='rb', fs_options=self.fs_options, fs=self.fs, mmap=True, for_arrow=True)
         reader = pa.ipc.open_file(self._source)
         batches = [reader.get_batch(i) for i in range(reader.num_record_batches)]
-        table = pa.Table.from_batches(batches)
+        table = pa.Table.from_batches(batches, schema=reader.schema)
         self._columns = dict(zip(table.schema.names, table.columns))
 
 
@@ -321,7 +321,7 @@ class DatasetArrowIPCStream(DatasetArrowFileBase):
     def _create_columns(self):
         self._source = vaex.file.open(path=self.path, mode='rb', fs_options=self.fs_options, fs=self.fs, mmap=True, for_arrow=True)
         reader = pa.ipc.open_stream(self._source)
-        table = pa.Table.from_batches(reader)
+        table = pa.Table.from_batches(reader, schema=reader.schema)
         self._columns = dict(zip(table.schema.names, table.columns))
 
 

--- a/tests/arrow/io_test.py
+++ b/tests/arrow/io_test.py
@@ -23,3 +23,16 @@ def test_chunks(df_trimmed, tmpdir):
     df_read = vaex.open(path)
     assert isinstance(df_read.columns['x'], pa.ChunkedArray)
     assert df_read.x.tolist() == df.x.tolist()
+
+
+@pytest.mark.parametrize("as_stream", [True, False])
+def test_empty(tmpdir, as_stream):
+    path = str(tmpdir.join('test.arrow'))
+    schema = pa.schema([pa.field("x", pa.string())])
+    with open(path, mode='wb') as f:
+        if as_stream:
+            writer = pa.ipc.new_stream(f, schema)
+        else:
+            writer = pa.ipc.new_file(f, schema)
+        writer.close()
+    vaex.open(path)


### PR DESCRIPTION
Pass along schema explicitly so that empty files can be opened