### PR TITLE
support native open json

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -219,6 +219,8 @@ def open(path, convert=False, progress=None, shuffle=False, fs_options={}, fs=No
             _, ext, _ = vaex.file.split_ext(path)
             if ext == '.csv':  # special case for csv
                 return vaex.from_csv(path, fs_options=fs_options, fs=fs, convert=convert, progress=progress, **kwargs)
+            if ext == ".json":  # special case for csv
+                return vaex.from_json(path, **kwargs)
             if convert:
                 path_output = convert if isinstance(convert, str) else filename_hdf5
                 vaex.convert.convert(

--- a/tests/open_test.py
+++ b/tests/open_test.py
@@ -158,3 +158,11 @@ def _cleanup_generated_files():
         os.remove(hdf5_file)
     for hdf5_file in glob.glob(os.path.join(path, '..', 'smæll2*')):
         os.remove(hdf5_file)
+
+
+def test_open_json():
+    df = vaex.open(csv2)
+    df.export("test2.json")
+    df_json = vaex.open("test2.json")
+    assert len(df) == len(df_json)
+    _cleanup_generated_files()


### PR DESCRIPTION
to support the following symmetricly

```
import vaex

df = vaex.example()
df.export("file.json")
vaex.open("file.json")
```