### PR TITLE
🐛 expression engine did not roundtrip dict correctly, missing ,

### DIFF
--- a/packages/vaex-core/vaex/expresso.py
+++ b/packages/vaex-core/vaex/expresso.py
@@ -366,7 +366,7 @@ class ExpressionString(ast.NodeVisitor):
             key = self.visit(key)
             value = self.visit(value)
             parts.append(f'{key}: {value}')
-        return '{' + ' '.join(parts) + '}'
+        return '{' + ', '.join(parts) + '}'
 
     def visit_Call(self, node):
         args = [self.visit(k) for k in node.args]

--- a/tests/expresso_test.py
+++ b/tests/expresso_test.py
@@ -63,7 +63,7 @@ def test_lists():
     assert expr == expr_translate
 
 def test_dicts():
-    expr = "fillmissing(o, {'a': 1})"
+    expr = "fillmissing(o, {'a': 1, 'b': 2})"
     validate_expression(expr, {'o'}, {'fillmissing'})
     node = parse_expression(expr)
     assert node is not None


### PR DESCRIPTION
fixes #2035