### PR TITLE
🐛 hdf5: do not keep a reference to numpy arrays on closing an hdf5 file

### DIFF
--- a/packages/vaex-hdf5/vaex/hdf5/writer.py
+++ b/packages/vaex-hdf5/vaex/hdf5/writer.py
@@ -30,6 +30,8 @@ class Writer:
         self._layout_called = False
 
     def close(self):
+        # make sure we don't have references to the numpy arrays any more
+        self.column_writers = {}
         if self.mmap is not None:
             self.mmap.close()
             self.file.close()


### PR DESCRIPTION
Otherwise the buffers of the numpy arrays are still being used.

Fixes #2062