### PR TITLE
✨ auto execute task context manager when awaiting task or promise

### DIFF
--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function
 import ast
 import asyncio
 from collections import defaultdict
+import contextlib
 import os
 import time
 import threading
@@ -183,6 +184,16 @@ class Executor:
             self.isnested = contextvars.ContextVar('executor', default=False)
         self.lock = threading.Lock()
         self.event_loop = asyncio.new_event_loop()
+
+    @contextlib.asynccontextmanager
+    async def auto_execute(self):
+        '''This async executor will start executing tasks automatically when a task is awaited for.'''
+        vaex.promise.auto_await_executor.set(self)
+        try:
+            yield
+            await self.execute_async()
+        finally:
+            vaex.promise.auto_await_executor.set(None)
 
     async def execute_async(self):
         raise NotImplementedError

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -327,6 +327,20 @@ def test_continue_next_task_after_cancel():
     assert result.isFulfilled
 
 
+@pytest.mark.asyncio
+async def test_auto_execute():
+    df = vaex.from_arrays(x=[2, 4])
+    async def means():
+        count, sum = await asyncio.gather(df.x.count(delay=True), df.x.sum(delay=True))
+        mean = await df.x.mean(delay=True)
+        return sum / count, mean
+    async with df.executor.auto_execute():
+        mean1, mean2 = await means()
+        assert mean1 == 3
+        assert mean2 == 3
+
+
+
 # def test_add_and_cancel_tasks(df_executor):
 #     df = df_executor
 


### PR DESCRIPTION
This allows us to write async code like this:
```
async def means():
    count, sum = await asyncio.gather(df.x.count(delay=True), df.x.sum(delay=True))
    mean = await df.x.mean(delay=True)
    return sum / count, mean
```

However, vaex does not automatically start executing tasks (only when
explicitly asked for).
Even worse, the executor might stop the task executing loop, before
new tasks are added (here the call to mean() might happen too late)

Within this new context manager, the executor will automatically get called

```
async with df.executor.auto_execute():
    mean1, mean2 = await means()
```