### PR TITLE
Regression test for interchanging categorical columns

### DIFF
--- a/tests/dataframe_protocol_test.py
+++ b/tests/dataframe_protocol_test.py
@@ -359,3 +359,13 @@ def test_null_count(df_factory, x):
     interchange_col = interchange_df.get_column_by_name("x")
     assert isinstance(interchange_col.null_count, int)
     assert interchange_col.null_count == 1
+
+
+def test_smoke_get_buffers_on_categorical_columns(df_factory):
+    # See https://github.com/vaexio/vaex/issues/2134#issuecomment-1195731379
+    x = np.array([3, 1, 1, 2, 0])
+    df = df_factory(x=x)
+    df = df.categorize('x')
+    interchange_df = df.__dataframe__()
+    interchange_col = interchange_df.get_column_by_name('x')
+    interchange_col.get_buffers()


### PR DESCRIPTION
#2122 ended up fixing a somewhat miscellaneous bug, which this PR adds a test for to prevent regressions. The bug in question was due to arrow arrays being passed around to `_VaexBuffer`, which isn't supported, where the fix ended up converting arrow arrays internally before initialising `_VaexBuffer`.