### PR TITLE
[NOT TO BE MERGED] Agg first / cast or raise error in case expression & order_expression are not the same dtypes

### DIFF
--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -259,15 +259,12 @@ class AggregatorDescriptorBasic(AggregatorDescriptor):
             if self.short_name in ['sum', 'summoment']:
                 self.dtype_out = self.dtype_in.upcast()
             if self.short_name == "first":
-                oe_dtype = df[str(self.expressions[1])].data_type().index_type
-                if self.dtype_in != oe_dtype:
-                    print(f'dtype_in: {self.dtype_in}')
-                    print(type(self.dtype_in))
-                    print(f'oe_dtype: {oe_dtype}')
-                    print(type(oe_dtype))
-                    if np.can_cast(oe_dtype, self.dtype_in):
-                        df[str(self.expressions[1])] = df[str(self.expressions[1])].astype(self.dtype_in)
-                    elif np.can_cast(self.dtype_in, oe_dtype):
+                oe_dtype = str(df[str(self.expressions[1])].data_type().index_type)
+                e_dtype = str(self.dtype_in)
+                if e_dtype != oe_dtype:
+                    if np.can_cast(oe_dtype, e_dtype):
+                        df[str(self.expressions[1])] = df[str(self.expressions[1])].astype(e_dtype)
+                    elif np.can_cast(e_dtype, oe_dtype):
                         df[str(self.expressions[0])] = df[str(self.expressions[0])].astype(oe_dtype)
                         self.dtype_in = df[str(self.expressions[0])].data_type().index_type
                     else:

--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -439,6 +439,13 @@ def max(expression, selection=None, edges=False):
 @register
 def first(expression, order_expression, selection=None, edges=False):
     '''Creates a first aggregation'''
+    if expression.dtype != order_expression.dtype:
+        if np.can_cast(order_expression.dtype, expression.dtype):
+            order_expression = order_expression.astype(expression.dtype)
+        elif np.can_cast(expression.dtype, order_expression.dtype):
+            expression = expression.astype(order_expression.dtype)
+        else:
+            raise TypeError("`expression` and `order_expression` parameters are not of same dtype.")
     return AggregatorDescriptorBasic('AggFirst', [expression, order_expression], 'first', multi_args=True, selection=selection, edges=edges)
 
 @register

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -583,6 +583,6 @@ def test_first():
 #    assert df.groupby('y', agg={'x_first': vaex.agg.first('x', 'row_idx')})['x_first'].tolist() == [7, 9, 11]
     x = np.array([7.1, 8.1, 9.1, 10.1, 11.1])
     df = vaex.from_arrays(x=x, y=y, row_idx=row_idx)
-    assert df.groupby('y', agg={'x_first': vaex.agg.first('x', 'row_idx')})['row_idx'].data_type() == 'float64'
+    assert df.groupby('y', agg={'x_first': vaex.agg.first('x', 'row_idx')})['x_first'].tolist() == [7.1, 9.1, 11.1]
 
 

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -570,3 +570,19 @@ def test_all():
 
     assert df.groupby('g', agg={'all': vaex.agg.all(selection=df.b1)})['all'].tolist() == [False, False]
     assert df.groupby('g', agg={'all': vaex.agg.all(selection=df.b2)})['all'].tolist() == [False, True]
+
+
+def test_first():
+    # x       = [7, 8, 9, 10, 11]
+    # y       = [1, 1, 2,  2,  3]
+    # row_idx = [0, 1, 2,  3,  4]
+    x = np.arange(7,12)
+    y = [1, 1, 2, 2, 3]
+    row_idx = np.arange(5)
+    df = vaex.from_arrays(x=x, y=y, row_idx=row_idx)
+#    assert df.groupby('y', agg={'x_first': vaex.agg.first('x', 'row_idx')})['x_first'].tolist() == [7, 9, 11]
+    x = np.array([7.1, 8.1, 9.1, 10.1, 11.1])
+    df = vaex.from_arrays(x=x, y=y, row_idx=row_idx)
+    assert df.groupby('y', agg={'x_first': vaex.agg.first('x', 'row_idx')})['row_idx'].data_type() == 'float64'
+
+


### PR DESCRIPTION
Hi,

Following discussion in #1378 , I open this PR, not ready to be merged, far from here.
As a reminder of the initial proposal from @maartenbreddels 

--------------
_The issue is that first assumes that both arguments are of the same type, which is not true, and we don't check that. So we have to_
  - _Check that and raise an error, or cast_
  - _Implement mixed types for first_
 
_Would you like to take a look at 1, and see if you can open a PR for that? I think this is all in agg.py_

--------------

I feel very very stupid with this 1st attempt, I beg your pardon, this may be more a loss of time for you, but if you feel you can afford it, it seems I have tons of questions. I ask clemency for my low level of understanding / coding skills.

--------------
**Installation**
As you pointed out @maartenbreddels , it seems installing _compilers_ was the missing trick in my installation.
Also, 1st question,

  - 1. Instead of using `pip install -e ".[dev]"`, I used `pip install -e .`. Do you know what can be the difference?

--------------
**Implementation**
Following your comment _I think this is all in agg.py_, I implemented checks on dtype in `AggregatorDescriptorBasic._prepare_types()`. File modifications can be seen in this PR.
I also started a test case `test_first` in `tests.agg_test`.

  - 2. Is this where you see the changes to be made?
  - 3. But already, these changes do not work.
     - 3.1 The 1st assert (that I commented out with last commit), which do not present any dtype trouble: the order of agg result -column `x_first`, albeit containing the right values, is not ordered as expected. The assert fails on `[7, 11, 9] == [7, 9, 11]`. Is it expected that the `groupby` with `agg.first` does not maintain order between groups?
     - 3.2 In `AggregatorDescriptorBasic._prepare_types()`, I could see that `dtype` is retrieved with `df['...'].data_type().index_type`. I could check on a dummy test that both `data_type().index_type` and `data_type()` returns actually the same type of object `vaex.datatype.DataType`. Please, what does `index_type` over `data_type()`?
     - 3.3 Should have been the 1st question: With changes made, I am modifying the dtype of some columns. Is it what you have in mind?

--------------
**AggregatorDescriptorMean**

I also had a look to how some other `Aggregator` class are implemented, and I found lines I just don't know / understand the syntax, and more specifically in `AggregatorDescriptorMean.add_tasks()`.
  - 4. Please what does mean a line like:
        `expression = expression_sum = expression = df[str(self.expression)]`
         ?
         Is there a kind of short-circuit logic to assign `expression` variable?


I am sorry, I feel very stupid with these questions.
Please, feel free to disregard these, I understand this is close to ask a free course on vaex and python programming here :)
Bests,