### PR TITLE
🐛 exporting arrow with large_string would result in schema conflict

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -6732,7 +6732,7 @@ class DataFrameLocal(DataFrame):
                 writer.write_table(table)
 
         if vaex.file.is_path_like(to) or vaex.file.is_file_object(to):
-            schema = self.schema_arrow()
+            schema = self.schema_arrow(reduce_large=reduce_large)
             with vaex.file.open(path=to, mode='wb', fs_options=fs_options, fs=fs) as sink:
                 if as_stream:
                     with pa.RecordBatchStreamWriter(sink, schema) as writer:

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -2,6 +2,7 @@ from common import *
 import os
 from pathlib import Path
 import tempfile
+import pyarrow as pa
 import pandas as pd
 import platform
 import hashlib
@@ -264,3 +265,9 @@ def test_export_json(tmpdir, df_filtered):
     # for column in df.get_column_names():
     for column in ['x', 'name']:
         assert df[column].tolist() == df2[column].tolist()
+
+
+def test_export_large_string(tmpdir):
+    s = pa.array(["Hi", "there"], type=pa.large_string())
+    df = vaex.from_arrays(s=s)
+    df.export_arrow(tmpdir / "test.arrow")


### PR DESCRIPTION
We tried to cast to small strings, but did not do this for the schema.

Fixes #2021