### PR TITLE
Remove pylab

### DIFF
--- a/docs/source/example_advanced_plotting.ipynb
+++ b/docs/source/example_advanced_plotting.ipynb
@@ -58,7 +58,7 @@
    "source": [
     "import vaex\n",
     "import numpy as np\n",
-    "import pylab as plt\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore')"
@@ -597,7 +597,7 @@
    "id": "atomic-entrance",
    "metadata": {},
    "source": [
-    "Finally we can plot a background density map of $v_y$ vs $v_z$, and then use  `pylab.quiver` to overplot the velocity vectors:"
+    "Finally we can plot a background density map of $v_y$ vs $v_z$, and then use  `plt.quiver` to overplot the velocity vectors:"
    ]
   },
   {

--- a/docs/source/example_ml_iris.ipynb
+++ b/docs/source/example_ml_iris.ipynb
@@ -105,7 +105,7 @@
     "import vaex\n",
     "import vaex.ml\n",
     "\n",
-    "import pylab as plt\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "\n",
     "df = vaex.datasets.iris()\n",

--- a/docs/source/example_ml_titanic.ipynb
+++ b/docs/source/example_ml_titanic.ipynb
@@ -62,7 +62,7 @@
     "import vaex.ml\n",
     "\n",
     "import numpy as np\n",
-    "import pylab as plt"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {

--- a/docs/source/getting_data_in_vaex.rst
+++ b/docs/source/getting_data_in_vaex.rst
@@ -57,7 +57,7 @@ Example:
 .. code-block:: python
 
     import vaex as vx
-    import pylab as plt
+    import matplotlib.pyplot as plt
     ds = vx.example()
     ds.select("x > -2")
     values = ds.to_dict(selection=True)

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -507,7 +507,7 @@
     }
    ],
    "source": [
-    "import matplotlib.pylab as plt\n",
+    "import matplotlib.pyplot as plt\n",
     "plt.plot(np.linspace(-10, 10, 64), counts_x)\n",
     "plt.show()"
    ]
@@ -1143,7 +1143,7 @@
      "output_type": "stream",
      "text": [
       "/Users/jovan/PyLibrary/vaex/packages/vaex-core/vaex/viz/mpl.py:779: MatplotlibDeprecationWarning: Adding an axes using the same arguments as a previous axes currently reuses the earlier instance.  In a future version, a new instance will always be created and returned.  Meanwhile, this warning can be suppressed, and the future behavior ensured, by passing a unique label to each axes instance.\n",
-      "  ax = pylab.subplot(gs[row_offset + row * row_scale:row_offset + (row + 1) * row_scale, column * column_scale:(column + 1) * column_scale])\n"
+      "  ax = plt.subplot(gs[row_offset + row * row_scale:row_offset + (row + 1) * row_scale, column * column_scale:(column + 1) * column_scale])\n"
      ]
     },
     {
@@ -1329,7 +1329,7 @@
     }
    ],
    "source": [
-    "import matplotlib.pylab as plt\n",
+    "import matplotlib.pyplot as plt\n",
     "x = df.evaluate(\"x\", selection=df.Lz < -2500)\n",
     "y = df.evaluate(\"y\", selection=df.Lz < -2500)\n",
     "plt.scatter(x, y, c=\"red\", alpha=0.5, s=4);"
@@ -2120,7 +2120,7 @@
     "import vaex\n",
     "import vaex.jupyter\n",
     "import numpy as np\n",
-    "import pylab as plt\n",
+    "import matplotlib.pyplot as plt\n",
     "df = vaex.example()"
    ]
   },

--- a/docs/source/tutorial_ml.ipynb
+++ b/docs/source/tutorial_ml.ipynb
@@ -64,7 +64,7 @@
     "import vaex.ml\n",
     "\n",
     "import numpy as np\n",
-    "import pylab as plt"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {

--- a/packages/vaex-core/vaex/dataset_misc.py
+++ b/packages/vaex-core/vaex/dataset_misc.py
@@ -175,12 +175,12 @@ class Zeldovich(DatasetArrays):
 		k_max = np.pi
 		F *= np.where(np.sqrt(k) > k_max, 0, np.sqrt(k**n) * np.exp(-k*4.0))
 		F.flat[0] = 0
-		#pylab.imshow(np.where(sqrt(k) > k_max, 0, np.sqrt(k**-2)), interpolation='nearest')
+		#plt.imshow(np.where(sqrt(k) > k_max, 0, np.sqrt(k**-2)), interpolation='nearest')
 		grf = np.fft.ifftn(F).real
 		Q = np.indices(shape) / float(N-1) - 0.5
 		s = np.array(np.gradient(grf)) / float(N)
-		#pylab.imshow(s[1], interpolation='nearest')
-		#pylab.show()
+		#plt.imshow(s[1], interpolation='nearest')
+		#plt.show()
 		s /= s.max() * 100.
 		#X = np.zeros((4, 3, N, N, N))
 		#for i in range(4):

--- a/packages/vaex-core/vaex/legacy.py
+++ b/packages/vaex-core/vaex/legacy.py
@@ -139,7 +139,7 @@ class SubspaceGridded(object):
         self.subspace_bounded.subspace.plot(np.log1p(self.grid), limits=self.subspace_bounded.bounds, axes=axes, **kwargs)
 
     def mean_line(self, axis=0, **kwargs):
-        from matplotlib import pylab
+        import matplotlib.pyplot as plt
         assert axis in [0, 1]
         other_axis = 0 if axis == 1 else 1
         xmin, xmax = self.subspace_bounded.bounds[axis]
@@ -154,16 +154,16 @@ class SubspaceGridded(object):
             counts = np.sum(self.grid, axis=axis)
             means = np.sum(self.grid * y[:, np.newaxis].T, axis=axis) / counts
         if axis == 0:
-            result = pylab.plot(x, means, **kwargs)
+            result = plt.plot(x, means, **kwargs)
         else:
-            result = pylab.plot(means, x, **kwargs)
+            result = plt.plot(means, x, **kwargs)
 
         self.subspace_bounded.lim()
         return result, x, means
 
     def _repr_png_(self):
-        from matplotlib import pylab
-        fig, ax = pylab.subplots()
+        from matplotlib import pyplot as plt
+        fig, ax = plt.subplots()
         self.plot(axes=ax, f=np.log1p)
         import vaex.utils
         if all([k is not None for k in [self.vx, self.vy, self.vcounts]]):
@@ -189,12 +189,12 @@ class SubspaceGridded(object):
         ax.title.set_text(r"$\log(1+counts)$")
         ax.set_xlabel(self.subspace_bounded.subspace.expressions[0])
         ax.set_ylabel(self.subspace_bounded.subspace.expressions[1])
-        # pylab.savefig
+        # plt.savefig
         # from .io import StringIO
         from six import StringIO
         file_object = StringIO()
         fig.canvas.print_png(file_object)
-        pylab.close(fig)
+        plt.close(fig)
         return file_object.getvalue()
 
     def cube_png(self, f=np.log1p, colormap="afmhot", file="cube.png"):
@@ -258,11 +258,11 @@ class SubspaceBounded(object):
         return SubspaceGridded(self, grid)
 
     def lim(self):
-        from matplotlib import pylab
+        from matplotlib import pyplot as plt
         xmin, xmax = self.bounds[0]
         ymin, ymax = self.bounds[1]
-        pylab.xlim(xmin, xmax)
-        pylab.ylim(ymin, ymax)
+        plt.xlim(xmin, xmax)
+        plt.ylim(ymin, ymax)
 
 
 class Subspaces(object):
@@ -637,7 +637,7 @@ class Subspace(object):
         return rgba8
 
     def plot_vectors(self, expression_x, expression_y, limits, wx=None, wy=None, counts=None, size=32, axes=None, **kwargs):
-        import pylab
+        import matplotlib.pyplot as plt
         # refactor: should go to bin_means_xy
         if counts is None:
             counts = self.histogram(size=size, limits=limits)
@@ -657,7 +657,7 @@ class Subspace(object):
         # vy = self.vy.grid / self.vcounts.grid
         x2d, y2d = np.meshgrid(positions[0], positions[1])
         if axes is None:
-            axes = pylab.gca()
+            axes = plt.gca()
         axes.quiver(x2d[mask], y2d[mask], vx[mask], vy[mask], **kwargs)
 
     def plot(self, grid=None, size=256, limits=None, square=False, center=None, weight=None, weight_stat="mean", figsize=None,
@@ -673,7 +673,7 @@ class Subspace(object):
         :param limits: Limits for the subspace in the form [[xmin, xmax], [ymin, ymax]], if None it will be calculated using Subspace.limits_sigma
         :param square: argument passed to Subspace.limits_sigma
         :param Executor executor: responsible for executing the tasks
-        :param figsize: (x, y) tuple passed to pylab.figure for setting the figure size
+        :param figsize: (x, y) tuple passed to plt.figure for setting the figure size
         :param aspect: Passed to matplotlib's axes.set_aspect
         :param xlabel: String for label on x axis (may contain latex)
         :param ylabel: Same for y axis
@@ -681,7 +681,7 @@ class Subspace(object):
         :return: matplotlib.image.AxesImage
 
          """
-        import pylab
+        import matplotlib.pyplot as plt
         f = _parse_f(f)
         limits = self.limits(limits)
         if limits is None:
@@ -691,14 +691,14 @@ class Subspace(object):
             group_limits = tuple(self.df(group_by).minmax()[0]) + (group_count,)
         # grid = self.histogram(limits=limits, size=size, weight=weight, group_limits=group_limits, group_by=group_by)
         if figsize is not None:
-            pylab.figure(num=None, figsize=figsize, dpi=80, facecolor='w', edgecolor='k')
+            plt.figure(num=None, figsize=figsize, dpi=80, facecolor='w', edgecolor='k')
         if axes is None:
-            axes = pylab.gca()
-        fig = pylab.gcf()
+            axes = plt.gca()
+        fig = plt.gcf()
         # if xlabel:
-        pylab.xlabel(xlabel or self.expressions[0])
+        plt.xlabel(xlabel or self.expressions[0])
         # if ylabel:
-        pylab.ylabel(ylabel or self.expressions[1])
+        plt.ylabel(ylabel or self.expressions[1])
         # axes.set_aspect(aspect)
         rgba8 = self.image_rgba(grid=grid, size=size, limits=limits, square=square, center=center, weight=weight, weight_stat=weight_stat,
                                 f=f, axes=axes,
@@ -745,13 +745,13 @@ class Subspace(object):
         :param grid: A 2d numpy array with the counts, if None it will be calculated using limits provided and Subspace.histogram
         :param size: Passed to Subspace.histogram
         :param limits: Limits for the subspace in the form [[xmin, xmax], [ymin, ymax]], if None it will be calculated using Subspace.limits_sigma
-        :param figsize: (x, y) tuple passed to pylab.figure for setting the figure size
+        :param figsize: (x, y) tuple passed to plt.figure for setting the figure size
         :param xlabel: String for label on x axis (may contain latex)
         :param ylabel: Same for y axis
         :param kwargs: extra argument passed to ...,
 
          """
-        import pylab
+        import matplotlib.pyplot as plt
         f = _parse_f(f)
         limits = self.limits(limits)
         assert self.dimension == 1, "can only plot 1d, not %s" % self.dimension
@@ -760,19 +760,19 @@ class Subspace(object):
         if grid is None:
             grid = self.histogram(limits=limits, size=size, weight=weight)
         if figsize is not None:
-            pylab.figure(num=None, figsize=figsize, dpi=80, facecolor='w', edgecolor='k')
+            plt.figure(num=None, figsize=figsize, dpi=80, facecolor='w', edgecolor='k')
         if axes is None:
-            axes = pylab.gca()
+            axes = plt.gca()
         # if xlabel:
-        pylab.xlabel(xlabel or self.expressions[0])
+        plt.xlabel(xlabel or self.expressions[0])
         # if ylabel:
-        # pylab.ylabel(ylabel or self.expressions[1])
-        pylab.ylabel("counts" or ylabel)
+        # plt.ylabel(ylabel or self.expressions[1])
+        plt.ylabel("counts" or ylabel)
         # axes.set_aspect(aspect)
         N = len(grid)
         xmin, xmax = limits[0]
-        return pylab.plot(np.arange(N) / (N - 1.0) * (xmax - xmin) + xmin, f(grid,), drawstyle="steps", **kwargs)
-        # pylab.ylim(-1, 6)
+        return plt.plot(np.arange(N) / (N - 1.0) * (xmax - xmin) + xmin, f(grid,), drawstyle="steps", **kwargs)
+        # plt.ylim(-1, 6)
 
     def plot_histogram_bq(self, f="identity", size=64, limits=None, color="red", bq_cleanup=True):
         import vaex.ext.bqplot
@@ -963,8 +963,8 @@ class Subspace(object):
         return widgets.VBox([fig, progress, tools])
 
     def figlarge(self, size=(10, 10)):
-        import pylab
-        pylab.figure(num=None, figsize=size, dpi=80, facecolor='w', edgecolor='k')
+        import matplotlib.pyplot as plt
+        plt.figure(num=None, figsize=size, dpi=80, facecolor='w', edgecolor='k')
 
     # def bounded(self):
     # return self.bounded_by_minmax()

--- a/packages/vaex-core/vaex/test/plot.py
+++ b/packages/vaex-core/vaex/test/plot.py
@@ -8,7 +8,7 @@ import shutil
 import numpy as np
 import PIL.Image
 import PIL.ImageChops
-import pylab as plt
+import matplotlib.pyplot as plt
 
 import vaex as vx
 import vaex.utils

--- a/packages/vaex-jupyter/vaex/jupyter/ipympl.py
+++ b/packages/vaex-jupyter/vaex/jupyter/ipympl.py
@@ -3,7 +3,7 @@ import vaex.image
 from .plot import BackendBase
 import copy
 from .utils import debounced
-import pylab as plt
+import matplotlib.pyplot as plt
 import matplotlib.widgets
 import ipywidgets as widgets
 

--- a/packages/vaex-ui/vaex/ui/layers.py
+++ b/packages/vaex-ui/vaex/ui/layers.py
@@ -638,7 +638,7 @@ class LayerTable(object):
         rgb = self._to_rgb(I, color=self.color)
         axes_list[0].rgb_images.append(rgb)
         # print "SCHL" * 1000
-        # pylab.imshow(np.log(schlegel_map[pix].T))
+        # plt.imshow(np.log(schlegel_map[pix].T))
 
     def plot(self, axes_list, stack_image):
         if self._can_plot:

--- a/packages/vaex-ui/vaex/ui/template_matplotlib.py
+++ b/packages/vaex-ui/vaex/ui/template_matplotlib.py
@@ -1,4 +1,4 @@
-import pylab
+import matplotlib.pyplot as plt
 import numpy as np
 import os
 import json
@@ -21,10 +21,10 @@ xmin, xmax, ymin, ymax = meta["extent"]
 
 if has_selection:
     grid_selection = np.load(filename_grid_selection)
-    pylab.imshow(grid, extent=meta["extent"], origin="lower", cmap="binary")
-    pylab.imshow(grid_selection, alpha=0.4, extent=meta["extent"], origin="lower")
+    plt.imshow(grid, extent=meta["extent"], origin="lower", cmap="binary")
+    plt.imshow(grid_selection, alpha=0.4, extent=meta["extent"], origin="lower")
 else:
-    pylab.imshow(grid, extent=meta["extent"], origin="lower")
+    plt.imshow(grid, extent=meta["extent"], origin="lower")
 
 if has_vectors:
     vx, vy, vz = np.load(filename_grid_vector)
@@ -34,6 +34,6 @@ if has_vectors:
     x = np.linspace(xmin + dx / 2, xmax - dx / 2, N)
     y = np.linspace(ymin + dy / 2, ymax - dy / 2, N)
     x2d, y2d = np.meshgrid(x, y)
-    pylab.quiver(x2d, y2d, vx, vy, color="white")
+    plt.quiver(x2d, y2d, vx, vy, color="white")
 
-pylab.show()
+plt.show()

--- a/packages/vaex-ui/vaex/ui/templates.py
+++ b/packages/vaex-ui/vaex/ui/templates.py
@@ -1,7 +1,7 @@
 __author__ = 'maartenbreddels'
 
 
-matplotlib = """import pylab
+matplotlib = """import matplotlib.pyplot as plt
 import numpy as np
 import os
 import json
@@ -24,10 +24,10 @@ xmin, xmax, ymin, ymax = meta["extent"]
 
 if has_selection:
     grid_selection = np.load(filename_grid_selection)
-    pylab.imshow(grid, extent=meta["extent"], origin="lower", cmap="binary")
-    pylab.imshow(grid_selection, alpha=0.4, extent=meta["extent"], origin="lower")
+    plt.imshow(grid, extent=meta["extent"], origin="lower", cmap="binary")
+    plt.imshow(grid_selection, alpha=0.4, extent=meta["extent"], origin="lower")
 else:
-    pylab.imshow(grid, extent=meta["extent"], origin="lower")
+    plt.imshow(grid, extent=meta["extent"], origin="lower")
 
 if has_vectors:
     vx, vy, vz = np.load(filename_grid_vector)
@@ -37,8 +37,8 @@ if has_vectors:
     x = np.linspace(xmin+dx/2, xmax-dx/2, N)
     y = np.linspace(ymin+dy/2, ymax-dy/2, N)
     x2d, y2d = np.meshgrid(x, y)
-    pylab.quiver(x2d, y2d, vx, vy, color="white")
+    plt.quiver(x2d, y2d, vx, vy, color="white")
 
-pylab.show()
+plt.show()
 
 """

--- a/packages/vaex-ui/vaex/ui/volumerendering.py
+++ b/packages/vaex-ui/vaex/ui/volumerendering.py
@@ -1076,9 +1076,9 @@ class VolumeRenderWidget(QtOpenGL.QGLWidget):
         glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, self.texture_size, self.texture_size)
 
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, self.render_buffer)
-        # from matplotlib import pylab
-        # pylab.imshow(np.log((self.data3d.astype(np.float32)).sum(axis=0)+1), cmap='PaulT_plusmin', origin="lower")
-        # pylab.show()
+        # from matplotlib import pyplot as plt
+        # plt.imshow(np.log((self.data3d.astype(np.float32)).sum(axis=0)+1), cmap='PaulT_plusmin', origin="lower")
+        # plt.show()
 
         # print(self.texture_size)
         # print(glCheckFramebufferStatus())
@@ -1320,16 +1320,16 @@ class VolumeRenderWidget(QtOpenGL.QGLWidget):
             glBindTexture(GL_TEXTURE_3D, 0)
 
         if 0:
-            import pylab
-            pylab.subplot(221)
-            pylab.imshow(np.log10(grids_2d[0] + 1))
-            pylab.subplot(222)
-            pylab.imshow(np.log10(grids_2d[1] + 1))
-            pylab.subplot(223)
-            pylab.imshow(np.log10(grids_2d[2] + 1))
-            pylab.subplot(224)
-            pylab.imshow(np.log10(self.grid[128] + 1))
-            pylab.show()
+            from matplotlib import pyplot as plt
+            plt.subplot(221)
+            plt.imshow(np.log10(grids_2d[0] + 1))
+            plt.subplot(222)
+            plt.imshow(np.log10(grids_2d[1] + 1))
+            plt.subplot(223)
+            plt.imshow(np.log10(grids_2d[2] + 1))
+            plt.subplot(224)
+            plt.imshow(np.log10(self.grid[128] + 1))
+            plt.show()
         self.update()
 
         # glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE)

--- a/packages/vaex-viz/vaex/viz/__init__.py
+++ b/packages/vaex-viz/vaex/viz/__init__.py
@@ -36,15 +36,15 @@ class ExpressionAccessorViz:
             :param grid: If the binning is done before by yourself, you can pass it
             :param facet: Expression to produce facetted plots ( facet='x:0,1,12' will produce 12 plots with x in a range between 0 and 1)
             :param limits: list of [xmin, xmax], or a description such as 'minmax', '99%'
-            :param figsize: (x, y) tuple passed to pylab.figure for setting the figure size
+            :param figsize: (x, y) tuple passed to plt.figure for setting the figure size
             :param f: transform values by: 'identity' does nothing 'log' or 'log10' will show the log of the value
             :param n: normalization function, currently only 'normalize' is supported, or None for no normalization
             :param normalize_axis: which axes to normalize on, None means normalize by the global maximum.
             :param normalize_axis:
             :param xlabel: String for label on x axis (may contain latex)
             :param ylabel: Same for y axis
-            :param: tight_layout: call pylab.tight_layout or not
-            :param kwargs: extra argument passed to pylab.plot
+            :param: tight_layout: call plt.tight_layout or not
+            :param kwargs: extra argument passed to plt.plot
             :return:
             """
             return self.df.viz.histogram(self.expression, what=what, grid=grid, shape=shape, facet=facet, limits=limits, figsize=figsize, f=f, n=n, normalize_axis=normalize_axis,

--- a/packages/vaex-viz/vaex/viz/contour.py
+++ b/packages/vaex-viz/vaex/viz/contour.py
@@ -1,7 +1,7 @@
 import re
 import vaex
 import numpy as np
-import pylab as plt
+import matplotlib.pyplot as plt
 
 def plot2d_contour(self, x=None, y=None, what="count(*)", limits=None, shape=256,
                    selection=None, f="identity", figsize=None,
@@ -21,14 +21,14 @@ def plot2d_contour(self, x=None, y=None, what="count(*)", limits=None, shape=256
     :param shape: {shape}
     :param selection: {selection}
     :param f: transform values by: 'identity' does nothing 'log' or 'log10' will show the log of the value
-    :param figsize: (x, y) tuple passed to pylab.figure for setting the figure size
+    :param figsize: (x, y) tuple passed to plt.figure for setting the figure size
     :param xlabel: label of the x-axis (defaults to param x)
     :param ylabel: label of the y-axis (defaults to param y)
     :param aspect: the aspect ratio of the figure
-    :param levels: the contour levels to be passed on pylab.contour or pylab.contourf
+    :param levels: the contour levels to be passed on plt.contour or plt.contourf
     :param colorbar: plot a colorbar or not
     :param colorbar_label: the label of the colourbar (defaults to param what)
-    :param colormap: matplotlib colormap to pass on to pylab.contour or pylab.contourf
+    :param colormap: matplotlib colormap to pass on to plt.contour or plt.contourf
     :param colors: the colours of the contours
     :param linewidths: the widths of the contours
     :param linestyles: the style of the contour lines

--- a/packages/vaex-viz/vaex/viz/mpl.py
+++ b/packages/vaex-viz/vaex/viz/mpl.py
@@ -72,19 +72,19 @@ def histogram(self, x=None, what="count(*)", grid=None, shape=64, facet=None, li
     :param grid: If the binning is done before by yourself, you can pass it
     :param facet: Expression to produce facetted plots ( facet='x:0,1,12' will produce 12 plots with x in a range between 0 and 1)
     :param limits: list of [xmin, xmax], or a description such as 'minmax', '99%'
-    :param figsize: (x, y) tuple passed to pylab.figure for setting the figure size
+    :param figsize: (x, y) tuple passed to plt.figure for setting the figure size
     :param f: transform values by: 'identity' does nothing 'log' or 'log10' will show the log of the value
     :param n: normalization function, currently only 'normalize' is supported, or None for no normalization
     :param normalize_axis: which axes to normalize on, None means normalize by the global maximum.
     :param normalize_axis:
     :param xlabel: String for label on x axis (may contain latex)
     :param ylabel: Same for y axis
-    :param: tight_layout: call pylab.tight_layout or not
-    :param kwargs: extra argument passed to pylab.plot
+    :param: tight_layout: call plt.tight_layout or not
+    :param kwargs: extra argument passed to plt.plot
     :return:
     """
 
-    import pylab
+    import matplotlib.pyplot as plt
     f = _parse_f(f)
     n = _parse_n(n)
     if type(shape) == int:
@@ -96,8 +96,8 @@ def histogram(self, x=None, what="count(*)", grid=None, shape=64, facet=None, li
             binby = [expression] + binby
     limits = self.limits(binby, limits)
     if figsize is not None:
-        pylab.figure(num=None, figsize=figsize, dpi=80, facecolor='w', edgecolor='k')
-    fig = pylab.gcf()
+        plt.figure(num=None, figsize=figsize, dpi=80, facecolor='w', edgecolor='k')
+    fig = plt.gcf()
     import re
     if facet is not None:
         match = re.match("(.*):(.*),(.*),(.*)", facet)
@@ -165,39 +165,39 @@ def histogram(self, x=None, what="count(*)", grid=None, shape=64, facet=None, li
         rows, columns = int(math.ceil(facet_count / 4.)), 4
         values = np.linspace(facet_limits[0], facet_limits[1], facet_count + 1)
         for i in range(facet_count):
-            ax = pylab.subplot(rows, columns, i + 1)
+            ax = plt.subplot(rows, columns, i + 1)
             value = ax.plot(xar, ngrid[i], drawstyle="steps-mid", label=label, **kwargs)
             v1, v2 = values[i], values[i + 1]
-            pylab.xlabel(xlabel or x)
-            pylab.ylabel(ylabel or what)
+            plt.xlabel(xlabel or x)
+            plt.ylabel(ylabel or what)
             ax.set_title("%3f <= %s < %3f" % (v1, facet_expression, v2))
             if self.iscategory(xexpression):
                 labels = self.category_labels(xexpression)
                 step = len(labels) // max_labels
-                pylab.xticks(range(len(labels))[::step], labels[::step], size='small')
+                plt.xticks(range(len(labels))[::step], labels[::step], size='small')
     else:
-        # im = pylab.imshow(rgrid, extent=np.array(limits[:2]).flatten(), origin="lower", aspect=aspect)
-        pylab.xlabel(xlabel or self.label(x))
-        pylab.ylabel(ylabel or what)
+        # im = plt.imshow(rgrid, extent=np.array(limits[:2]).flatten(), origin="lower", aspect=aspect)
+        plt.xlabel(xlabel or self.label(x))
+        plt.ylabel(ylabel or what)
         # print(xar, ngrid)
         # repeat the first element, that's how plot/steps likes it..
         g = np.concatenate([ngrid[0:1], ngrid])
-        value = pylab.plot(xar, g, drawstyle="steps-pre", label=label, **kwargs)
+        value = plt.plot(xar, g, drawstyle="steps-pre", label=label, **kwargs)
         if self.iscategory(xexpression):
             labels = self.category_labels(xexpression)
             step = len(labels) // max_labels
-            pylab.xticks(range(len(labels))[::step], labels[::step], size='small')
+            plt.xticks(range(len(labels))[::step], labels[::step], size='small')
     if tight_layout:
-        pylab.tight_layout()
+        plt.tight_layout()
     if hardcopy:
-        pylab.savefig(hardcopy)
+        plt.savefig(hardcopy)
     if show:
-        pylab.show()
+        plt.show()
     return value
     # N = len(grid)
     # xmin, xmax = limits[0]
-    # return pylab.plot(np.arange(N) / (N-1.0) * (xmax-xmin) + xmin, f(grid,), drawstyle="steps", **kwargs)
-    # pylab.ylim(-1, 6)
+    # return plt.plot(np.arange(N) / (N-1.0) * (xmax-xmin) + xmin, f(grid,), drawstyle="steps", **kwargs)
+    # plt.ylim(-1, 6)
 
 
 @patch
@@ -211,12 +211,12 @@ def scatter(self, x, y, xerr=None, yerr=None, cov=None, corr=None, s_expr=None, 
     length_check=True, label=None, xlabel=None, ylabel=None, errorbar_kwargs={}, ellipse_kwargs={}, **kwargs):
     """Viz (small amounts) of data in 2d using a scatter plot
 
-    Convenience wrapper around pylab.scatter when for working with small DataFrames or selections
+    Convenience wrapper around plt.scatter when for working with small DataFrames or selections
 
     :param x: Expression for x axis
     :param y: Idem for y
-    :param s_expr: When given, use if for the s (size) argument of pylab.scatter
-    :param c_expr: When given, use if for the c (color) argument of pylab.scatter
+    :param s_expr: When given, use if for the s (size) argument of plt.scatter
+    :param c_expr: When given, use if for the c (color) argument of plt.scatter
     :param labels: Annotate the points with these text values
     :param selection: Single selection expression, or None
     :param length_limit: maximum number of rows it will plot
@@ -225,10 +225,10 @@ def scatter(self, x, y, xerr=None, yerr=None, cov=None, corr=None, s_expr=None, 
     :param xlabel: label for x axis, if None .label(x) is used
     :param ylabel: label for y axis, if None .label(y) is used
     :param errorbar_kwargs: extra dict with arguments passed to plt.errorbar
-    :param kwargs: extra arguments passed to pylab.scatter
+    :param kwargs: extra arguments passed to plt.scatter
     :return:
     """
-    import pylab as plt
+    import matplotlib.pyplot as plt
     x = _ensure_strings_from_expressions(x)
     y = _ensure_strings_from_expressions(y)
     label = str(label or selection)
@@ -382,18 +382,18 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
     :param limits: list of [[xmin, xmax], [ymin, ymax]], or a description such as 'minmax', '99%'
     :param grid: if the binning is done before by yourself, you can pass it
     :param colormap: matplotlib colormap to use
-    :param figsize: (x, y) tuple passed to pylab.figure for setting the figure size
+    :param figsize: (x, y) tuple passed to plt.figure for setting the figure size
     :param xlabel:
     :param ylabel:
     :param aspect:
-    :param tight_layout: call pylab.tight_layout or not
+    :param tight_layout: call plt.tight_layout or not
     :param colorbar: plot a colorbar or not
     :param interpolation: interpolation for imshow, possible options are: 'nearest', 'bilinear', 'bicubic', see matplotlib for more
     :param return_extra:
     :return:
     """
-    import pylab
     import matplotlib
+    import matplotlib.pyplot as plt
     n = _parse_n(normalize)
     if type(shape) == int:
         shape = (shape,) * 2
@@ -403,7 +403,7 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
     for expression in [y, x]:
         if expression is not None:
             binby = [expression] + binby
-    fig = pylab.gcf()
+    fig = plt.gcf()
     if figsize is not None:
         fig.set_size_inches(*figsize)
     import re
@@ -621,7 +621,7 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
     # print(grid.shape)
     # grid = self.reduce(grid, )
     axes = []
-    # cax = pylab.subplot(1,1,1)
+    # cax = plt.subplot(1,1,1)
 
     background_color = np.array(matplotlib.colors.colorConverter.to_rgb(background_color))
 
@@ -738,7 +738,7 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
                 sm = matplotlib.cm.ScalarMappable(norm, colormaps[j])
                 sm.set_array(1)  # make matplotlib happy (strange behavious)
                 if facets > 1:
-                    ax = pylab.subplot(gs[0, j])
+                    ax = plt.subplot(gs[0, j])
                     colorbar = fig.colorbar(sm, cax=ax, orientation="horizontal")
                 else:
                     colorbar = fig.colorbar(sm)
@@ -754,7 +754,7 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
                 sm = matplotlib.cm.ScalarMappable(norm, colormaps[i])
                 sm.set_array(1)  # make matplotlib happy (strange behavious)
                 if facets > 1:
-                    ax = pylab.subplot(gs[i, -1])
+                    ax = plt.subplot(gs[i, -1])
                     colorbar = fig.colorbar(sm, cax=ax)
                 else:
                     colorbar = fig.colorbar(sm)
@@ -793,7 +793,7 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
                 sm = matplotlib.cm.ScalarMappable(norm, colormaps[what_index])
                 sm.set_array(1)  # make matplotlib happy (strange behavious)
                 if facets > 1:
-                    ax = pylab.subplot(gs[row, column])
+                    ax = plt.subplot(gs[row, column])
                     colorbar = fig.colorbar(sm, ax=ax)
                 else:
                     colorbar = fig.colorbar(sm)
@@ -801,9 +801,9 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
                 colorbar.ax.set_ylabel(colorbar_label or label)
 
             if facets > 1:
-                ax = pylab.subplot(gs[row_offset + row * row_scale:row_offset + (row + 1) * row_scale, column * column_scale:(column + 1) * column_scale])
+                ax = plt.subplot(gs[row_offset + row * row_scale:row_offset + (row + 1) * row_scale, column * column_scale:(column + 1) * column_scale])
             else:
-                ax = pylab.gca()
+                ax = plt.gca()
             axes.append(ax)
             logger.debug("rgrid: %r", rgrid.shape)
             plot_rgrid = rgrid
@@ -834,10 +834,10 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
                     return self.label(expression)
             if visual_reverse["x"] =='x':
                 labelsx = labels['x']
-                pylab.xlabel(labelsx[subplot_index])
+                plt.xlabel(labelsx[subplot_index])
             if visual_reverse["x"] =='x':
                 labelsy = labels['y']
-                pylab.ylabel(labelsy[subplot_index])
+                plt.ylabel(labelsy[subplot_index])
             if visual["z"] in ['row']:
                 labelsz = labels['z']
                 ax.set_title(labelsz[i])
@@ -850,24 +850,24 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
             if self.iscategory(xexpression):
                 labels = self.category_labels(xexpression)
                 step = max(len(labels) // max_labels, 1)
-                pylab.xticks(np.arange(len(labels))[::step], labels[::step], size='small')
+                plt.xticks(np.arange(len(labels))[::step], labels[::step], size='small')
             yexpression = yexpressions[subplot_index]
             if self.iscategory(yexpression):
                 labels = self.category_labels(yexpression)
                 step = max(len(labels) // max_labels, 1)
-                pylab.yticks(np.arange(len(labels))[::step], labels[::step], size='small')
+                plt.yticks(np.arange(len(labels))[::step], labels[::step], size='small')
             facet_index += 1
     if title:
         fig.suptitle(title, fontsize="x-large")
     if tight_layout:
         if title:
-            pylab.tight_layout(rect=[0, 0.03, 1, 0.95])
+            plt.tight_layout(rect=[0, 0.03, 1, 0.95])
         else:
-            pylab.tight_layout()
+            plt.tight_layout()
     if hardcopy:
-        pylab.savefig(hardcopy)
+        plt.savefig(hardcopy)
     if show:
-        pylab.show()
+        plt.show()
     if return_extra:
         return im, grid, fgrid, ngrid, rgrid
     else:
@@ -914,7 +914,7 @@ def healpix_heatmap(self, healpix_expression="source_id/34359738368", healpix_ma
     """
     # plot_level = healpix_level #healpix_max_level-reduce_level
     import healpy as hp
-    import pylab as plt
+    import matplotlib.pyplot as plt
     if grid is None:
         reduce_level = healpix_max_level - healpix_level
         NSIDE = 2**healpix_level

--- a/packages/vaex-viz/vaex/viz/tensor.py
+++ b/packages/vaex-viz/vaex/viz/tensor.py
@@ -4,7 +4,7 @@ import numpy as np
 
 def plot2d_tensor(self, x, y, vx, vy, shape=16, limits=None, delay=None, show=False, normalize=False, selection=None,
                   facecolor='green', alpha=0.5, edgecolor='black', scale=1., min_count=0):
-    import matplotlib.pylab as plt
+    import matplotlib.pyplot as plt
     shape = vaex.dataset._expand_shape(shape, 2)
 
     @vaex.delayed

--- a/packages/vaex-viz/vaex/viz/vector.py
+++ b/packages/vaex-viz/vaex/viz/vector.py
@@ -4,7 +4,7 @@ import numpy as np
 
 def plot2d_vector(self, x, y, vx, vy, shape=16, limits=None, delay=None, show=False, normalize=False,
                   selection=None, min_count=0, **kwargs):
-    import matplotlib.pylab as plt
+    import matplotlib.pyplot as plt
     shape = vaex.dataset._expand_shape(shape, 2)
 
     @vaex.delayed


### PR DESCRIPTION
Replaced pylab with matplotlib.pyplot since the use of pylab is [discouraged](https://matplotlib.org/stable/api/index.html?highlight=pylab#module-pylab) by matplotlib.