### PR TITLE
🐛 support empty parquet and arrow files

### DIFF
--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -593,6 +593,8 @@ class ColumnProxy(vaex.column.Column):
                     array_chunks.append(ar)
             if len(array_chunks) == 1:
                 return array_chunks[0]
+            if len(array_chunks) == 0:
+                return vaex.dtype(self.dtype).create_array([])
             return vaex.array_types.concat(array_chunks)
         else:
             raise NotImplementedError

--- a/tests/arrow/io_test.py
+++ b/tests/arrow/io_test.py
@@ -36,3 +36,13 @@ def test_empty(tmpdir, as_stream):
             writer = pa.ipc.new_file(f, schema)
         writer.close()
     vaex.open(path)
+
+
+@pytest.mark.parametrize("filename", ['test.parquet', 'test.arrow'])
+def test_empty(tmpdir, filename):
+    df = vaex.from_arrays(x=[1,2])
+    path = tmpdir / filename
+    dff = df[df.x > 3]
+    dff.export(path)
+    df2 = vaex.open(path)
+    assert df2.x.tolist() == []


### PR DESCRIPTION
What do you think of `df.schema_arrow`, is it time for an `arrow` accessor, so we have `df.arrow.schema()` ?