### PR TITLE
🐛 apply with filtered data could give wrong dtypes

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -6411,7 +6411,7 @@ class DataFrameLocal(DataFrame):
                 deps |= filter_deps
             columns = {k: dataset[k][:] for k in deps if k in dataset}
 
-            if self.filtered:
+            if self.filtered and filtered:
                 filter_scope = scopes._BlockScope(df, i1, i2, None, selection=True, values={**df.variables, **{k: columns[k] for k in filter_deps if k in columns}})
                 filter_scope.filter_mask = None
                 filter_mask = filter_scope.evaluate(vaex.dataframe.FILTER_SELECTION_NAME)

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -90,3 +90,29 @@ def test_dtype_no_eval():
     df._evaluate_implementation = MagicMock()
     assert df.data_type(df['#']) == float
     assert df.data_type(df['with space']) == str
+
+
+def test_dtype_filtered():
+    df = vaex.from_arrays(x=[None, "aap", "noot", "mies"])
+    df["y"] = df.x.str.lower()
+    dff = df.dropna()
+    assert dff.y.dtype == str
+
+
+def test_dtype_apply():
+    def func(x):
+        if x == "b":
+            clr = "blue"
+        elif x == "r":
+            clr = "red"
+        elif x == "y":
+            clr = "yellow"
+        else:
+            clr = "other"
+        return clr
+
+    x = [None, "b", None, "y", "r"]
+    df = vaex.from_arrays(x=x)
+    df = df.dropna()
+    df["y"] = df.x.apply(func)
+    assert df.y.dtype == str


### PR DESCRIPTION
This is quite an exotic bug, discovered by https://github.com/vaexio/vaex/discussions/1933.

Sometimes doing `df.y.dt.strftime('%Y')` results in a dtype of `null` (?). However, this only happens if the dataframe contains another column, say `x` of dtype `string` that has at least two missing values, of which one _has to be in the first position_.  If one does `dropna()` in that column `x`, the result of doing `strftime` on `y` gives weird dtype (see unit test for better explanation). 

See https://github.com/vaexio/vaex/discussions/1933 for a temporary workaround.

Checklist 
- [x] make unit test
- [ ] make test pass