### PR TITLE
✨ execute_async block less, doing true await on the thread pool

### DIFF
--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -292,11 +292,11 @@ class ExecutorLocal(Executor):
         # level, such that we don't need await in the downstream code
         # so we can reuse the same code in a sync way
         gen = self.execute_generator(use_async=True)
+        value = None
         while True:
             try:
-                value = next(gen)
+                value = gen.send(value)
                 value = await value
-                gen.send(value)
             except StopIteration:
                 break
 

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -288,14 +288,23 @@ class ExecutorLocal(Executor):
         return chunk_size
 
     async def execute_async(self):
-        for _ in self.execute_generator():
-            await asyncio.sleep(1e-5)  # allow task switch
+        # consume awaitables from the generator, and await them here at the top
+        # level, such that we don't need await in the downstream code
+        # so we can reuse the same code in a sync way
+        gen = self.execute_generator(use_async=True)
+        while True:
+            try:
+                value = next(gen)
+                value = await value
+                gen.send(value)
+            except StopIteration:
+                break
 
     def execute(self):
         for _ in self.execute_generator():
             pass  # just eat all elements
 
-    def execute_generator(self):
+    def execute_generator(self, use_async=False):
         logger.debug("starting with execute")
 
         with self.lock:  # setup thread local initial values
@@ -413,12 +422,11 @@ class ExecutorLocal(Executor):
                     if not ok_executor:
                         logger.debug("Pass cancelled because of the global progress event: %r", self.signal_progress.callbacks)
                     return ok_tasks and ok_executor
-                for _element in self.thread_pool.map(self.process_part, dataset.chunk_iterator(run.dataset_deps, chunk_size),
+                for element in self.thread_pool.map(self.process_part, dataset.chunk_iterator(run.dataset_deps, chunk_size),
                                                     dataset.row_count,
                                                     progress=progress,
-                                                    cancel=lambda: self._cancel(run), unpack=True, run=run):
-                    pass  # just eat all element
-                    yield
+                                                    cancel=lambda: self._cancel(run), unpack=True, run=run, use_async=use_async):
+                    yield element  # this can be an awaitable, when use_async=True
                 duration_wallclock = time.time() - t0
                 logger.debug("executing took %r seconds", duration_wallclock)
                 self.local.executing = False

--- a/packages/vaex-core/vaex/execution.py
+++ b/packages/vaex-core/vaex/execution.py
@@ -422,11 +422,10 @@ class ExecutorLocal(Executor):
                     if not ok_executor:
                         logger.debug("Pass cancelled because of the global progress event: %r", self.signal_progress.callbacks)
                     return ok_tasks and ok_executor
-                for element in self.thread_pool.map(self.process_part, dataset.chunk_iterator(run.dataset_deps, chunk_size),
+                yield from self.thread_pool.map(self.process_part, dataset.chunk_iterator(run.dataset_deps, chunk_size),
                                                     dataset.row_count,
                                                     progress=progress,
-                                                    cancel=lambda: self._cancel(run), unpack=True, run=run, use_async=use_async):
-                    yield element  # this can be an awaitable, when use_async=True
+                                                    cancel=lambda: self._cancel(run), unpack=True, run=run, use_async=use_async)
                 duration_wallclock = time.time() - t0
                 logger.debug("executing took %r seconds", duration_wallclock)
                 self.local.executing = False

--- a/packages/vaex-core/vaex/multithreading.py
+++ b/packages/vaex-core/vaex/multithreading.py
@@ -67,7 +67,7 @@ class ThreadPoolIndex(concurrent.futures.ThreadPoolExecutor):
         self.nthreads = self._max_workers
         self._debug_sleep = 0
 
-    def map(self, callable, iterator, count, on_error=None, progress=None, cancel=None, unpack=False, **kwargs_extra):
+    def map(self, callable, iterator, count, on_error=None, progress=None, cancel=None, unpack=False, use_async=False, **kwargs_extra):
         progress = progress or (lambda x: True)
         cancelled = False
 
@@ -94,13 +94,24 @@ class ThreadPoolIndex(concurrent.futures.ThreadPoolExecutor):
                 if cancelled:
                     break
         if self.nthreads == 1:  # when using 1 thread, it makes debugging easier (better stacktrace)
-            iterator = self._map(wrapped, cancellable_iter())
+            if use_async:
+                iterator = self._map_async(wrapped, cancellable_iter())
+            else:
+                iterator = self._map(wrapped, cancellable_iter())
         else:
-            iterator = super(ThreadPoolIndex, self).map(wrapped, cancellable_iter())
+            if use_async:
+                loop = asyncio.get_event_loop()
+                iterator = (loop.run_in_executor(self, lambda value=value: wrapped(value)) for value in cancellable_iter())
+            else:
+                iterator = super(ThreadPoolIndex, self).map(wrapped, cancellable_iter())
         total = 0
         iterator = iter(buffer(iterator, self._max_workers + 3))
         try:
             for value in iterator:
+                if use_async:
+                    value = yield value
+                else:
+                    yield value
                 if value != None:
                     total += value
                 progress_value = (total) / count
@@ -111,7 +122,6 @@ class ThreadPoolIndex(concurrent.futures.ThreadPoolExecutor):
                         cancelled = True
                         cancel()
                         break
-                yield value
         finally:
             if not cancelled:
                 cancelled = True
@@ -127,3 +137,9 @@ class ThreadPoolIndex(concurrent.futures.ThreadPoolExecutor):
     def _map(self, callable, iterator):
         for i in iterator:
             yield callable(i)
+
+    def _map_async(self, callable, iterator):
+        for i in iterator:
+            future = asyncio.Future()
+            future.set_result(callable(i))
+            yield future

--- a/tests/progress_test.py
+++ b/tests/progress_test.py
@@ -77,7 +77,7 @@ async def test_progress_calls_async(df):
         assert x == x2
         assert y == y2
         assert counter.counter > 0
-        assert counter.last_args[0], 1.0
+        assert counter.last_args[0] == 1.0
 
 
 def test_cancel(df):


### PR DESCRIPTION
`py.test tests/progress_test.py -k test_cancel_huge` for instance cancels much quicker, because it does not have to wait for the blocking yield in the thread pool.