### PR TITLE
🐛 allow col as column name

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -2184,8 +2184,11 @@ class DataFrame(object):
             pass
         data = ColumnList()
         for name in self.get_column_names():
-            expression = getattr(self, name, None)
-            if not isinstance(expression, Expression):
+            if name != 'col':  # avoid recursion
+                expression = getattr(self, name, None)
+                if not isinstance(expression, Expression):
+                    expression = Expression(self, name)
+            else:
                 expression = Expression(self, name)
             setattr(data, name, expression)
         return data

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -94,3 +94,6 @@ def test_special_names():
     # getattr(df, 'data', None) to return None
     df = vaex.from_arrays(data=[1, 2])
     assert df['data'].tolist() == [1, 2]
+
+    df = vaex.from_arrays(col=[1, 2])
+    assert df['col'].tolist() == [1, 2]


### PR DESCRIPTION
As it would lead to recursion error.

Fixes #1992