### PR TITLE
✨ limit and limit_raise for unique and nunique

### DIFF
--- a/packages/vaex-core/src/hash.hpp
+++ b/packages/vaex-core/src/hash.hpp
@@ -131,7 +131,7 @@ class hash_common {
     using hasher_map = typename hashmap_type::hasher;
     using hasher_map_choice = typename hashmap_type::hasher; // typename vaex::hash<key_type>;
 
-    hash_common(int16_t nmaps) : maps(nmaps), maplocks(nmaps), nan_count(0), null_count(0), sealed(false) {}
+    hash_common(int16_t nmaps, int64_t limit = -1) : maps(nmaps), limit(limit), maplocks(nmaps), nan_count(0), null_count(0), sealed(false) {}
 
     void update1(key_type &key) {
         std::size_t hash = hasher_map_choice()(key);
@@ -249,6 +249,7 @@ class hash_common {
     }
 
     std::vector<hashmap_type> maps;
+    int64_t limit;
     std::vector<std::mutex> maplocks;
     int64_t nan_count;
     int64_t null_count;

--- a/packages/vaex-core/src/hash_object.cpp
+++ b/packages/vaex-core/src/hash_object.cpp
@@ -179,7 +179,7 @@ template<class T=PyObject*>
 class ordered_set : public hash_base<ordered_set<T>, T, T> {
 public:
     using typename hash_base<ordered_set<T>, T, T>::value_type;
-    ordered_set(int ignore) {}
+    ordered_set(int ignore, int64_t limit) {}
     using typename hash_base<ordered_set<T>,T, T>::storage_type;
     py::array_t<bool> isin(py::buffer object_array) {
         py::buffer_info info = object_array.request();
@@ -334,7 +334,7 @@ void init_hash_object(py::module &m) {
         std::string ordered_setname = "ordered_set_object";
         typedef ordered_set<> Type;
         py::class_<Type>(m, ordered_setname.c_str())
-            .def(py::init<int>())
+            .def(py::init<int, int64_t>(), py::arg("nmaps"), py::arg("limit") = -1)
             .def("isin", &Type::isin)
             .def("update", &Type::update, "add values", py::arg("values"), py::arg("start_index") = 0, py::arg("chunk_size") = 1024 * 128, py::arg("bucket_size") = 1024 * 128,
                  py::arg("return_values") = false)

--- a/packages/vaex-core/src/hash_primitives.cpp
+++ b/packages/vaex-core/src/hash_primitives.cpp
@@ -39,7 +39,7 @@ void init_hash_(M m, std::string name, std::string suffix) {
         std::string ordered_setname = "ordered_set_" + name + suffix;
         typedef ordered_set<T, Hashmap> Type;
         auto cls = py::class_<Type>(m, ordered_setname.c_str())
-                       .def(py::init<int>())
+                       .def(py::init<int, int64_t>(), py::arg("nmaps"), py::arg("limit") = -1)
                        .def(py::init(&Type::create))
                        .def("isin", &Type::isin)
                        .def("flatten_values", &Type::flatten_values)

--- a/packages/vaex-core/src/hash_primitives.hpp
+++ b/packages/vaex-core/src/hash_primitives.hpp
@@ -97,7 +97,7 @@ class hash_base : public hash_common<Derived, T, Hashmap<T, int64_t>> {
         if (bucket_size < chunk_size) {
             throw std::runtime_error("bucket size should be larger than chunk_size");
         }
-        if (this->limit >= -1 && return_values) {
+        if (this->limit >= 0 && return_values) {
             throw std::runtime_error("Cannot combine limit with return_inverse");
         }
         const bool use_offsets = return_values || (start_index != -1);

--- a/packages/vaex-core/src/hash_string.cpp
+++ b/packages/vaex-core/src/hash_string.cpp
@@ -78,7 +78,7 @@ void init_hash_string(py::module &m) {
         std::string ordered_setname = "ordered_set_string";
         typedef ordered_set<> Type;
         auto cls = py::class_<Type>(m, ordered_setname.c_str())
-                       .def(py::init<int>())
+                       .def(py::init<int, int64_t>(), py::arg("nmaps"), py::arg("limit") = -1)
                        .def(py::init(&Type::create<StringList32>))
                        .def(py::init(&Type::create<StringList64>))
                        .def("isin", &Type::isin)

--- a/packages/vaex-core/src/hash_string.hpp
+++ b/packages/vaex-core/src/hash_string.hpp
@@ -53,7 +53,7 @@ class hash_base : public hash_common<Derived, T, hashmap<T, int64_t>> {
         if (bucket_size < chunk_size) {
             throw std::runtime_error("bucket size should be larger than chunk_size");
         }
-        if (this->limit >= -1 && return_values) {
+        if (this->limit >= 0 && return_values) {
             throw std::runtime_error("Cannot combine limit with return_inverse");
         }
         int64_t size = strings->length;

--- a/packages/vaex-core/vaex/column.py
+++ b/packages/vaex-core/vaex/column.py
@@ -574,6 +574,8 @@ def _to_string_sequence(x, force=True):
                 return vaex.strings.StringList64(bytes, indices, length, 0, null_bitmap, 0)
             else:
                 ValueError('unsupported dtype ' +str(x.dtype))
+    elif isinstance(x, vaex.superstrings.StringList32):
+        return x
     elif isinstance(x, (list, type)):
         return _to_string_sequence(np.array(x))
     else:

--- a/packages/vaex-core/vaex/docstrings.py
+++ b/packages/vaex-core/vaex/docstrings.py
@@ -42,3 +42,5 @@ _doc_snippets['fs_options'] = 'see :func:`vaex.open` e.g. for S3 {"profile": "my
 _doc_snippets['fs'] = 'Pass a file system object directly, see :func:`vaex.open`'
 _doc_snippets['random_state'] = 'Sets a seed or `RandomState` for reproducability. When `None`, a random seed it chosen.'
 _doc_snippets['trim'] = 'Trim off begin or end of dataframe to avoid missing values'
+_doc_snippets['limit'] = 'Limit the amount of results'
+_doc_snippets['limit_raise'] = 'Raise :exception:`vaex.RowLimitException` when limit is exceeded, or return at maximum \'limit\' amount of results.'

--- a/packages/vaex-core/vaex/encoding.py
+++ b/packages/vaex-core/vaex/encoding.py
@@ -298,8 +298,8 @@ class selection_encoding:
             return {'type': 'ndarray', 'data': encoding.encode('ndarray', obj)}
         elif isinstance(obj, vaex.array_types.supported_arrow_array_types):
             return {'type': 'arrow-array', 'data': encoding.encode('arrow-array', obj)}
-        elif isinstance(obj, vaex.hash.ordered_set):
-            return {'type': 'ordered-set', 'data': encoding.encode('ordered-set', obj)}
+        elif isinstance(obj, vaex.hash.HashMapUnique):
+            return {'type': 'hash-map-unique', 'data': encoding.encode('hash-map-unique', obj)}
         elif isinstance(obj, np.generic):
             return {'type': 'numpy-scalar', 'data': encoding.encode('numpy-scalar', obj)}
         elif isinstance(obj, np.integer):
@@ -321,40 +321,6 @@ class selection_encoding:
             return encoding.decode(obj_spec['type'], obj_spec['data'])
         else:
             return obj_spec
-
-
-@register("ordered-set")
-class ordered_set_encoding:
-    @staticmethod
-    def encode(encoding, obj):
-        keys = obj.key_array()
-        if isinstance(keys, (vaex.strings.StringList32, vaex.strings.StringList64)):
-            keys = vaex.strings.to_arrow(keys)
-        keys = encoding.encode('array', keys)
-        clsname = obj.__class__.__name__
-        return {
-            'class': clsname,
-            'data': {
-                'keys': keys,
-                'null_value': obj.null_value,
-                'nan_count': obj.nan_count,
-                'missing_count': obj.null_count,
-                'fingerprint': obj.fingerprint,
-            }
-        }
-
-
-    @staticmethod
-    def decode(encoding, obj_spec):
-        clsname = obj_spec['class']
-        cls = getattr(vaex.hash, clsname)
-        keys = encoding.decode('array', obj_spec['data']['keys'])
-        dtype = vaex.dtype_of(keys)
-        if dtype.is_string:
-            keys = vaex.strings.to_string_sequence(keys)
-        value = cls(keys, obj_spec['data']['null_value'], obj_spec['data']['nan_count'], obj_spec['data']['missing_count'], obj_spec['data']['fingerprint'])
-        return value
-
 
 
 class Encoding:

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -15,13 +15,14 @@ import numpy as np
 import pandas as pd
 import tabulate
 import pyarrow as pa
-from vaex.datatype import DataType
-from vaex.docstrings import docsubst
 
+import vaex.hash
+import vaex.serialize
 from vaex.utils import _ensure_strings_from_expressions, _ensure_string_from_expression
 from vaex.column import ColumnString, _to_string_sequence
 from .hash import counter_type_from_dtype
-import vaex.serialize
+from vaex.datatype import DataType
+from vaex.docstrings import docsubst
 from . import expresso
 
 
@@ -1381,7 +1382,7 @@ def f({0}):
             raise ValueError('only axis=None is supported')
         # we map the keys to a ordinal values [0, N-1] using the set
         key_set = df._set(self.expression, flatten=axis is None)
-        found_keys = key_set.keys()
+        found_keys = vaex.array_types.tolist(key_set.keys())
 
         # we want all possible values to be converted
         # so mapper's key should be a superset of the keys found
@@ -1411,32 +1412,26 @@ def f({0}):
         # to the default_value
         dtype_item = self.data_type(self.expression, axis=-1)
         null_count = mapper_keys.count(None)
-        nan_count = len([k for k in mapper_keys if k != k])
         if null_count:
             null_value = mapper_keys.index(None)
         else:
             null_value = 0x7fffffff
 
         mapper_keys = dtype_item.create_array(mapper_keys)
-        if vaex.array_types.is_string_type(dtype_item):
-            mapper_keys = _to_string_sequence(mapper_keys)
-
-        from .hash import ordered_set_type_from_dtype
-        ordered_set_type = ordered_set_type_from_dtype(dtype_item)
         fingerprint = key_set.fingerprint + "-mapper"
-        ordered_set = ordered_set_type(mapper_keys, null_value, nan_count, null_count, fingerprint)
-        indices = ordered_set.map_ordinal(mapper_keys)
+        hash_map_unique = vaex.hash.HashMapUnique.from_keys(mapper_keys, null_value=null_value, null_count=null_count, fingerprint=fingerprint, dtype=dtype_item)
+        indices = hash_map_unique.map(mapper_keys)
         mapper_values = [mapper_values[i] for i in indices]
 
         choices = [default_value] + [mapper_values[index] for index in indices]
         choices = pa.array(choices)
 
-        key_set_name = df.add_variable('map_key_set', ordered_set, unique=True)
+        key_hash_map_unique_name = df.add_variable('map_key_hash_map_unique', hash_map_unique, unique=True)
         choices_name = df.add_variable('map_choices', choices, unique=True)
         if allow_missing:
-            expr = '_map({}, {}, {}, use_missing={!r}, axis={!r})'.format(self, key_set_name, choices_name, use_masked_array, axis)
+            expr = '_map({}, {}, {}, use_missing={!r}, axis={!r})'.format(self, key_hash_map_unique_name, choices_name, use_masked_array, axis)
         else:
-            expr = '_map({}, {}, {}, axis={!r})'.format(self, key_set_name, choices_name, axis)
+            expr = '_map({}, {}, {}, axis={!r})'.format(self, key_hash_map_unique_name, choices_name, axis)
         return Expression(df, expr)
 
     @property

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2438,19 +2438,18 @@ for name in dir(scopes['str']):
 
 # expression_namespace['str_strip'] = str_strip
 
+# kept for backwards compatibility
 @register_function()
-def _ordinal_values(x, ordered_set):
-    from vaex.column import _to_string_sequence
+def _ordinal_values(x, hashmap_unique):
+    return hashmap_apply(x, hashmap_unique)
 
-    if not isinstance(x, vaex.array_types.supported_array_types) or isinstance(ordered_set, vaex.superutils.ordered_set_string):
-        # sometimes the dtype can be object, but seen as an string array
-        x = _to_string_sequence(x)
-    else:
-        x = vaex.array_types.to_numpy(x)
-    indices = ordered_set.map_ordinal(x)
-    if np.ma.isMaskedArray(x):
-        indices[x.mask] = ordered_set.null_value
+
+@register_function()
+def hashmap_apply(x, hashmap):
+    '''Apply values to hashmap'''
+    indices = hashmap.map(x)
     return indices
+
 
 @register_function()
 def _choose(ar, choices, default=None):

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2479,14 +2479,8 @@ def _map(ar, value_to_index, choices, default_value=None, use_missing=False, axi
         import vaex.arrow.utils
         ar, wrapper = vaex.arrow.utils.list_unwrap(ar)
 
-    if not isinstance(ar, vaex.array_types.supported_array_types) or isinstance(value_to_index, vaex.superutils.ordered_set_string):
-        # sometimes the dtype can be object, but seen as an string array
-        ar = _to_string_sequence(ar)
-        # -1 points to missing
-        indices = value_to_index.map_ordinal(ar) + 1
-    else:
-        ar = vaex.array_types.to_numpy(ar)
-        indices = value_to_index.map_ordinal(ar) + 1
+    ar = vaex.array_types.to_numpy(ar)
+    indices = value_to_index.map(ar) + 1
     values = choices.take(indices)
     if np.ma.isMaskedArray(ar):
         mask = np.ma.getmaskarray(ar).copy()
@@ -2566,19 +2560,8 @@ def _isin(x, values):
 
 
 @register_function(name='isin_set', on_expression=False)
-def _isin_set(x, set):
-    if vaex.column._is_stringy(x) or isinstance(set, vaex.superutils.ordered_set_string):
-        x = vaex.column._to_string_column(x)
-        x = _to_string_sequence(x)
-        # return x.string_sequence.isin(values)
-        return set.isin(x)
-    else:
-        if np.ma.isMaskedArray(x):
-            isin = set.isin(x.data)
-            isin[x.mask] = False
-            return isin
-        else:
-            return set.isin(x)
+def _isin_set(x, hashmap_unique):
+    return hashmap_unique.isin(x)
 
 
 @register_function()

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -178,7 +178,7 @@ class Grouper(BinnerBase):
         self.progressbar = vaex.utils.progressbars(progress, title=f"grouper: {repr(self.label)}" )
         dtype = self.expression.dtype
         if materialize_experimental:
-            set, values = df_original._set(self.expression, unique_limit=row_limit, return_inverse=True)
+            set, values = df_original._set(self.expression, limit=row_limit, return_inverse=True)
             # TODO: add column should have a unique argument
             self.df.add_column(f'__materialized_{self.label}', values)
 

--- a/packages/vaex-core/vaex/hash.py
+++ b/packages/vaex-core/vaex/hash.py
@@ -1,9 +1,13 @@
 import copyreg
+import sys
 import os
 
 import pyarrow as pa
+import numpy as np
 
 import vaex
+import vaex.array_types
+from vaex.column import _to_string_sequence
 import vaex.utils
 
 
@@ -53,3 +57,198 @@ def index_type_from_dtype(dtype, transient=True, prime_growth=False):
     if prime_growth:
         name += "_prime_growth"
     return vaex.utils.find_type_from_dtype(vaex.hash, name, dtype, transient=transient, support_non_native=False)
+
+
+@vaex.encoding.register("hash-map-unique")
+class HashMapUnique:
+    '''HashMap that maps keys to unique integers'''
+    def __init__(self, dtype, nmaps=1, limit=None, _internal=None):
+        self.dtype = dtype
+        self.dtype_item = self.dtype
+        limit = -1 if limit is None else limit
+        if _internal is None:
+            cls = ordered_set_type_from_dtype(dtype)
+            self._internal = cls(nmaps, limit)
+        else:
+            self._internal = _internal
+
+    @staticmethod
+    def encode(encoding, obj):
+        keys = obj._internal.key_array()
+        if isinstance(keys, (vaex.strings.StringList32, vaex.strings.StringList64)):
+            keys = vaex.strings.to_arrow(keys)
+        keys = encoding.encode('array', keys)
+        clsname = obj._internal.__class__.__name__
+        return {
+            'class': clsname,
+            'dtype': encoding.encode('dtype', vaex.dtype(obj.dtype)),
+            'data': {
+                'keys': keys,
+                'null_value': obj.null_value,
+                'nan_count': obj.nan_count,
+                'missing_count': obj.null_count,
+                'fingerprint': obj.fingerprint,
+            }
+        }
+
+    @staticmethod
+    def decode(encoding, obj_spec):
+        clsname = obj_spec['class']
+        cls = getattr(vaex.hash, clsname)
+        keys = encoding.decode('array', obj_spec['data']['keys'])
+        dtype = vaex.dtype_of(keys)
+        if dtype.is_string:
+            keys = vaex.strings.to_string_sequence(keys)
+        _hash_map_internal = cls(keys, obj_spec['data']['null_value'], obj_spec['data']['nan_count'], obj_spec['data']['missing_count'], obj_spec['data']['fingerprint'])
+        dtype = encoding.decode('dtype', obj_spec['dtype'])
+        return vaex.hash.HashMapUnique(dtype, _internal=_hash_map_internal)
+
+    @classmethod
+    def from_keys(cls, keys, null_value, null_count, dtype=None, fingerprint=''):
+        dtype = vaex.dtype_of(keys) if dtype is None else dtype
+        if vaex.dtype_of(keys) == float:
+            nancount = np.isnan(keys).sum()
+        else:
+            nancount = 0
+        set_type = vaex.hash.ordered_set_type_from_dtype(dtype)
+        if dtype.is_string:
+            values = vaex.column.ColumnStringArrow.from_arrow(keys)
+            string_sequence = values.string_sequence
+            hash_map_unique_internal = set_type(string_sequence, null_value, nancount, null_count, fingerprint)
+        else:
+            hash_map_unique_internal = set_type(keys, null_value, nancount, null_count, fingerprint)
+        return HashMapUnique(dtype, _internal=hash_map_unique_internal)
+
+    def add(self, ar, return_inverse=False):
+        if self.dtype_item.is_string:
+            ar = _to_string_sequence(ar)
+        else:
+            ar = vaex.array_types.to_numpy(ar)
+            if ar.strides != (ar.itemsize,):
+                ar = ar.copy()
+
+        chunk_size = 1024*1024
+        if np.ma.isMaskedArray(ar):
+            mask = np.ma.getmaskarray(ar)
+            if return_inverse:
+                return self._internal.update(ar, mask, -1, chunk_size=chunk_size, bucket_size=chunk_size*4, return_values=return_inverse)
+            else:
+                self._internal.update(ar, mask,  -1, chunk_size=chunk_size, bucket_size=chunk_size*4)
+        else:
+            if return_inverse:
+                return self._internal.update(ar, -1, chunk_size=chunk_size, bucket_size=chunk_size*4, return_values=return_inverse)
+            else:
+                self._internal.update(ar, -1, chunk_size=chunk_size, bucket_size=chunk_size*4)
+    
+    def __len__(self):
+        return len(self._internal)
+
+    def merge(self, others):
+        self._internal.merge(others)
+
+    def keys(self, mask=True):
+        ar = self._internal.key_array()
+        if self.dtype_item.is_datetime or self.dtype_item.is_timedelta:
+            ar = ar.view(self.dtype_item.numpy)
+        if isinstance(ar, vaex.superstrings.StringList64):
+            # TODO: find out why this more efficient path does not work
+            # col = vaex.column.ColumnStringArrow.from_string_sequence(self.bin_values)
+            # self.bin_values = pa.array(col)
+            ar = pa.array(ar.to_numpy())
+        if mask and self.has_null and (self.dtype_item.is_primitive or self.dtype_item.is_datetime):
+            mask = np.zeros(shape=ar.shape, dtype="?")
+            mask[self.null_value] = 1
+            ar = np.ma.array(ar, mask=mask)
+        return ar
+
+    def map(self, keys):
+        '''Map key values to unique integers'''
+        from vaex.column import _to_string_sequence
+
+        if not isinstance(keys, vaex.array_types.supported_array_types) or self.dtype == str:
+            # sometimes the dtype can be object, but seen as an string array
+            keys = _to_string_sequence(keys)
+        else:
+            keys = vaex.array_types.to_numpy(keys)
+        indices = self._internal.map_ordinal(keys)
+        if np.ma.isMaskedArray(keys):
+            indices[keys.mask] = self.null_value
+        return indices
+
+    @property
+    def has_null(self):
+        return self._internal.has_null
+
+    @property
+    def has_nan(self):
+        return self._internal.has_nan
+
+    @property
+    def null_value(self):
+        return self._internal.null_value
+
+    @property
+    def nan_value(self):
+        return self._internal.nan_value
+
+    @property
+    def fingerprint(self):
+        return self._internal.fingerprint
+
+    @property
+    def nan_count(self):
+        return self._internal.nan_count
+
+    @property
+    def null_count(self):
+        return self._internal.null_count
+
+    def sorted(self, keys=None, indices=None, return_keys=False):
+        keys = self.keys() if keys is None else keys
+        keys = vaex.array_types.to_arrow(keys)
+        indices = pa.compute.sort_indices(keys) if indices is None else indices
+        # arrow sorts with null last
+        null_value = -1 if not self.has_null else len(keys)-1
+        keys = pa.compute.take(keys, indices)
+        fingerprint = self._internal.fingerprint + "-sorted"
+        if self.dtype_item.is_string:
+            string_sequence = vaex.column.ColumnStringArrow.from_arrow(keys).string_sequence
+            set = type(self._internal)(string_sequence, null_value, self._internal.nan_count, self._internal.null_count, fingerprint)
+        else:
+            set = type(self._internal)(keys, null_value, self._internal.nan_count, self._internal.null_count, fingerprint)
+        hash_map_sorted = HashMapUnique(self.dtype, _internal=set)
+        if return_keys:
+            return hash_map_sorted, keys
+        else:
+            return hash_map_sorted
+
+    def limit(self, limit):
+        fingerprint = self.fingerprint + f"-limit-{limit}"
+        keys = self.keys(mask=False)
+        keys = keys[:limit]
+        null_value = self.null_value
+        null_count = 1
+        nan_count = 0
+        if null_value >= limit:
+            null_value = -1
+            null_count = 0
+        if self.dtype_item == float:
+            nan_count = np.isnan(keys).sum()
+        if self.dtype_item.is_string:
+            bin_values = vaex.column.ColumnStringArrow.from_arrow(keys)
+            string_sequence = bin_values.string_sequence
+            hash_map_unique = type(self._internal)(string_sequence, null_value, nan_count, null_count, fingerprint)
+        else:
+            hash_map_unique = type(self._internal)(keys, null_value, nan_count, null_count, fingerprint)
+        hash_map_unique.fingerprint = fingerprint
+        return HashMapUnique(self.dtype, _internal=hash_map_unique)
+
+    def __sizeof__(self) -> int:
+        return sys.getsizeof(self._internal)
+
+
+@dask.base.normalize_token.register(HashMapUnique)
+def normalize(obj):
+    if not obj.fingerprint:
+        raise RuntimeError('No fingerprint present in HashMapUnique')
+    return obj.fingerprint

--- a/packages/vaex-core/vaex/hash.py
+++ b/packages/vaex-core/vaex/hash.py
@@ -2,6 +2,7 @@ import copyreg
 import sys
 import os
 
+import dask.base
 import pyarrow as pa
 import numpy as np
 
@@ -14,7 +15,6 @@ import vaex.utils
 if vaex.utils.has_c_extension:
     from .superutils import *
     from . import superutils
-    import dask.base
 
     ordered_set = tuple([cls for name, cls in vars(superutils).items() if name.startswith('ordered_set')])
 

--- a/packages/vaex-core/vaex/hash.py
+++ b/packages/vaex-core/vaex/hash.py
@@ -106,7 +106,7 @@ class HashMapUnique:
     @classmethod
     def from_keys(cls, keys, null_value, null_count, dtype=None, fingerprint=''):
         dtype = vaex.dtype_of(keys) if dtype is None else dtype
-        if vaex.dtype_of(keys) == float:
+        if dtype == float:
             nancount = np.isnan(keys).sum()
         else:
             nancount = 0
@@ -174,6 +174,20 @@ class HashMapUnique:
         if np.ma.isMaskedArray(keys):
             indices[keys.mask] = self.null_value
         return indices
+
+    def isin(self, values):
+        if vaex.column._is_stringy(values) or self.dtype_item == str:
+            values = vaex.column._to_string_column(values)
+            values = _to_string_sequence(values)
+            # return x.string_sequence.isin(values)
+            return self._internal.isin(values)
+        else:
+            if np.ma.isMaskedArray(values):
+                isin = self._internal.isin(values.data)
+                isin[values.mask] = False
+                return isin
+            else:
+                return self._internal.isin(values)
 
     @property
     def has_null(self):

--- a/packages/vaex-core/vaex/json.py
+++ b/packages/vaex-core/vaex/json.py
@@ -5,6 +5,7 @@ import numpy as np
 import pyarrow as pa
 
 import vaex
+from vaex.encoding import Encoding
 
 
 serializers = []
@@ -148,6 +149,36 @@ class OrdererSetSerializer:
             keys = vaex.strings.to_string_sequence(keys)
         value = cls(keys, data['data']['null_value'], data['data']['nan_count'], data['data']['missing_count'], data['data']['fingerprint'])
         return value
+
+
+
+
+@register
+class HashMapUniqueSerializer:
+    @staticmethod
+    def can_encode(obj):
+        import vaex.hash
+        return isinstance(obj, vaex.hash.HashMapUnique)
+
+    @staticmethod
+    def encode(obj):
+        encoding = vaex.encoding.Encoding()
+        data = encoding.encode('hash-map-unique', obj)
+        wiredata = vaex.encoding.inline.serialize(data, encoding)
+        return {'type': 'hash-map-unique', 'data': wiredata}
+
+    @staticmethod
+    def can_decode(data):
+        return data.get('type', '') == 'hash-map-unique'
+
+    @staticmethod
+    def decode(data):
+        wiredata = data['data']
+        encoding = vaex.encoding.Encoding()
+        data = vaex.encoding.inline.deserialize(wiredata, encoding)
+        obj = encoding.decode('hash-map-unique', data)
+        return obj
+
 
 
 def encode(obj):

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -329,7 +329,7 @@ def test_executor_from_other_thread():
 
 def test_cancel_single_job():
     df = vaex.from_arrays(x=[1, 2, 3])
-    res1 = df._set(df.x, unique_limit=1, delay=True)
+    res1 = df._set(df.x, limit=1, delay=True)
     res2 = df._set(df.x, delay=True)
     df.execute()
     assert res1.isRejected
@@ -339,12 +339,12 @@ def test_cancel_single_job():
 def test_exception():
     df = vaex.from_arrays(x=[1, 2, 3])
     with pytest.raises(vaex.RowLimitException, match='.* >= 1 .*'):
-        df._set(df.x, unique_limit=1)
+        df._set(df.x, limit=1)
 
 
 def test_continue_next_task_after_cancel():
     df = vaex.from_arrays(x=[1, 2, 3])
-    res1 = df._set(df.x, unique_limit=1, delay=True)
+    res1 = df._set(df.x, limit=1, delay=True)
     def on_error(exception):
         return df._set(df.x, delay=True)
     result = res1.then(None, on_error)

--- a/tests/hashmap_unique_test.py
+++ b/tests/hashmap_unique_test.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+def test_hashmap_unique_basics(df_local):
+    df = df_local
+    xmap = df._hash_map_unique('x')
+    assert set(xmap.keys().tolist()) == set(range(10))
+
+    assert xmap.sorted().keys().tolist() == list(range(10))
+
+def test_hashmap_unique_missing(df_local):
+    df = df_local
+    mmap = df._hash_map_unique('m')
+    expected = list(range(10))
+    expected[9] = None
+    result = mmap.keys().tolist()
+    assert set(result) == set(expected)    
+
+    for limit in range(1, 10):
+        result_limit = mmap.limit(limit).keys()
+        assert result_limit.tolist() == result[:limit]
+
+
+    result_sorted = mmap.sorted().keys().tolist()
+    assert set(result_sorted) == set(expected)
+
+
+def test_hashmap_unique_nan(df_local):
+    df = df_local
+    nmmap = df._hash_map_unique('nm')
+    assert np.isnan(nmmap.keys()).sum() == 1
+
+    expected = list(range(10))
+    expected[7] = None
+    # we can't compare nan, so use 999 as proxy
+    expected[6] = 999
+
+    result = nmmap.keys()
+    result = np.ma.where(np.isnan(result), 999, result).tolist()
+    assert set(result) == set(expected)
+
+    for limit in range(1, 10):
+        result_limit = nmmap.limit(limit).keys()
+        result_limit = np.ma.where(np.isnan(result_limit), 999, result_limit)
+        assert result_limit.tolist() == result[:limit]
+
+    result_sorted = nmmap.sorted().keys()
+    expected_sorted = [0, 1, 2, 3, 4, 5, 8, 9, None, 999]
+    result_sorted = np.ma.where(np.isnan(result_sorted), 999, result_sorted).tolist()
+    assert set(result_sorted) == set(expected_sorted)
+    assert np.isnan(nmmap.sorted().keys()).sum() == 1
+
+
+def test_hashmap_unique_strings(df_factory):
+    expected = ['aap', 'noot', 'mies', None, 'kees']
+    df = df_factory(s=expected)
+    mmap = df._hash_map_unique('s')
+    result = mmap.keys().tolist()
+    assert set(result) == set(expected)    
+
+    for limit in range(1, 10):
+        result_limit = mmap.limit(limit).keys()
+        assert result_limit.tolist() == result[:limit]
+
+    result_sorted = mmap.sorted().keys().tolist()
+    assert set(result_sorted) == set(expected)

--- a/tests/internal/hash_test.py
+++ b/tests/internal/hash_test.py
@@ -433,7 +433,7 @@ def test_set_max_unique(buffer_size):
     df = vaex.from_arrays(x=np.arange(1000))
     with buffer_size(df):
         with pytest.raises(vaex.RowLimitException, match='.* >= 2 .*'):
-            df._set('x', unique_limit=2)
+            df._set('x', limit=2)
         # TODO: this does not happen any more if we have a single set/hashmap
         # with pytest.raises(vaex.RowLimitException, match='.*larger than.*'):
         #     df._set('x', unique_limit=len(df)-1)

--- a/tests/progress_test.py
+++ b/tests/progress_test.py
@@ -43,10 +43,10 @@ def test_progress_error():
     df = vaex.from_arrays(x=vaex.vrange(0, 10000))
     with vaex.progress.tree('rich') as progressbar:
         try:
-            df._set('x', progress=progressbar, unique_limit=1)
+            df._set('x', progress=progressbar, limit=1)
         except vaex.RowLimitException:
             pass
-        assert progressbar.children[0].bar.status.startswith('Resulting set would')
+        assert progressbar.children[0].bar.status.startswith('Resulting hash_map_unique would')
         assert progressbar.children[0].finished
         assert progressbar.finished
         # assert progressbar.children[0].bar.status == 'from cache'

--- a/tests/unique_test.py
+++ b/tests/unique_test.py
@@ -126,3 +126,29 @@ def test_unique_datetime_timedelta():
     assert set(unique_delta) == {datetime.timedelta(0),
                                  datetime.timedelta(days=1),
                                  datetime.timedelta(days=2)}
+
+
+def test_unique_limit_primitive():
+    x = np.arange(100)
+    df = vaex.from_arrays(x=x)
+    with pytest.raises(vaex.RowLimitException, match='.*Resulting hash_map_unique.*'):
+        values = df.x.unique(limit=11)
+    values = df.x.unique(limit=11, limit_raise=False)
+    assert len(values) == 11
+    with pytest.raises(vaex.RowLimitException, match='.*Resulting hash_map_unique.*'):
+        df.x.nunique(limit=11)
+    assert df.x.nunique(limit=11, limit_raise=False) == 11
+    df.x.nunique(limit=100)
+
+
+def test_unique_limit_string():
+    x = np.arange(100)
+    df = vaex.from_arrays(x=[str(k) for k in x])
+    with pytest.raises(vaex.RowLimitException, match='.*Resulting hash_map_unique.*'):
+        values = df.x.unique(limit=11)
+    values = df.x.unique(limit=11, limit_raise=False)
+    assert len(values) == 11
+    with pytest.raises(vaex.RowLimitException, match='.*Resulting hash_map_unique.*'):
+        df.x.nunique(limit=11)
+    assert df.x.nunique(limit=11, limit_raise=False) == 11
+    df.x.nunique(limit=100)


### PR DESCRIPTION
This also includes a refactor of what we previously called 'set'
or 'ordered_set'.

This is now renamed to HashMapUnique, which describes what it does:
It maps keys to unique integers between [0, len(map)-1] using a
hashmap.

To support limit with limit_raise=False, we need tasks to stop early
but still return a value.

The default 'limit_raise=True' is consistent with groupby's row_limit
and is much safer behaviour.