### PR TITLE
✨ Lazy ordinal encode

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -335,7 +335,7 @@ def from_items(*items):
     return from_dict(dict(items))
 
 
-def from_arrays(**arrays):
+def from_arrays(**arrays) -> vaex.dataframe.DataFrameLocal:
     """Create an in memory DataFrame from numpy arrays.
 
     Example
@@ -833,7 +833,7 @@ def dtype(type):
     '''Creates a Vaex DataType based on a NumPy or Arrow type'''
     return vaex.datatype.DataType(type)
 
-def dtype_of(ar):
+def dtype_of(ar) -> vaex.datatype.DataType:
     '''Creates a Vaex DataType from a NumPy or Arrow array'''
     if vaex.array_types.is_arrow_array(ar):
         return dtype(ar.type)

--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -131,7 +131,8 @@ def to_numpy(x, strict=False):
     elif isinstance(x, np.ndarray):
         return x
     elif isinstance(x, supported_arrow_array_types):
-        if not strict and is_string(x):
+        dtype = vaex.dtype_of(x)
+        if not strict and not (dtype.is_primitive or dtype.is_temporal):
             return x
         x = vaex.arrow.convert.column_from_arrow_array(x)
         return to_numpy(x, strict=strict)

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -27,6 +27,7 @@ from vaex.utils import Timer
 import vaex.events
 # import vaex.ui.undo
 import vaex.grids
+import vaex.hash
 import vaex.multithreading
 import vaex.promise
 import vaex.execution
@@ -643,6 +644,9 @@ class DataFrame(object):
                             mask = np.zeros(len(keys), dtype=np.uint8)
                             mask[hash_map_unique.null_value] = 1
                             keys = np.ma.array(keys, mask=mask)
+                        if data_type_item == str and isinstance(keys, np.ndarray):
+                            # the np.delete will cast to dtype object
+                            keys = pa.array(keys)
                 keys = vaex.array_types.convert(keys, array_type)
                 if return_inverse:
                     return keys, inverse
@@ -5710,11 +5714,13 @@ class DataFrameLocal(DataFrame):
         df._categories[column] = dict(labels=labels, N=len(labels), min_value=min_value)
         return df
 
-    def ordinal_encode(self, column, values=None, inplace=False):
+    def ordinal_encode(self, column, values=None, inplace=False, lazy=False):
         """Encode column as ordinal values and mark it as categorical.
 
         The existing column is renamed to a hidden column and replaced by a numerical columns
         with values between [0, len(values)-1].
+
+        :param lazy: When False, it will materialize the ordinal codes.
         """
         column = _ensure_string_from_expression(column)
         df = self if inplace else self.copy()
@@ -5725,6 +5731,29 @@ class DataFrameLocal(DataFrame):
         df_unfiltered.select_nothing(name=FILTER_SELECTION_NAME)
         df_unfiltered._length_unfiltered = df._length_original
         df_unfiltered.set_active_range(0, df._length_original)
+        expression = df_unfiltered[column]
+        if lazy:
+            if values is None:
+                found_values = df_unfiltered.unique(column, array_type='numpy-arrow')
+                minimal_type = vaex.utils.required_dtype_for_max(len(found_values), signed=True)
+                dtype = vaex.dtype_of(found_values)
+                if dtype == int:
+                    min_value = found_values.min()
+                    max_value = found_values.max()
+                    if (max_value - min_value +1) == len(found_values):
+                        warnings.warn(f'It seems your column {column} is already ordinal encoded (values between {min_value} and {max_value}), automatically switching to use df.categorize')
+                        return df.categorize(column, min_value=min_value, max_value=max_value, inplace=inplace)
+                values = found_values
+            else:
+                values = expression.dtype.create_array(values)
+            fp = f'hash-map-unique-{expression.fingerprint()}'
+            hash_map_unique_name = fp.replace('-', '_')
+            hash_map_unique = vaex.hash.HashMapUnique.from_keys(values, fingerprint=fp)
+            df.add_variable(hash_map_unique_name, hash_map_unique)
+            expr = df._expr('hashmap_apply({}, {}, check_missing=True)'.format(column, hash_map_unique_name))
+            df[column] = expr
+            df._categories[column] = dict(labels=values, N=len(values), min_value=0)
+            return df  # no else but return to avoid large diff
         # codes point to the index of found_values
         # meaning: found_values[codes[0]] == ds[column].values[0]
         found_values, codes = df_unfiltered.unique(column, return_inverse=True, array_type='numpy-arrow')

--- a/packages/vaex-core/vaex/datatype.py
+++ b/packages/vaex-core/vaex/datatype.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 import dask.base
 import numpy as np
 import pyarrow as pa
@@ -437,13 +438,38 @@ class DataType:
     def byteorder(self):
         return self.numpy.byteorder
 
-    def create_array(self, values):
+    def create_array(self, values : Sequence):
+        '''Create an array from a sequence with the same dtype
+
+        If values is a list containing None, it will map to a masked array (numpy) or null values (arrow)
+
+        >>> DataType(np.dtype('float32')).create_array([1., 2.5, None, np.nan])
+        masked_array(data=[1.0, 2.5, --, nan],
+                     mask=[False, False,  True, False],
+               fill_value=1e+20)
+        >>> DataType(pa.float32()).create_array([1., 2.5, None, np.nan])  # doctest:+ELLIPSIS
+        <pyarrow.lib.FloatArray object at ...>
+        [
+          1,
+          2.5,
+          null,
+          nan
+        ]
+        '''
         if self.is_arrow:
             if vaex.array_types.is_arrow_array(values):
                 return values
             else:
                 return pa.array(values, type=self.arrow)
         else:
+            if isinstance(values, np.ndarray):
+                return values.astype(self.internal, copy=False)
+            mask = [k is None for k in values]
+            if any(mask):
+                values = [values[0] if k is None else k for k in values]
+                return np.ma.array(values, mask=mask)
+            else:
+                return np.array(values)
             return np.asarray(values, dtype=self.numpy)
 
 @dask.base.normalize_token.register(DataType)

--- a/packages/vaex-core/vaex/datatype.py
+++ b/packages/vaex-core/vaex/datatype.py
@@ -245,9 +245,15 @@ class DataType:
         >>> date_type.is_timedelta
         False
         '''
-        if self.is_string:
+        if self.is_arrow:
             return False
-        return vaex.array_types.to_numpy_type(self.internal).kind in 'm'
+        else:
+            return self.kind in 'm'
+
+    @property
+    def is_temporal(self):
+        '''Alias of (is_datetime or is_timedelta)'''
+        return self.is_datetime or self.is_timedelta
 
     @property
     def is_float(self):

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -1411,15 +1411,9 @@ def f({0}):
         # and later on in _choose, we map values not even seen in the dataframe
         # to the default_value
         dtype_item = self.data_type(self.expression, axis=-1)
-        null_count = mapper_keys.count(None)
-        if null_count:
-            null_value = mapper_keys.index(None)
-        else:
-            null_value = 0x7fffffff
-
         mapper_keys = dtype_item.create_array(mapper_keys)
         fingerprint = key_set.fingerprint + "-mapper"
-        hash_map_unique = vaex.hash.HashMapUnique.from_keys(mapper_keys, null_value=null_value, null_count=null_count, fingerprint=fingerprint, dtype=dtype_item)
+        hash_map_unique = vaex.hash.HashMapUnique.from_keys(mapper_keys, fingerprint=fingerprint, dtype=dtype_item)
         indices = hash_map_unique.map(mapper_keys)
         mapper_values = [mapper_values[i] for i in indices]
 

--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2445,9 +2445,9 @@ def _ordinal_values(x, hashmap_unique):
 
 
 @register_function()
-def hashmap_apply(x, hashmap):
-    '''Apply values to hashmap'''
-    indices = hashmap.map(x)
+def hashmap_apply(x, hashmap, check_missing=False):
+    '''Apply values to hashmap, if check_missing is True, missing values in the hashmap will translated to null/missing values'''
+    indices = hashmap.map(x, check_missing=check_missing)
     return indices
 
 

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -318,7 +318,7 @@ class GrouperCategory(BinnerBase):
                 # we will map from int to int
                 sort_indices = vaex.array_types.to_numpy(sort_indices)
                 fingerprint = self.expression.fingerprint() + "-grouper-sort-mapper"
-                self.hash_map_unique = vaex.hash.HashMapUnique.from_keys(sort_indices + self.min_value, null_value=-1, null_count=0, fingerprint=fingerprint)
+                self.hash_map_unique = vaex.hash.HashMapUnique.from_keys(sort_indices + self.min_value, fingerprint=fingerprint)
                 self.min_value = 0
                 self.sort_indices = None
                 self.basename = "hash_map_unique_%s" % vaex.utils._python_save_name(str(self.expression) + "_" + self.hash_map_unique.fingerprint)
@@ -379,19 +379,9 @@ class GrouperLimited(BinnerBase):
             self.bin_values = pa.array(vaex.array_types.tolist(values))
             self.values = self.bin_values
         self.N = len(self.bin_values)
-        dtype = vaex.dtype_of(self.values)
-        set_type = vaex.hash.ordered_set_type_from_dtype(dtype)
-        values_list = self.values.tolist()
-        try:
-            null_value = values_list.index(None)
-            null_count = 1
-        except ValueError:
-            null_value = -1
-            null_count = 0
-
         fp = vaex.cache.fingerprint(values)
         fingerprint = f"set-grouper-fixed-{fp}"
-        self.hash_map_unique = vaex.hash.HashMapUnique.from_keys(self.values, null_value=null_value, null_count=null_count, fingerprint=fingerprint)
+        self.hash_map_unique = vaex.hash.HashMapUnique.from_keys(self.values, fingerprint=fingerprint)
 
         self.basename = "hash_map_unique_%s" % vaex.utils._python_save_name(str(self.expression) + "_" + self.hash_map_unique.fingerprint)
         self.binby_expression = expression

--- a/tests/category_test.py
+++ b/tests/category_test.py
@@ -1,3 +1,4 @@
+from vaex.dataframe import DataFrameLocal
 from common import *
 import collections
 import numpy as np
@@ -6,40 +7,54 @@ import vaex
 import pytest
 
 
-@pytest.mark.parametrize("auto_encode", [False, True])
-def test_cat_string(auto_encode):
+@pytest.mark.parametrize("future", [False, True])
+@pytest.mark.parametrize("lazy", [False, True])
+def test_cat_string(future, lazy):
     ds0 = vaex.from_arrays(colors=['red', 'green', 'blue', 'green'])
-    ds = ds0.ordinal_encode('colors')#, ['red', 'green'], inplace=True)
+    ds = ds0.ordinal_encode('colors', lazy=lazy)#, ['red', 'green'], inplace=True)
     assert ds.colors.dtype.internal.name == 'int8'
-    ds = ds._future() if auto_encode else ds
+    ds = ds._future() if future else ds
     assert ds.is_category('colors')
-    if auto_encode:
+    if future:
         assert ds.data_type('colors') == str
     else:
         assert ds.data_type('colors') == int
     assert ds.limits('colors', shape=128) == ([-0.5, 2.5], 3)
 
-    ds = ds0.ordinal_encode('colors', values=['red', 'green'])
+    ds = ds0.ordinal_encode('colors', values=['red', 'green'], lazy=lazy)
     assert ds.is_category('colors')
     assert ds.limits('colors', shape=128) == ([-0.5, 1.5], 2)
-    assert ds.data.colors.tolist() == [0, 1, None, 1]
+    if not lazy:
+        assert ds.data.colors.tolist() == [0, 1, None, 1]
 
     assert ds.copy().is_category(ds.colors)
 
     # with pytest.raises(ValueError):
     # 	assert ds.is_category('colors', values=['red', 'orange'])
 
-def test_count_cat():
-    ds0 = vaex.from_arrays(colors=['red', 'green', 'blue', 'green'], counts=[1, 2, 3, 4])
+@pytest.mark.parametrize("lazy", [False, True])
+def test_count_cat(lazy):
     ds0 = vaex.from_arrays(colors=['red', 'green', 'blue', 'green'], names=['apple', 'apple', 'berry', 'apple'])
-    ds = ds0.ordinal_encode(ds0.colors)
-    ds = ds0.ordinal_encode(ds0.names)
-
-    ds = ds0.ordinal_encode('colors', ['red', 'green', 'blue'])
+    ds = ds0.ordinal_encode('colors', ['red', 'green', 'blue'], lazy=lazy)
     assert ds.count(binby=ds.colors).tolist() == [1, 2, 1]
-    ds = ds0.ordinal_encode('colors', ['red', 'blue', 'green', ], inplace=True)
+
+    ds = ds0.ordinal_encode('colors', ['red', 'blue', 'green', ], inplace=True, lazy=lazy)
     assert ds.count(binby=ds.colors).tolist() == [1, 1, 2]
 
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_ordinal_encode_float(lazy, df_factory):
+    x = [1., 2.5, None, np.nan]
+    df = df_factory(x=x)
+    assert df.x.tolist()[:3] == [1., 2.5, None]
+    dfe = df.ordinal_encode('x', lazy=lazy)
+    dfe = dfe._future()
+    assert dfe.x.tolist()[:3] == [1., 2.5, None]
+
+    # gives values explicitly
+    dfe = df.ordinal_encode('x', lazy=lazy, values=x)
+    dfe = dfe._future()
+    assert dfe.x.tolist()[:3] == [1., 2.5, None]
 
 def test_categorize():
     ds0 = vaex.from_arrays(c=[0, 1, 1, 3])
@@ -49,12 +64,13 @@ def test_categorize():
     assert ds0.category_count(ds0.c) == 4
 
 
-def test_cat_missing_values():
+@pytest.mark.parametrize("lazy", [False, True])
+def test_cat_missing_values(lazy):
     colors = ['red', 'green', 'blue', 'green', 'MISSING']
     mask   = [False, False,   False,   False,  True]
     colors = np.ma.array(colors, mask=mask)
     ds0 = vaex.from_arrays(colors=colors)
-    ds = ds0.ordinal_encode('colors', ['red', 'green', 'blue'])
+    ds = ds0.ordinal_encode('colors', ['red', 'green', 'blue'], lazy=lazy)
     assert ds.count(binby=ds.colors, edges=True).tolist() == [1, 0, 1, 2, 1, 0]
 
     # if we want missing values and non-categorized values to be reported seperately

--- a/tests/shape_test.py
+++ b/tests/shape_test.py
@@ -1,0 +1,31 @@
+import vaex
+import numpy as np
+import pyarrow as pa
+from vaex.dataframe import DataFrameLocal
+
+
+def test_shape_1d_columns():
+    Nrows = 8
+    x = np.arange(Nrows)
+    df = vaex.from_arrays(x=x)
+    assert df.shape == (Nrows, 1)
+    assert df.x.shape == (Nrows,)
+    df = vaex.from_arrays(x=x, y=x ** 2)
+    assert df.shape == (Nrows, 2)
+
+
+def test_shape_2d_columns():
+    Nrows = 8
+    x = np.arange(Nrows * 3).reshape((Nrows, 3))
+    df = vaex.from_arrays(x=x)
+    assert df.shape == (Nrows, 1)
+    assert df.x.shape == (Nrows, 3)
+
+
+def test_shape_category():
+    s = ["aap", "noot", "mies", "mies", "aap"]
+    df: DataFrameLocal = vaex.from_arrays(s=s)
+    df = df.ordinal_encode('s')
+    df = df._future()
+    assert df.shape == (len(s), 1)
+    assert df.s.shape == (len(s),)


### PR DESCRIPTION
Before the ordinal encode would materialize the 'index' or 'codes'
numerical array. This is fine if you care about performance, but
if you want to do this on large dataframes, with the purpose of
exporting, you'd want to do this lazily.