### PR TITLE
🐛 use label instead of expression for non-ident column names in binby

### DIFF
--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -541,7 +541,7 @@ class GroupByBase(object):
                 self.groupby_expression = [str(by.expression) for by in self.by]
                 self.binners = tuple(by.binner for by in self.by)
                 self.shape = [by.N for by in self.by]
-                self.dims = self.groupby_expression[:]
+                self.dims = [by.label for by in self.by]
                 self.progressbar_groupers(1)
             return process(promise)
 

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -550,6 +550,15 @@ def test_binner_2d(df_factory):
     assert xar.coords['g'].data.tolist() == [0, 1]
     assert xar.data.tolist() == [[1, 0], [1, 1], [1, 2]]
 
+
+def test_binby_non_identifiers():
+    df = vaex.from_dict({"#": [1, 2, 3]})
+    binner = vaex.groupby.Binner(df['#'], 0, 3, bins=3)
+    xar = df.binby(binner, agg="count")
+    assert xar.coords['#'].data.tolist() == [0.5, 1.5, 2.5]
+    assert xar.data.tolist() == [0, 1, 1]
+
+
 def test_groupby_limited_plain(df_factory):
     df = df_factory(x=[1, 2, 2, 3, 3, 4], s=["aap", "aap", "aap", "noot", "noot", "mies"])
     g = vaex.groupby.GrouperLimited(df.s, values=['aap', 'noot'], keep_other=True, other_value='others', label="type")


### PR DESCRIPTION
Otherwise variable names would be df['#'] instead of '#'