### PR TITLE
🐛 when aggregation leads to arrow data, non-dense binners fail

### DIFF
--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -8,6 +8,7 @@ import numpy as np
 import pyarrow as pa
 from vaex.dataframe import DataFrame
 
+import vaex.array_types
 from vaex.delayed import delayed_args, delayed_dict, delayed_list
 from vaex.utils import _ensure_list, _ensure_string_from_expression
 import vaex
@@ -945,7 +946,7 @@ class GroupBy(GroupByBase):
                             columns[key] = value
                 else:
                     for key, value in arrays.items():
-                        columns[key] = value[mask]
+                        columns[key] = vaex.array_types.filter(value, mask)
             logger.info(f"constructed dataframe")
             dataset_arrays = vaex.dataset.DatasetArrays(columns)
             dataset = DatasetGroupby(dataset_arrays, self.df, self.by_original, actions, combine=self.combine, expand=self.expand, sort=self.sort)

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -707,6 +707,11 @@ def test_agg_arrow():
     assert dfg.s.tolist() == ['aap', 'kees', 'other']
     assert set(dfg.l.tolist()[0]) == {0, 2}
 
+    g = vaex.groupby.BinnerInteger(df.x, sort=True, min_value=0, max_value=2)
+    dfg = df.groupby(g, agg={'s': vaex.agg.list(df.s)}, sort=True)
+    assert dfg.x.tolist() == [0, 1, 2]
+    assert set(dfg.s.tolist()[0]) == {'mies', 'aap', 'noot', None}
+
     df = df.ordinal_encode('s')
     dfg = df.groupby(df.s, agg={'l': vaex.agg.list(df.x)}, sort=True)
     assert dfg.s.tolist() == ['aap', 'kees', 'mies', 'noot', None]


### PR DESCRIPTION
We assumed the data to be numpy data.
This didn't affect the dense binners where we did not have to post-filter the arrays.

cc @Ben-Epstein 