### PR TITLE
✨ do not use asyncio for the sync execute path

### DIFF
--- a/packages/vaex-server/vaex/server/executor.py
+++ b/packages/vaex-server/vaex/server/executor.py
@@ -12,6 +12,9 @@ class Executor(vaex.execution.Executor):
         # TODO: turn evaluate into a task
         return self.client._rmi(df, methodname, args, kwargs)
 
+    def execute(self):
+        self.run(self.execute_async())
+
     async def execute_async(self):
         self.signal_begin.emit()
         cancelled = False


### PR DESCRIPTION
We use generators now, so the 'top level'
execute_async can still do task switching while sharing the same
code with the sync version.

The remote executor will prefer to use the async version, and will
use nest asyncio when a sync call is done.