### PR TITLE
Fix blake3 pin

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -24,7 +24,7 @@ install_requires_core = ["numpy>=1.16", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2",
                          "requests", "six", "cloudpickle", "pandas", "dask",
                          "nest-asyncio>=1.3.3", "pyarrow>=3.0", "frozendict",
-                         "blake3", "filelock", "pydantic>=1.8.0", "rich",
+                         "blake3==0.2.1", "filelock", "pydantic>=1.8.0", "rich",
                         ]
 if sys.version_info[0] == 2:
     install_requires_core.append("futures>=2.2.0")


### PR DESCRIPTION
Vaex uses the syntax `blake3.blake3(..., multithreading=True)` which was removed in the new blake3 version

https://github.com/vaexio/vaex/blob/master/packages/vaex-core/vaex/dataset.py#L99

And many other places in this file