### PR TITLE
ci: restore python 3.6

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
       max-parallel: 10
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - name: disk space

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -133,6 +133,11 @@ jobs:
     #     # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     #     # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Install fixes for Python 3.6
+      if: matrix.python-version == '3.6'
+      run: |
+        # by default on 3.6 we get an old version, so manually upgrade
+        pip install gcsfs==0.8.0
     - name: Test with pytest
       run: |
         ./ci/04-run-test-suite.sh

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 12
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/packages/vaex-server/vaex/server/fastapi.py
+++ b/packages/vaex-server/vaex/server/fastapi.py
@@ -42,8 +42,8 @@ class HistogramInput(BaseModel):
     dataset_id: str
     expression: str
     shape: int = 128
-    min: Optional[Union[float, str]] = None
-    max: Optional[Union[float, str]] = None
+    min: Optional[Union[float, int, str]] = None
+    max: Optional[Union[float, int, str]] = None
     filter: str = None
     virtual_columns: Dict[str, str] = None
 

--- a/packages/vaex-server/vaex/server/fastapi.py
+++ b/packages/vaex-server/vaex/server/fastapi.py
@@ -128,19 +128,19 @@ async def dataset():
 
 @router.get("/dataset/{dataset_id}", summary="Meta information about a dataset (schema etc)")
 async def dataset(dataset_id: str = path_dataset):
-    async with get_df(dataset_id) as df:
+    with get_df(dataset_id) as df:
         schema = {k: str(v) for k, v in df.schema().items()}
         return {"id": dataset_id, "row_count": len(df), "schema": schema}
 
-@contextlib.asynccontextmanager
-async def get_df(name):
+@contextlib.contextmanager
+def get_df(name):
     if name not in datasets:
         raise HTTPException(status_code=404, detail=f"dataset {name!r} not found")
     yield vaex.from_dataset(datasets[name])
 
 
 async def _compute_histogram(input: HistogramInput) -> HistogramOutput:
-    async with get_df(input.dataset_id) as df:
+    with get_df(input.dataset_id) as df:
         limits = [input.min, input.max]
         limits = df.limits(input.expression, limits, delay=True)
         await df.execute_async()
@@ -184,7 +184,7 @@ async def histogram_plot(input: HistogramInput = Depends(HistogramInput)) -> His
 
 
 async def _compute_heatmap(input: HeatmapInput) -> HeatmapOutput:
-    async with get_df(input.dataset_id) as df:
+    with get_df(input.dataset_id) as df:
         limits_x = [input.min_x, input.max_x]
         limits_y = [input.min_y, input.max_y]
         limits_x = df.limits(input.expression_x, limits_x, delay=True)
@@ -253,7 +253,9 @@ async def websocket_endpoint(websocket: WebSocket):
         data = await websocket.receive()
         if data['type'] == 'websocket.disconnect':
             return
-        asyncio.create_task(handler.handle_message(data['bytes']))
+        # see https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+        # TODO: replace after we drop 36 support asyncio.create_task(handler.handle_message(data['bytes']))
+        asyncio.ensure_future(handler.handle_message(data['bytes']))
 
 
 app = FastAPI(
@@ -344,6 +346,11 @@ class Server(threading.Thread):
 
         from uvicorn.config import Config
         from uvicorn.server import Server
+        if sys.version_info[:2] < (3, 7):
+            # make python 3.6 work
+            import asyncio
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
         # uvloop will trigger a: RuntimeError: There is no current event loop in thread 'fastapi-thread'
         config = Config(app, host=self.host, port=self.port, **self.kwargs, loop='asyncio')

--- a/packages/vaex-server/vaex/server/tornado_server.py
+++ b/packages/vaex-server/vaex/server/tornado_server.py
@@ -49,7 +49,12 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
         # Tornado does not receive messages before the current is finished, this
         # avoids this limitation of tornado, so we can send progress/cancel information
         logger.debug("get msg: %r", websocket_msg)
-        asyncio.create_task(self._on_message(websocket_msg))
+        try:
+            # see https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+            # TODO: replace after we drop 36 support asyncio.create_task(handler.handle_message(data['bytes']))
+            asyncio.ensure_future(self._on_message(websocket_msg))
+        except:
+            logger.exception("creating task")
 
     async def _on_message(self, websocket_msg):
         logger.debug("handle msg: %r", websocket_msg)

--- a/packages/vaex-server/vaex/server/websocket.py
+++ b/packages/vaex-server/vaex/server/websocket.py
@@ -72,7 +72,9 @@ class WebSocketHandler:
                 # but never send old or same values
                 if (last_progress is None or (f - last_progress) > 0.05 or f == 1.0) and (last_progress is None or f > last_progress):
                     def wrapper():
-                        progress_futures.append(asyncio.create_task(send_progress()))
+                        # see https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+                        # TODO: replace after we drop 36 support progress_futures.append(asyncio.create_task(send_progress()))
+                        progress_futures.append(asyncio.ensure_future(send_progress()))
                     ioloop.call_soon_threadsafe(wrapper)
                 return True
 

--- a/tests/execution_test.py
+++ b/tests/execution_test.py
@@ -1,15 +1,18 @@
 import asyncio
+import contextlib
 from unittest.mock import MagicMock
 from concurrent.futures import ThreadPoolExecutor
 import concurrent.futures
 import platform
 import threading
+import sys
 
 import pytest
 import numpy as np
 
 from common import small_buffer
 import vaex
+import vaex.execution
 
 
 def test_evaluate_expression_once():
@@ -209,6 +212,8 @@ def test_reentrant_catch(df_local):
         assert 'nested' in str(exc.value)
 
 
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="Python 36 has no contextvars module")
 @pytest.mark.asyncio
 async def test_async_safe(df_local):
     df = df_local
@@ -327,6 +332,7 @@ def test_continue_next_task_after_cancel():
     assert result.isFulfilled
 
 
+@pytest.mark.skipif(not hasattr(contextlib, 'asynccontextmanager'), reason="Python 36 has no asynccontextmanager")
 @pytest.mark.asyncio
 async def test_auto_execute():
     df = vaex.from_arrays(x=[2, 4])

--- a/tests/from_pandas_test.py
+++ b/tests/from_pandas_test.py
@@ -1,9 +1,14 @@
+import datetime
+import sys
+
 import pandas as pd
 import numpy as np
+import pytest
+
 import vaex
-import datetime
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 7), reason="Python 36+Pandas has no Float64Dtype")
 def test_from_pandas():
     dd_dict = {
         'boolean': [True, True, False, None, True],


### PR DESCRIPTION
Given CI runs much better, and we still distributed py36 wheels, lets see if we can get CI restored again.