### PR TITLE
Feat: add `describe` method to `groupby`

### DIFF
--- a/ci/04-run-test-suite.sh
+++ b/ci/04-run-test-suite.sh
@@ -7,4 +7,13 @@ else
     source ${HOME}/.bash_profile
 fi
 export VAEX_SERVER_OVERRIDE='{"dataframe.vaex.io":"dataframe-dev.vaex.io"}'
-py.test tests packages/vaex-core/vaex/datatype_test.py packages/vaex-core/vaex/file/ packages/vaex-core/vaex/test/dataset.py::TestDataset --doctest-modules packages/vaex-core/vaex/datatype.py packages/vaex-core/vaex/utils.py --timeout=1000
+py.test tests\
+        packages/vaex-core/vaex/datatype_test.py\
+        packages/vaex-core/vaex/file/\
+        packages/vaex-core/vaex/test/dataset.py::TestDataset\
+        --doctest-modules\
+          packages/vaex-core/vaex/datatype.py\
+          packages/vaex-core/vaex/utils.py\
+          packages/vaex-core/vaex/struct.py\
+          packages/vaex-core/vaex/groupby.py\
+        --timeout=1000

--- a/packages/vaex-core/vaex/array_types.py
+++ b/packages/vaex-core/vaex/array_types.py
@@ -38,6 +38,9 @@ def is_array(ar):
     return is_arrow_array(ar) or is_numpy_array(ar)
 
 
+def is_scalar(x):
+    return not is_array(x) or (is_numpy_array(x) and x.ndim == 0)
+
 def filter(ar, boolean_mask):
     if isinstance(ar, supported_arrow_array_types):
         return ar.filter(pa.array(boolean_mask))

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -744,3 +744,20 @@ def test_row_limit_sparse():
     df = vaex.from_arrays(x=x, y=y)
     with pytest.raises(vaex.RowLimitException, match='.* would have >= 11 unique combinations.*'):
         df.groupby(['x', 'y'], assume_sparse=False, row_limit=11)
+
+
+def test_describe_agg():
+    df = vaex.datasets.titanic()
+    res = df.groupby('pclass').describe(['age', df.sex])
+    assert res.shape == (3, 9)
+    assert res.get_column_names() == ['pclass',
+                                      'age_count',
+                                      'age_count_na',
+                                      'age_mean',
+                                      'age_std',
+                                      'age_min',
+                                      'age_max',
+                                      'sex_count',
+                                      'sex_count_na']
+    assert res.age_count_na.tolist() == [39, 16, 208]
+    assert res.age_max.tolist() == [80, 70, 74]

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -761,3 +761,14 @@ def test_describe_agg():
                                       'sex_count_na']
     assert res.age_count_na.tolist() == [39, 16, 208]
     assert res.age_max.tolist() == [80, 70, 74]
+
+    # make it work without args
+    res = df.groupby().describe(['age', df.sex])
+
+
+def test_groupby_empty(df_factory):
+    df = df_factory(x=[1, 2, 2, 3, 3, 4], s=["aap", "aap", "aap", "noot", "noot", "mies"])
+    dfg = df.groupby(agg={"count": vaex.agg.count(), "first_x": vaex.agg.first("x"), "s": vaex.agg.list("s")})
+    assert dfg["count"].tolist() == [6]
+    assert dfg["first_x"].tolist() == [1]
+    assert dfg["s"].tolist() == [df.s.tolist()]


### PR DESCRIPTION
This PR add/proposes a feature requested in https://github.com/vaexio/vaex/issues/1998

The feature can be best described with an example:
```python
import vaex
df = vaex.datasets.titanic()
res = df.groupby('pclass').describe(['age', df.sex])
print(res)

  #    pclass    age_count    age_count_na    age_mean    age_std    age_min    age_max    sex_count    sex_count_na
  0         1          284              39     39.1599    14.5224     0.9167         80          323               0
  1         2          261              16     29.5067    13.6125     0.6667         70          277               0
  2         3          501             208     24.8164    11.9463     0.1667         74          709               0
```

This is a convenience method, but I think it makes sense to add.
