### PR TITLE
Fix: make `value_counts` work for small chunks.

### DIFF
--- a/tests/value_counts_test.py
+++ b/tests/value_counts_test.py
@@ -124,3 +124,9 @@ def test_value_counts_list(df_types):
     vc = df.int_list.value_counts()
     assert vc[1] == 2
     assert vc[2] == 1
+
+def test_value_counts_small_chunk_size():
+    df = vaex.datasets.iris()
+    df.executor.chunk_size = 3
+    result = df[df.petal_width > 1].class_.value_counts()
+    assert result.tolist() == [50, 43]


### PR DESCRIPTION
Fix for `value_counts`which can fail when the chunk size is small and we have a filtered dataframe. This can also happen if one using a machine with many cores, which can in turn make the internal processing chunks small.

Checklist:
- [x] Expose this via unit-test
- [ ] Make test pass