### PR TITLE
Update settings.py

### DIFF
--- a/packages/vaex-core/vaex/settings.py
+++ b/packages/vaex-core/vaex/settings.py
@@ -102,7 +102,7 @@ class AsyncEnum(str, Enum):
 try:
     import vaex.server
     has_server = True
-except ImportError:
+except (AttributeError, ImportError):
     has_server = False
 
 if has_server:


### PR DESCRIPTION
Not having vaex-server causes an AttributeError on import, not an import error. This is a fast fix but perhaps a deeper dive is warranted.

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/var/folders/3d/d0dl2ykn6c18qg7kg_j7tplm0000gn/T/ipykernel_71377/416772059.py in <module>
      5     has_server = False
      6 
----> 7 import vaex.server

~/.pyenv/versions/3.9.6/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/vaex/__init__.py in <module>
     40 import six
     41 
---> 42 import vaex.dataframe
     43 import vaex.dataset
     44 from vaex.docstrings import docsubst

~/.pyenv/versions/3.9.6/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/vaex/dataframe.py in <module>
     30 import vaex.multithreading
     31 import vaex.promise
---> 32 import vaex.execution
     33 import vaex.expresso
     34 import logging

~/.pyenv/versions/3.9.6/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/vaex/execution.py in <module>
     18 import vaex.cpu  # force registration of task-part-cpu
     19 import vaex.encoding
---> 20 import vaex.memory
     21 import vaex.multithreading
     22 import vaex.vaexfast

~/.pyenv/versions/3.9.6/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/vaex/memory.py in <module>
      4 
      5 import pkg_resources
----> 6 import vaex.settings
      7 
      8 # thread local variable, where 'global' tracker go

~/.pyenv/versions/3.9.6/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/vaex/settings.py in <module>
     14 
     15 logger = logging.getLogger("vaex.settings")
---> 16 _default_home = vaex.utils.get_vaex_home()
     17 try:
     18     import dotenv

AttributeError: partially initialized module 'vaex' has no attribute 'utils' (most likely due to a circular import)
```