### PR TITLE
🐛 wrong order of casting and subtracting offset cause overflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -160,7 +160,7 @@ jobs:
       run: |
         ./ci/05-run-notebooks.sh
     - name: Authenticate Google Cloud Platform
-      if: ${{ (github.event.pull_request.head.repo.full_name == 'vaexio/vaex') }}
+      if: ${{ (github.event.pull_request.head.repo.full_name == 'vaexio/vaex') && !((matrix.os == 'windows-latest') || (matrix.os == 'macOS-latest' && matrix.python-version == '3.6'))  }}
       uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID_VAEX }}

--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -259,16 +259,13 @@ class Grouper(BinnerBase):
             @vaex.delayed
             def process(hashmap_unique: vaex.hash.HashMapUnique):
                 self.bin_values = hashmap_unique.keys()
-                print("bin_values", self.bin_values)
                 if self.allow_simplify and dtype == int and len(self.bin_values):
-                    print("simplify")
                     vmin = self.bin_values.min()
                     vmax = self.bin_values.max()
                     int_range = vmax - vmin + 1
                     # we allow for 25% unused 'slots'
                     bins = len(self.bin_values)
                     if int_range <= (bins * 4 / 3):
-                        print("yes!")
                         dense = bins == int_range
                         self.simpler = BinnerInteger(self.expression, min_value=vmin, max_value=vmax, dropmissing=not hashmap_unique.has_null, dense=dense, sort=sort, ascending=ascending)
                         return
@@ -279,11 +276,8 @@ class Grouper(BinnerBase):
                 logger.debug('Constructed grouper for expression %s with %i values', str(expression), len(self.bin_values))
 
                 if self.sort:
-                    print("sort")
                     if pre_sort:
-                        print("presort 1", self.bin_values)
                         hashmap_unique, self.bin_values = hashmap_unique.sorted(keys=self.bin_values, ascending=ascending, return_keys=True)
-                        print("presort 2", self.bin_values)
                         self.sort_indices = None
                     else:
                         indices = pa.compute.sort_indices(self.bin_values, sort_keys=[("x", "ascending" if ascending else "descending")])
@@ -291,7 +285,6 @@ class Grouper(BinnerBase):
                         # the bin_values will still be pre sorted, maybe that is confusing (implementation detail)
                         self.bin_values = pa.compute.take(self.bin_values, self.sort_indices)
                 else:
-                    print("no sort")
                     self.sort_indices = None
                 self.hashmap_unique = hashmap_unique
 
@@ -341,7 +334,6 @@ class GrouperCombined(Grouper):
 
         Used in the sparse/combined group by.
         '''
-        print("call super")
         super().__init__(expression, df, sort=sort, row_limit=row_limit, progress=progress, allow_simplify=False)
         assert len(multipliers) == len(parents)
         self.parents = parents

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -412,7 +412,7 @@ def test_groupby_int_binner_with_null(df_factory):
 
 def test_groupby_int_binner_with_offset_combine(df_factory):
     offset = 2**16
-    df = df_factory(x=np.array([0, 1, 1, 2]) + offset, y=np.array([0, 0, 0, 1]))
+    df = df_factory(x=np.array([0, 1, 1, 2], dtype='int32') + offset, y=np.array([0, 0, 0, 1], dtype='int32'))
 
     binner_x = vaex.groupby.BinnerInteger(df.x, min_value=offset, max_value=offset+2, sort=True, ascending=True)
     binner_y = vaex.groupby.BinnerInteger(df.y, min_value=0, max_value=1, sort=True, ascending=True)

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -410,6 +410,19 @@ def test_groupby_int_binner_with_null(df_factory):
     assert dfg["sum"].tolist() == [99, 5, 4, 3, 6]
 
 
+def test_groupby_int_binner_with_offset_combine(df_factory):
+    offset = 2**16
+    df = df_factory(x=np.array([0, 1, 1, 2]) + offset, y=np.array([0, 0, 0, 1]))
+
+    binner_x = vaex.groupby.BinnerInteger(df.x, min_value=offset, max_value=offset+2, sort=True, ascending=True)
+    binner_y = vaex.groupby.BinnerInteger(df.y, min_value=0, max_value=1, sort=True, ascending=True)
+    dfg = df.groupby([binner_x, binner_y], agg={"sum": vaex.agg.sum("x")}, assume_sparse=True, sort=True)
+    assert dfg["x"].tolist() == [offset+0, offset+1, offset+2]
+    assert dfg["y"].tolist() == [0,     0,   1]
+    assert dfg["sum"].tolist() ==[offset, (offset+1)*2, offset+2]
+
+
+
 def test_groupby_simplify_to_int_binner():
     x = np.arange(1024)
     x[:200] = 0  # <20% the same


### PR DESCRIPTION
    Which could lead to wrong groupby results.
    Fixes: #2048