### PR TITLE
fix: avoid dask 2022.4.0

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -28,7 +28,7 @@ url = 'https://www.github.com/maartenbreddels/vaex'
 # TODO: would be nice to have astropy only as dep in vaex-astro
 install_requires_core = ["numpy>=1.16", "aplus", "tabulate>=0.8.3",
                          "future>=0.15.2", "pyyaml", "progressbar2",
-                         "requests", "six", "cloudpickle", "pandas", "dask",
+                         "requests", "six", "cloudpickle", "pandas", "dask!=2022.4.0",
                          "nest-asyncio>=1.3.3", "pyarrow>=3.0", "frozendict!=2.2.0",
                          "blake3", "filelock", "pydantic>=1.8.0", "rich",
                         ]


### PR DESCRIPTION
Again breakage, followup of https://github.com/vaexio/vaex/pull/1873

I think this is taking too much time, and we should drop this, what do you think @JovanVeljanoski ?