### PR TITLE
🐛 multi-d sparse groupby would fail for arrow data (e.g. list agg)

### DIFF
--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -915,7 +915,7 @@ class GroupBy(GroupByBase):
                 values = self.by[0].bin_values
                 columns = {field.name: ar for field, ar in zip(values.type, values.flatten())}
                 for key, value in arrays.items():
-                    assert value.ndim == 1
+                    assert vaex.array_types.ndim(value) == 1
                     columns[key] = value
             else:
                 columns = {}

--- a/tests/agg_test.py
+++ b/tests/agg_test.py
@@ -716,3 +716,10 @@ def test_agg_arrow():
     dfg = df.groupby(df.s, agg={'l': vaex.agg.list(df.x)}, sort=True)
     assert dfg.s.tolist() == ['aap', 'kees', 'mies', 'noot', None]
     assert set(dfg.l.tolist()[0]) == {0, 2}
+
+
+    df = vaex.from_arrays(x=x, s=s, y=y)
+    dfg = df.groupby([df.s, df.x], agg={'l': vaex.agg.list(df.y)}, sort=True, assume_sparse=True)
+    assert dfg.s.tolist() == ['aap', 'aap', 'kees', 'mies', 'mies', 'noot', None]
+    assert dfg.x.tolist() == [0, 2, 1, 0, 1, 0, 0]
+    assert set(dfg.l.tolist()[0]) == {1}


### PR DESCRIPTION
Fixes #2029