### PR TITLE
feat(ml): Enable most metrics to support selections

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -43,4 +43,5 @@ dependencies:
 - tornado
 - uvicorn<0.16
 - xarray
-- myst-parser<0.18  # 0.18 breaks our test, missing main
+# currently not using this, since the test that requires this is flakey
+# - myst-parser<0.18  # 0.18 breaks our test, missing main

--- a/packages/vaex-ml/SCIKIT_LEARN_LICENSE.txt
+++ b/packages/vaex-ml/SCIKIT_LEARN_LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2007-2021 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/vaex-ml/vaex/ml/metrics.py
+++ b/packages/vaex-ml/vaex/ml/metrics.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 import vaex
@@ -8,6 +10,80 @@ def ensure_string_arguments(*args):
     for arg in args:
         result.append(vaex.utils._ensure_string_from_expression(arg))
     return result
+
+
+def _prf_divide(numerator, denominator, metric, modifier, average, warn_for, zero_division="warn"):
+    '''Performs division and handles divide-by-zero.
+
+    On zero-division, sets the corresponding result elements equal to 0 or 1 (according to ``zero_division``).
+    Plus, if ``zero_division != "warn"`` raises a warning.
+
+    The metric, modifier and average arguments are used only for determining an appropriate warning.
+
+    Note: this function was forked from the https://github.com/scikit-learn/scikit-learn/ project
+    and was originally published under BSD-3 license, which is included in packages/vaex-ml/SCIKIT_LEARN_LICENSE.txt
+    '''
+    mask = denominator == 0.0
+    denominator = denominator.copy()
+    denominator[mask] = 1  # avoid infs/nans
+    result = numerator / denominator
+
+    if not np.any(mask):
+        return result
+
+    # if ``zero_division=1``, set those with denominator == 0 equal to 1
+    result[mask] = 0.0 if zero_division in ["warn", 0] else 1.0
+
+    # the user will be removing warnings if zero_division is set to something
+    # different than its default value. If we are computing only f-score
+    # the warning will be raised only if precision and recall are ill-defined
+    if zero_division != "warn" or metric not in warn_for:
+        return result
+
+    # build appropriate warning
+    # E.g. "Precision and F-score are ill-defined and being set to 0.0 in
+    # labels with no predicted samples. Use ``zero_division`` parameter to
+    # control this behavior."
+
+    if metric in warn_for and "f-score" in warn_for:
+        msg_start = "{0} and F-score are".format(metric.title())
+    elif metric in warn_for:
+        msg_start = "{0} is".format(metric.title())
+    elif "f-score" in warn_for:
+        msg_start = "F-score is"
+    else:
+        return result
+
+    _warn_prf(average, modifier, msg_start, len(result))
+
+    return result
+
+
+def _warn_prf(average, modifier, msg_start, result_size):
+    '''
+    Note: this function was forked from the https://github.com/scikit-learn/scikit-learn/ project
+    and was originally published under BSD-3 license, which is included in packages/vaex-ml/SCIKIT_LEARN_LICENSE.txt
+    '''
+    axis0, axis1 = "sample", "label"
+    if average == "samples":
+        axis0, axis1 = axis1, axis0
+    msg = (
+        "{0} ill-defined and being set to 0.0 {{0}} "
+        "no {1} {2}s. Use `zero_division` parameter to control"
+        " this behavior.".format(msg_start, modifier, axis0)
+    )
+    if result_size == 1:
+        msg = msg.format("due to")
+    else:
+        msg = msg.format("in {0}s with".format(axis1))
+    warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
+
+
+class UndefinedMetricWarning(UserWarning):
+    '''Warning used when the metric is invalid
+
+    (this function is taken verbatim from scikit-learn)
+    '''
 
 
 class DataFrameAccessorMetrics():
@@ -23,12 +99,14 @@ class DataFrameAccessorMetrics():
         self.df = self.ml.df
 
     @vaex.docstrings.docsubst
-    def accuracy_score(self, y_true, y_pred):
+    def accuracy_score(self, y_true, y_pred, selection=None, array_type='python'):
         '''
         Calculates the accuracy classification score.
 
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
+        :param selection: {selection}
+        :param array_type: {array_type}
         :returns: The accuracy score.
 
         Example:
@@ -40,14 +118,19 @@ class DataFrameAccessorMetrics():
           0.6
         '''
         y_true, y_pred = ensure_string_arguments(y_true, y_pred)
-        return (self.df[y_true] == self.df[y_pred]).sum() / len(self.df)
+        acc = (self.df[y_true] == self.df[y_pred]).sum(selection=selection) / self.df.count(selection=selection)
+        if vaex.utils._issequence(acc):
+            return vaex.array_types.convert(acc, type=array_type)
+        else:
+            return acc
 
     @vaex.docstrings.docsubst
-    def confusion_matrix(self, y_true, y_pred, array_type=None):
+    def confusion_matrix(self, y_true, y_pred, selection=None, array_type=None):
         '''
         Docstrings
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
+        :param selection: {selection}
         :param array_type: {array_type}
         :returns: The confusion matrix
 
@@ -68,10 +151,10 @@ class DataFrameAccessorMetrics():
         if df.is_category(y_pred) is not True:
             df = df.ordinal_encode(y_pred)
 
-        return df.count(binby=(y_pred, y_true), array_type=array_type).T
+        return df.count(binby=(y_true, y_pred), selection=selection, array_type=array_type)
 
     @vaex.docstrings.docsubst
-    def precision_recall_fscore(self, y_true, y_pred, average='binary'):
+    def precision_recall_fscore(self, y_true, y_pred, average='binary', selection=None, array_type=None):
         '''Calculates the precision, recall and f1 score for a classification problem.
 
         These metrics are defined as follows:
@@ -87,33 +170,69 @@ class DataFrameAccessorMetrics():
         The "macro" average is the unweighted mean of a metric for each label.
         For multiclass problems the data can be ordinal encoded, but class names are also supported.
 
+        :y_true: {expression_one}
+        :y_pred: {expression_one}
+        :average: Should be either 'binary' or 'macro'.
+        :selection: {selection}
+        :array_type: {array_type}
+        :returns: The precision, recall and f1 score
+
         Example:
+
+        >>> import vaex
+        >>> import vaex.ml.metrics
+        >>> df = vaex.from_arrays(y_true=[1, 1, 0, 1, 0, 1], y_pred=[1, 0, 0, 1, 1, 1])
+        >>> df.ml.metrics.precision_score(df.y_true, df.y_pred)
+          (0.75, 0.75, 0.75)
         '''
         y_true, y_pred = ensure_string_arguments(y_true, y_pred)
         assert average in ['binary', 'macro']
 
+        C = self.confusion_matrix(y_true=y_true, y_pred=y_pred, array_type='numpy', selection=selection)
+
         if average == 'binary':
-            assert set(self.df[y_true].unique()) == {0, 1}, '`y_true` must be encoded in 1s and 0s'
-            assert set(self.df[y_pred].unique()) == {0, 1}, '`y_pred` must be encoded in 1s and 0s'
-            selections = [f'({y_true}==1) & ({y_pred}==1)', f'{y_pred}==1', f'{y_true}==1']
-            count_y_true_y_pred, count_y_pred, count_y_true = self.df.count(selection=selections)
-            precision = count_y_true_y_pred / count_y_pred
-            recall = count_y_true_y_pred / count_y_true
-            f1 = 2 * (precision * recall) / (precision + recall)
+            if (len(C.shape) == 2) & (C.shape == (2, 2)):
+                Cdiag = np.diag(C)
+                precision = _prf_divide(Cdiag, np.sum(C, axis=0), 'precision', 'predicted', average, 'precision')[1]
+                recall = _prf_divide(Cdiag, np.sum(C, axis=1), 'recall', 'predicted', average, 'recall')[1]
+                f1 = _prf_divide(vaex.array_types.to_numpy(2 * precision * recall),
+                                 vaex.array_types.to_numpy(precision + recall),
+                                 'f1', 'predicted', average, 'f1').item()
+            elif (len(C.shape) == 3) & (C.shape[1:] == (2, 2)):
+                Cdiag = np.array([np.diag(i) for i in C])
+                precision = _prf_divide(Cdiag, np.array([np.sum(i, axis=0) for i in C]), 'precision', 'predicted', average, 'precision')[:, 1]
+                recall = _prf_divide(Cdiag, np.array([np.sum(i, axis=1) for i in C]), 'recall', 'predicted', average, 'recall')[:, 1]
+                f1 = _prf_divide(2 * precision * recall, precision + recall, 'f1', 'predicted', average, 'f1')
+            else:
+                raise ValueError('Cannot calculate metrics for `average="binary"`.')
 
         else:
-            C = self.confusion_matrix(y_true=y_true, y_pred=y_pred, array_type='numpy')
-            precision_array = (np.diag(C) / np.sum(C, axis=0))
-            recall_array = (np.diag(C) / np.sum(C, axis=1))
-            f1_array = 2 * (precision_array * recall_array) / (precision_array + recall_array)
-            precision = precision_array.mean()
-            recall = recall_array.mean()
-            f1 = f1_array.mean()
+            if len(C.shape) == 2:
+                Cdiag = np.diag(C)
+                precision_array = _prf_divide(Cdiag, np.sum(C, axis=0), 'precision', 'predicted', average, 'precision')
+                recall_array = _prf_divide(Cdiag, np.sum(C, axis=1), 'recall', 'predicted', average, 'recall')
+                f1_array = _prf_divide(vaex.array_types.to_numpy(2 * precision_array * recall_array),
+                                       vaex.array_types.to_numpy(precision_array + recall_array), 'f1', 'predicted', average, 'f1')
+                precision = precision_array.mean()
+                recall = recall_array.mean()
+                f1 = f1_array.mean()
+            if len(C.shape) == 3:
+                Cdiag = np.array([np.diag(i) for i in C])
+                precision_array = _prf_divide(Cdiag, np.array([np.sum(i, axis=0) for i in C]), 'precision', 'predicted', average, 'precision')
+                recall_array = _prf_divide(Cdiag, np.array([np.sum(i, axis=1) for i in C]), 'recall', 'predicted', average, 'recall')
+                f1_array = _prf_divide(2 * precision_array * recall_array, precision_array + recall_array, 'f1', 'predicted', average, 'f1')
+                precision = precision_array.mean(axis=1)
+                recall = recall_array.mean(axis=1)
+                f1 = f1_array.mean(axis=1)
 
+        if vaex.utils._issequence(precision):
+            return (vaex.array_types.convert(precision, type=array_type),
+                    vaex.array_types.convert(recall, type=array_type),
+                    vaex.array_types.convert(f1, type=array_type))
         return precision, recall, f1
 
     @vaex.docstrings.docsubst
-    def precision_score(self, y_true, y_pred, average='binary'):
+    def precision_score(self, y_true, y_pred, average='binary', selection=None, array_type=None):
         '''Calculates the precision classification score.
 
         For a binary classification problem, `average` should be set to "binary".
@@ -126,6 +245,8 @@ class DataFrameAccessorMetrics():
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
         :param average: Should be either 'binary' or 'macro'.
+        :param selection: {selection}
+        :param array_type: {array_type}
         :returns: The precision score
 
         Example:
@@ -138,11 +259,11 @@ class DataFrameAccessorMetrics():
         '''
 
         y_true, y_pred = ensure_string_arguments(y_true, y_pred)
-        precision, _, _ = self.precision_recall_fscore(y_true, y_pred, average=average)
+        precision, _, _ = self.precision_recall_fscore(y_true, y_pred, average=average, selection=selection, array_type=array_type)
         return precision
 
     @vaex.docstrings.docsubst
-    def recall_score(self, y_true, y_pred, average='binary'):
+    def recall_score(self, y_true, y_pred, average='binary', selection=None, array_type=None):
         '''
         Calculates the recall classification score.
 
@@ -156,6 +277,8 @@ class DataFrameAccessorMetrics():
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
         :param average: Should be either 'binary' or 'macro'.
+        :param selection: {selection}
+        :param array_type: {array_type}
         :returns: The recall score
 
         Example:
@@ -167,10 +290,10 @@ class DataFrameAccessorMetrics():
           0.75
         '''
         y_true, y_pred = ensure_string_arguments(y_true, y_pred)
-        _, recall, _ = self.precision_recall_fscore(y_true, y_pred, average=average)
+        _, recall, _ = self.precision_recall_fscore(y_true, y_pred, average=average, selection=selection, array_type=array_type)
         return recall
 
-    def f1_score(self, y_true, y_pred, average='binary'):
+    def f1_score(self, y_true, y_pred, average='binary', selection=None, array_type=None):
         '''Calculates the F1 score.
 
         This is the harmonic average between the precision and the recall.
@@ -185,6 +308,8 @@ class DataFrameAccessorMetrics():
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
         :param average: Should be either 'binary' or 'macro'.
+        :param selection: {selection}
+        :param array_type: {array_type}
         :returns: The recall score
 
         Example:
@@ -196,16 +321,17 @@ class DataFrameAccessorMetrics():
           0.75
         '''
         y_true, y_pred = ensure_string_arguments(y_true, y_pred)
-        _, _, f1 = self.precision_recall_fscore(y_true, y_pred, average=average)
+        _, _, f1 = self.precision_recall_fscore(y_true, y_pred, average=average, selection=selection, array_type=array_type)
         return f1
 
-    def matthews_correlation_coefficient(self, y_true, y_pred):
+    def matthews_correlation_coefficient(self, y_true, y_pred, selection=None, array_type=None):
         '''Calculates the Matthews correlation coefficient.
 
         This metric can be used for both binary and multiclass classification problems.
 
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
+        :param selection: {selection}
         :returns: The Matthews correlation coefficient.
 
         Example:
@@ -216,20 +342,35 @@ class DataFrameAccessorMetrics():
         >>> df.ml.metrics.matthews_correlation_coefficient(df.y_true, df.y_pred)
           0.25
         '''
-        C = self.confusion_matrix(y_true=y_true, y_pred=y_pred)
-        # This is from scikit-learn
-        t_sum = C.sum(axis=1, dtype=np.float64)
-        p_sum = C.sum(axis=0, dtype=np.float64)
-        n_correct = np.trace(C, dtype=np.float64)
-        n_samples = p_sum.sum()
-        cov_ytyp = n_correct * n_samples - np.dot(t_sum, p_sum)
-        cov_ypyp = n_samples ** 2 - np.dot(p_sum, p_sum)
-        cov_ytyt = n_samples ** 2 - np.dot(t_sum, t_sum)
+        C = self.confusion_matrix(y_true=y_true, y_pred=y_pred, selection=selection, array_type='numpy')
+        if len(C.shape) == 2:
+            # This is from scikit-learn
+            t_sum = C.sum(axis=1, dtype=np.float64)
+            p_sum = C.sum(axis=0, dtype=np.float64)
+            n_correct = np.trace(C, dtype=np.float64)
+            n_samples = p_sum.sum()
+            cov_ytyp = n_correct * n_samples - np.dot(t_sum, p_sum)
+            cov_ypyp = n_samples ** 2 - np.dot(p_sum, p_sum)
+            cov_ytyt = n_samples ** 2 - np.dot(t_sum, t_sum)
 
-        if cov_ypyp * cov_ytyt == 0:
-            return 0.0
+            if cov_ypyp * cov_ytyt == 0:
+                return 0.0
+            else:
+                return cov_ytyp / np.sqrt(cov_ytyt * cov_ypyp)
         else:
-            return cov_ytyp / np.sqrt(cov_ytyt * cov_ypyp)
+            t_sum = np.array([i.sum(axis=1, dtype=np.float64) for i in C])
+            p_sum = np.array([i.sum(axis=0, dtype=np.float64) for i in C])
+            n_correct = np.array([np.trace(i, dtype=np.float64) for i in C])
+            n_samples =p_sum.sum(axis=1)
+            cov_ytyp = n_correct * n_samples - np.array([np.dot(i, j) for i, j in zip(t_sum, p_sum)])
+            cov_ypyp = n_samples ** 2 - np.array([np.dot(i, i) for i in p_sum])
+            cov_ytyt = n_samples ** 2 - np.array([np.dot(i, i) for i in t_sum])
+            mcc = _prf_divide(cov_ytyp, np.sqrt(cov_ytyt * cov_ypyp), metric='MCC', modifier='predicted', average='n/a', warn_for=[None])
+
+            if vaex.utils._issequence(mcc):
+                return vaex.array_types.convert(mcc, type=array_type)
+            return mcc
+
 
     @vaex.docstrings.docsubst
     def classification_report(self, y_true, y_pred, average='binary', decimals=3):
@@ -265,11 +406,13 @@ class DataFrameAccessorMetrics():
         return report
 
     @vaex.docstrings.docsubst
-    def mean_absolute_error(self, y_true, y_pred):
+    def mean_absolute_error(self, y_true, y_pred, selection=None, array_type='python'):
         '''Calculate the mean absolute error.
 
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
+        :param selection: {selection}
+        :param str array_type: {array_type}
         :returns: The mean absolute error
 
         Example:
@@ -281,14 +424,21 @@ class DataFrameAccessorMetrics():
           2.0846666666666667
         '''
         y_true, y_pred = ensure_string_arguments(y_true, y_pred)
-        return (np.abs(self.df[y_true] - self.df[y_pred])).mean().item()
+        score = (np.abs(self.df[y_true] - self.df[y_pred])).mean(selection=selection)
+
+        if vaex.utils._issequence(selection):
+            return vaex.array_types.convert(score, type=array_type)
+        else:
+            return score.item()
 
     @vaex.docstrings.docsubst
-    def mean_squared_error(self, y_true, y_pred):
+    def mean_squared_error(self, y_true, y_pred, selection=None, array_type='python'):
         '''Calculates the mean squared error.
 
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
+        :param selection: {selection}
+        :param str array_type: {array_type}
         :returns: The mean squared error
 
         Example:
@@ -300,7 +450,12 @@ class DataFrameAccessorMetrics():
           5.589000000000001
         '''
         y_true, y_pred = ensure_string_arguments(y_true, y_pred)
-        return ((self.df[y_true] - self.df[y_pred])**2).mean().item()
+        score = ((self.df[y_true] - self.df[y_pred])**2).mean(selection=selection)
+
+        if vaex.utils._issequence(selection):
+            return vaex.array_types.convert(score, type=array_type)
+        else:
+            return score.item()
 
     @vaex.docstrings.docsubst
     def r2_score(self, y_true, y_pred):
@@ -308,6 +463,8 @@ class DataFrameAccessorMetrics():
 
         :param y_true: {expression_one}
         :param y_pred: {expression_one}
+        :param selection: {selection}
+        :param str array_type: {array_type}
         :returns: The R**2 score
 
         Example:
@@ -322,7 +479,4 @@ class DataFrameAccessorMetrics():
 
         numerator = ((self.df[y_true] - self.df[y_pred])**2).sum()
         denominator = ((self.df[y_true] - self.df[y_true].mean())**2).sum()
-        if denominator == 0:
-            return 0.0
-        else:
-            return 1 - (numerator / denominator)
+        return 1 - _prf_divide(numerator, denominator, metric='R2', modifier='predicted', average='n/a', warn_for=[None])

--- a/tests/ml/metrics_test.py
+++ b/tests/ml/metrics_test.py
@@ -9,13 +9,16 @@ import vaex.ml.metrics
 from vaex.ml.metrics import ensure_string_arguments
 
 df_binary = vaex.from_arrays(x=[1, 0, 1, 1, 0, 0, 0],
-                             y=[1, 0, 1, 1, 0, 1, 1])
+                             y=[1, 0, 1, 1, 0, 1, 1],
+                             z=[0, 1, 0, 0, 0, 1, 1])
 
-df_multi_class = vaex.from_arrays(x=[1, 0, 1, 1, 0, 2, 0, 2],
-                                  y=[1, 0, 1, 1, 0, 2, 2, 1])
+df_multi_class = vaex.from_arrays(x=[1, 0, 1, 1, 0, 2, 0, 2, 1],
+                                  y=[1, 0, 1, 1, 0, 2, 2, 1, 1],
+                                  z=[0, 1, 0, 0, 0, 1, 1, 0, 1])
 
 df_multi_class_strings = vaex.from_arrays(x=['dog', 'cat', 'dog', 'dog', 'cat', 'mouse', 'cat', 'mouse'],
-                                          y=['dog', 'cat', 'dog', 'dog', 'cat', 'mouse', 'mouse', 'dog'])
+                                          y=['dog', 'cat', 'dog', 'dog', 'cat', 'mouse', 'mouse', 'dog'],
+                                          z=[0, 0, 0, 1, 1, 0, 1, 0])
 
 
 def test_ensure_string_arguments():
@@ -26,70 +29,91 @@ def test_ensure_string_arguments():
 
 
 @pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
-def test_accuracy_score(df):
-    assert df.ml.metrics.accuracy_score(df.x, df.y) == metrics.accuracy_score(df.x.values, df.y.values)
+@pytest.mark.parametrize('selection', [None, [None, 'z==0']])
+def test_accuracy_score(df, selection):
+    if selection is None:
+        assert df.ml.metrics.accuracy_score(df.x, df.y) == metrics.accuracy_score(df.x.values, df.y.values)
+    else:
+        result_vaex = df.ml.metrics.accuracy_score(df.x, df.y, selection=selection)
+        for i, sel in enumerate(selection):
+            result_sklearn = metrics.accuracy_score(df.filter(sel).x.values, df.filter(sel).y.values)
+            assert result_vaex[i] == result_sklearn
 
 
 @pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
-def test_precision_score(df):
-    average = 'binary'
-    average = 'binary'
-    if df.x.nunique() > 2:
-        average = 'macro'
-
-    vaex_score = df.ml.metrics.precision_score(df.x, df.y, average=average)
-    sklearn_score = metrics.precision_score(df.x.values, df.y.values, average=average)
-    assert vaex_score == sklearn_score
-
-
-@pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
-def test_recall_score(df):
+@pytest.mark.parametrize('selection', [None, [None, 'z==0', 'z==1']])
+def test_precision_recall_f1_score(df, selection):
     average = 'binary'
     if df.x.nunique() > 2:
         average = 'macro'
 
-    vaex_score = df.ml.metrics.recall_score(df.x, df.y, average=average)
-    sklearn_score = metrics.recall_score(df.x.values, df.y.values, average=average)
-    assert vaex_score == sklearn_score
+    if selection is None:
+        vaex_score = df.ml.metrics.precision_score(df.x, df.y, average=average)
+        sklearn_score = metrics.precision_score(df.x.values, df.y.values, average=average)
+        assert vaex_score == sklearn_score
+
+    else:
+        vaex_score = df.ml.metrics.precision_recall_fscore(df.x, df.y, selection=selection, average=average)
+        vaex_score = np.array(vaex_score).T
+        for i, sel in enumerate(selection):
+            sklearn_score = np.array(metrics.precision_recall_fscore_support(df.filter(sel).x.values, df.filter(sel).y.values, average=average)[:3])
+            np.testing.assert_array_almost_equal(vaex_score[i], sklearn_score)
 
 
 @pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
-def test_f1_score(df):
-    average = 'binary'
-    if df.x.nunique() > 2:
-        average = 'macro'
-
-    vaex_score = df.ml.metrics.f1_score(df.x, df.y, average=average)
-    sklearn_score = metrics.f1_score(df.x.values, df.y.values, average=average)
-    np.testing.assert_almost_equal(vaex_score, sklearn_score)
-
-
-@pytest.mark.parametrize('df', [df_binary, df_multi_class, df_multi_class_strings])
-def test_matthews_correlation_coefficient(df):
-    vaex_score = df.ml.metrics.matthews_correlation_coefficient(df.x, df.y)
-    sklearn_score = metrics.matthews_corrcoef(df.x.values, df.y.values)
-    assert vaex_score == sklearn_score
+@pytest.mark.parametrize('selection', [None, [None, 'z==0', 'z==1']])
+def test_matthews_correlation_coefficient(df, selection):
+    if selection is None:
+        vaex_score = df.ml.metrics.matthews_correlation_coefficient(df.x, df.y)
+        sklearn_score = metrics.matthews_corrcoef(df.x.values, df.y.values)
+        assert vaex_score == sklearn_score
+    else:
+        vaex_score = df.ml.metrics.matthews_correlation_coefficient(df.x, df.y, selection=selection)
+        for i, sel in enumerate(selection):
+            sklearn_score = metrics.matthews_corrcoef(df.filter(sel).x.values, df.filter(sel).y.values)
+            assert vaex_score[i] == sklearn_score
 
 
 @pytest.mark.parametrize('df', [df_binary, df_multi_class])
-def test_confusion_matrix(df):
-    vaex_result = df.ml.metrics.confusion_matrix(df.x, df.y)
-    sklearn_result = metrics.confusion_matrix(df.x.values, df.y.values)
-    np.testing.assert_array_equal(vaex_result, sklearn_result)
+@pytest.mark.parametrize('selection', [None, [None, 'z==0']])
+def test_confusion_matrix(df, selection):
+    if selection is None:
+        vaex_result = df.ml.metrics.confusion_matrix(df.x, df.y)
+        sklearn_result = metrics.confusion_matrix(df.x.values, df.y.values)
+        np.testing.assert_array_equal(vaex_result, sklearn_result)
+    else:
+        vaex_result = df.ml.metrics.confusion_matrix(df.x, df.y, selection=selection)
+        for i, sel in enumerate(selection):
+            sklearn_result = metrics.confusion_matrix(df.filter(sel).x.values, df.filter(sel).y.values)
+            np.testing.assert_array_equal(vaex_result[i], sklearn_result)
 
 
-def test_mean_absolute_error():
+@pytest.mark.parametrize('selection', [None, [None, 'class_==0', 'class_==1']])
+def test_mean_absolute_error(selection):
     df = vaex.datasets.iris()
-    vaex_result = df.ml.metrics.mean_absolute_error(df.petal_width, df.petal_length)
-    sklearn_result = metrics.mean_absolute_error(df.petal_width.values, df.petal_length.values)
-    assert vaex_result == sklearn_result
+    if selection is None:
+        vaex_result = df.ml.metrics.mean_absolute_error(df.petal_width, df.petal_length)
+        sklearn_result = metrics.mean_absolute_error(df.petal_width.values, df.petal_length.values)
+        assert vaex_result == sklearn_result
+    else:
+        vaex_result = df.ml.metrics.mean_absolute_error(df.petal_width, df.petal_length, selection=selection)
+        for i, sel in enumerate(selection):
+            sklearn_result = metrics.mean_absolute_error(df.filter(sel).petal_width.values, df.filter(sel).petal_length.values)
+            np.testing.assert_almost_equal(vaex_result[i], sklearn_result)
 
 
-def test_mean_squared_error():
+@pytest.mark.parametrize('selection', [None, [None, 'class_==0', 'class_==1']])
+def test_mean_squared_error(selection):
     df = vaex.datasets.iris()
-    vaex_result = df.ml.metrics.mean_squared_error(df.petal_width, df.petal_length)
-    sklearn_result = metrics.mean_squared_error(df.petal_width.values, df.petal_length.values)
-    assert vaex_result == sklearn_result
+    if selection is None:
+        vaex_result = df.ml.metrics.mean_squared_error(df.petal_width, df.petal_length)
+        sklearn_result = metrics.mean_squared_error(df.petal_width.values, df.petal_length.values)
+        assert vaex_result == sklearn_result
+    else:
+        vaex_result = df.ml.metrics.mean_squared_error(df.petal_width, df.petal_length, selection=selection)
+        for i, sel in enumerate(selection):
+            sklearn_result = metrics.mean_squared_error(df.filter(sel).petal_width.values, df.filter(sel).petal_length.values)
+            np.testing.assert_almost_equal(vaex_result[i], sklearn_result)
 
 
 def test_r2_score():
@@ -105,5 +129,5 @@ def test_classification_report():
     assert report == expected_result
 
     report = df_multi_class.ml.metrics.classification_report(df_binary.x, df_binary.y, average='macro')
-    expected_result = '\n        Classification report:\n\n        Accuracy:  0.75\n        Precision: 0.75\n        Recall:    0.722\n        F1:        0.719\n        '
+    expected_result = '\n        Classification report:\n\n        Accuracy:  0.778\n        Precision: 0.767\n        Recall:    0.722\n        F1:        0.73\n        '
     assert report == expected_result

--- a/tests/server/rest_test.py
+++ b/tests/server/rest_test.py
@@ -1,11 +1,8 @@
-import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-from myst_parser.main import to_tokens
-import aiohttp
 
 import vaex.server.fastapi
 
@@ -121,13 +118,11 @@ def test_heatmap_plot(request_client, df_example_original):
 
 # TODO: we can't use this using threads, need to use asyncio
 # def test_parallel():
-#     tpe = ThreadPoolExecutor(4)    
+#     tpe = ThreadPoolExecutor(4)
 #     def request():
 #         min, max = 0, 10
 #         shape = 5
 #         response = request_client.get(f"/histogram/example/x?min={min}&max={max}&shape={shape}")
-#         assert response.status_code == 200, f"Unexpected response: {response.text}"
-#         return 42
 #     N = 10
 #     futures = []
 #     for i in range(N):


### PR DESCRIPTION
At the request of @Ben-Epstein , this is an attempt to make (most) metrics to support the `selections`  argument, in the same style as in various other vaex methods. 

To do:
 - [x] Update the license etc, to acknowledge that some of the code has been taken from scikit-learn. (We have not simply used scikit-learn, as we do not want to make it a strict dependency for just 2 methods).  Can you help with this @maartenbreddels 