### PR TITLE
fix: join failed when the lhs dataframe had nan/null and the rhs not

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -43,4 +43,4 @@ dependencies:
 - tornado
 - uvicorn<0.16
 - xarray
-- myst-parser
+- myst-parser<0.18  # 0.18 breaks our test, missing main

--- a/packages/vaex-core/src/hash_primitives.hpp
+++ b/packages/vaex-core/src/hash_primitives.hpp
@@ -726,7 +726,7 @@ class index_hash : public hash_base<index_hash<T2, Hashmap2>, T2, Hashmap2> {
 
     // TODO: might be better to use a node based hasmap, we don't want to move large vectors
     typedef hashmap<key_type, std::vector<int64_t>> overflow_type;
-    index_hash(int nmaps = 1) : Base(nmaps), overflows(nmaps), has_duplicates(false) {}
+    index_hash(int nmaps = 1) : Base(nmaps), overflows(nmaps), has_duplicates(false), null_value(-1), nan_value(-1) {}
 
     int64_t length() const {
         int64_t c = this->count();
@@ -792,6 +792,9 @@ class index_hash : public hash_base<index_hash<T2, Hashmap2>, T2, Hashmap2> {
             if (custom_isnan(key)) {
                 output(i) = nan_value;
                 assert(this->nan_count > 0);
+                if(nan_value == -1) {
+                    encountered_unknown = true;
+                }
             } else {
                 std::size_t hash = hasher_map_choice()(key);
                 size_t map_index = (hash % nmaps);
@@ -829,9 +832,15 @@ class index_hash : public hash_base<index_hash<T2, Hashmap2>, T2, Hashmap2> {
             if (custom_isnan(key)) {
                 output(i) = nan_value;
                 assert(this->nan_count > 0);
+                if(nan_value == -1) {
+                    encountered_unknown = true;
+                }
             } else if (input_mask(i) == 1) {
                 output(i) = null_value;
                 assert(this->null_count > 0);
+                if(null_value == -1) {
+                    encountered_unknown = true;
+                }
             } else {
                 std::size_t hash = hasher_map_choice()(key);
                 size_t map_index = (hash % nmaps);

--- a/packages/vaex-core/src/hash_string.hpp
+++ b/packages/vaex-core/src/hash_string.hpp
@@ -681,7 +681,7 @@ class index_hash : public hash_base<index_hash<T>, T, T, V> {
     typedef hashmap<key_type, std::vector<int64_t>> overflow_type;
 
     // TODO: might be better to use a node based hasmap, we don't want to move large vectors
-    index_hash(int nmaps, int64_t limit = -1) : Base(nmaps, limit), overflows(nmaps), has_duplicates(false) {
+    index_hash(int nmaps, int64_t limit = -1) : Base(nmaps, limit), overflows(nmaps), has_duplicates(false), null_value(-1) {
         for (int i = 0; i < nmaps; i++) {
             // string_arrays_overflow.emplace_back(std::make_shared<StringList64>());
             // for each key in overflow, it should be present in the main string array
@@ -753,6 +753,9 @@ class index_hash : public hash_base<index_hash<T>, T, T, V> {
                 if (strings->is_null(i)) {
                     output(i) = null_value;
                     assert(this->null_count > 0);
+                    if(null_value == -1) {
+                        encountered_unknown = true;
+                    }
                 } else {
                     const string_view &key = strings->view(i);
                     std::size_t hash = hasher_map_choice()(key);

--- a/tests/internal/hash_test.py
+++ b/tests/internal/hash_test.py
@@ -346,6 +346,30 @@ def test_index():
     index.update(ar2, 3)
     assert index.map_index(ar).tolist() == [0, 1, 2, 3, 4, 5]
 
+
+def test_index_non_existing_primitive():
+    ar1 = np.arange(3, dtype="f8")
+    ar2 = np.arange(1, 4, dtype="f8")
+    index = index_hash_float64(1)
+    index.update(ar1, 0)
+    assert index.map_index(ar1).tolist() == [0, 1, 2]
+    assert index.map_index(ar2).tolist() == [1, 2, -1]
+
+    # test when nan is not missing (which triggers a special case comparison)
+    ar2[-1] = np.nan
+    assert not index.has_nan
+    assert index.map_index(ar2).tolist() == [1, 2, -1]
+
+
+def test_index_non_existing_string():
+    ar1 = vaex.strings.array(["aap", "noot", "mies"])
+    index = index_hash_string(1)
+    ar2 = vaex.strings.array(["noot", "mies", None])
+    index.update(ar1, 0)
+    assert index.map_index(ar1).tolist() == [0, 1, 2]
+    assert index.map_index(ar2).tolist() == [1, 2, -1]
+
+
 @pytest.mark.parametrize("nmaps", [1, 2, 3])
 def test_index_multi(nmaps):
     strings = vaex.strings.array(['aap', 'noot', 'mies'])


### PR DESCRIPTION
Fixes #2077

The reason this happened sporadically, is that in the C++
code nan_value and null_value were not initialized in the ctor,
but were assumed to be intialized later on. However, since the
hashmap itself never saw the nulls or nans, this did not happen.