### PR TITLE
Feat: add `skew` and `kurtosis` aggregators.

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1171,8 +1171,6 @@ class DataFrame(object):
         array([ 15271.90481083,   7284.94713504,   3738.52239232,   1449.63418988])
         >>> df.var("vz", binby=["(x**2+y**2)**0.5"], shape=4)**0.5
         array([ 123.57954851,   85.35190177,   61.14345748,   38.0740619 ])
-        >>> df.std("vz", binby=["(x**2+y**2)**0.5"], shape=4)
-        array([ 123.57954851,   85.35190177,   61.14345748,   38.0740619 ])
 
         :param expression: {expression}
         :param binby: {binby}
@@ -1186,6 +1184,56 @@ class DataFrame(object):
         """
         edges = False
         return self._compute_agg('var', expression, binby, limits, shape, selection, delay, edges, progress, array_type=array_type)
+
+    @docsubst
+    def skew(self, expression, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None, edges=False, array_type=None):
+        '''
+        Calculate the skew for the given expression, possible on a grid defined by binby.
+
+        Example:
+
+        >>> df.skew("vz")
+        0.02116528
+        >>> df.skew("vz", binby=["E"], shape=4)
+        array([-0.069976  , -0.01003445,  0.05624177, -2.2444322 ])
+
+        :param expression: {expression}
+        :param binby: {binby}
+        :param limits: {limits}
+        :param shape: {shape}
+        :param selection: {selection}
+        :param delay: {delay}
+        :param progress: {progress}
+        :param array_type: {array_type}
+        :return: {return_stat_scalar}
+        '''
+        edges=False
+        return self._compute_agg('skew', expression, binby, limits, shape, selection, delay, edges, progress, array_type=array_type)
+
+    @docsubst
+    def kurtosis(self, expression, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None, edges=False, array_type=None):
+        '''
+        Calculate the kurtosis for the given expression, possible on a grid defined by binby.
+
+        Example:
+
+        >>> df.kurtosis('vz')
+        0.33414303
+        >>> df.kurtosis("vz", binby=["E"], shape=4)
+        array([0.35286113, 0.14455428, 0.52955107, 5.06716345])
+
+        :param expression: {expression}
+        :param binby: {binby}
+        :param limits: {limits}
+        :param shape: {shape}
+        :param selection: {selection}
+        :param delay: {delay}
+        :param progress: {progress}
+        :param array_type: {array_type}
+        :return: {return_stat_scalar}
+        '''
+        edges=False
+        return self._compute_agg('kurtosis', expression, binby, limits, shape, selection, delay, edges, progress, array_type=array_type)
 
     @docsubst
     def covar(self, x, y, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None):

--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -605,7 +605,7 @@ class Expression(with_metaclass(Meta)):
             indices, fields = slicer
         else:
             raise NotImplementedError
-        
+
         if indices != slice(None):
             expr = self.df[indices][self.expression]
         else:
@@ -930,6 +930,20 @@ class Expression(with_metaclass(Meta)):
         del kwargs['self']
         kwargs['expression'] = self.expression
         return self.ds.var(**kwargs)
+
+    def skew(self, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None):
+        '''Shortcut for df.skew(expression, ...), see `DataFrame.skew`'''
+        kwargs = dict(locals())
+        del kwargs['self']
+        kwargs['expression'] = self.expression
+        return self.df.skew(**kwargs)
+
+    def kurtosis(self, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None):
+        '''Shortcut for df.kurtosis(expression, ...), see `DataFrame.kurtosis`'''
+        kwargs = dict(locals())
+        del kwargs['self']
+        kwargs['expression'] = self.expression
+        return self.df.kurtosis(**kwargs)
 
     def minmax(self, binby=[], limits=None, shape=default_shape, selection=False, delay=False, progress=None):
         '''Shortcut for ds.minmax(expression, ...), see `Dataset.minmax`'''

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -620,3 +620,37 @@ def test_unique_2d(df_factory, binner1, binner2):
         assert dfg['x'].tolist() == [0, 0, 1, 1, 2, 2]
         assert dfg['y'].tolist() == [4, 5, 4, 5, 4, 5]
         assert dfg['c'].tolist() == [1, 1, 1, 2, 1, 3]
+
+
+def test_skew(df_example):
+    df = df_example
+    pandas_df = df.to_pandas_df()
+    np.testing.assert_approx_equal(df.skew("x"), pandas_df.x.skew(), significant=5)
+    np.testing.assert_approx_equal(df.skew("Lz"), pandas_df.Lz.skew(), significant=5)
+    np.testing.assert_approx_equal(df.skew("E"), pandas_df.E.skew(), significant=5)
+
+
+def test_groupby_skew(df_example):
+    df = df_example
+    pandas_df = df.to_pandas_df()
+    vaex_g = df.groupby("id", sort=True).agg({"skew": vaex.agg.skew("Lz")})
+    pandas_g = pandas_df.groupby("id", sort=True).agg(skew=("Lz", "skew"))
+    np.testing.assert_almost_equal(vaex_g["skew"].values, pandas_g["skew"].values, decimal=4)
+
+
+def test_kurtosis(df_example):
+    df = df_example
+    pandas_df = df.to_pandas_df()
+    np.testing.assert_approx_equal(df.kurtosis("x"), pandas_df.x.kurtosis(), significant=4)
+    np.testing.assert_approx_equal(df.kurtosis("Lz"), pandas_df.Lz.kurtosis(), significant=4)
+    np.testing.assert_approx_equal(df.kurtosis("E"), pandas_df.E.kurtosis(), significant=4)
+
+
+def test_groupby_kurtosis(df_example):
+    import pandas as pd
+
+    df = df_example
+    pandas_df = df.to_pandas_df()
+    vaex_g = df.groupby("id", sort=True).agg({"kurtosis": vaex.agg.kurtosis("Lz")})
+    pandas_g = pandas_df.groupby("id", sort=True).agg(kurtosis=("Lz", pd.Series.kurtosis))
+    np.testing.assert_almost_equal(vaex_g["kurtosis"].values, pandas_g["kurtosis"].values, decimal=3)


### PR DESCRIPTION
Notes:
- This PR has been branched off https://github.com/vaexio/vaex/pull/1848 and thus requires that branch to be merged first since we are using the refactoring done there
- Closes https://github.com/vaexio/vaex/issues/1215

Checklist:
- [x] implement 'df.skew' and `vaex.agg.skew`
- [x] implement 'df.kurtosis and `vaex.agg.kurtosis`
- [x] Unit tests for everything
- [ ] Code review