### PR TITLE
Fix: Export csv with protected column names from arrow data structures

### DIFF
--- a/ci/conda-env.yml
+++ b/ci/conda-env.yml
@@ -42,6 +42,6 @@ dependencies:
 - scipy
 - tornado
 - uvicorn<0.16
-- xarray
+- xarray<2022.6.0
 # currently not using this, since the test that requires this is flakey
 # - myst-parser<0.18  # 0.18 breaks our test, missing main

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3512,9 +3512,8 @@ class DataFrame(object):
             raise ValueError('only scipy.sparse.csr_matrix is supported')
 
     def _save_assign_expression(self, name, expression=None):
-        obj = getattr(self, name, None)
         # it's ok to set it if it does not exist, or we overwrite an older expression
-        if obj is None or isinstance(obj, Expression):
+        if not hasattr(self, name) or isinstance(getattr(self, name), Expression):
             if expression is None:
                 expression = name
             if isinstance(expression, str):
@@ -6032,7 +6031,7 @@ class DataFrameLocal(DataFrame):
             dataset_columns = list(dataset_columns)
             dataset_columns.sort()
             dataset = self.dataset.project(*dataset_columns)
-            df = vaex.from_dataset(dataset)
+            df : DataFrame = vaex.from_dataset(dataset)
 
             # and reconstruct the rest (virtual columns and variables)
             other = {k for k in required if k not in self.dataset}

--- a/tests/data/badname.csv
+++ b/tests/data/badname.csv
@@ -1,0 +1,2 @@
+description,test
+a,b

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -271,3 +271,17 @@ def test_export_large_string(tmpdir):
     s = pa.array(["Hi", "there"], type=pa.large_string())
     df = vaex.from_arrays(s=s)
     df.export_arrow(tmpdir / "test.arrow")
+
+
+def test_export_csv_badnames(tmpdir):
+    data_path = os.path.join(os.path.dirname(__file__), "data/badname.csv")
+    df = vaex.open(data_path)
+
+    df = df.as_arrow()
+
+    output_path = str(tmpdir.join('test.csv'))
+    df.export_csv(output_path)
+
+    df2 = vaex.open(output_path)
+    assert df.get_column_names() == df2.get_column_names()
+    assert df.shape == df2.shape


### PR DESCRIPTION
Fixes https://github.com/vaexio/vaex/issues/2057

- [x] Create a test
- [ ] make test pass