### PR TITLE
Fix: groupby on type int sometimes confuses dtypes

### DIFF
--- a/packages/vaex-core/vaex/groupby.py
+++ b/packages/vaex-core/vaex/groupby.py
@@ -14,7 +14,7 @@ from vaex.delayed import delayed_args, delayed_dict, delayed_list
 from vaex.utils import _ensure_list, _ensure_string_from_expression
 import vaex
 import vaex.hash
-
+import vaex.utils
 
 try:
     collections_abc = collections.abc
@@ -272,8 +272,8 @@ class Grouper(BinnerBase):
                         return
 
                 if vaex.dtype_of(self.bin_values) == int and len(self.bin_values):
-                    max_value = self.bin_values.max()
-                    self.bin_values = self.bin_values.astype(vaex.utils.required_dtype_for_max(max_value))
+                    min_value, max_value = self.bin_values.min(), self.bin_values.max()
+                    self.bin_values = self.bin_values.astype(vaex.utils.required_dtype_for_range(min_value, max_value))
                 logger.debug('Constructed grouper for expression %s with %i values', str(expression), len(self.bin_values))
 
                 if self.sort:

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -837,6 +837,18 @@ def required_dtype_for_max(N, signed=True):
         raise ValueError(f"Cannot store a max value of {N} inside an uint64/int64")
 
 
+def required_dtype_for_range(vmin, vmax, signed=True):
+    if signed:
+        dtypes = [np.int8, np.int16, np.int32, np.int64]
+    else:
+        dtypes = [np.uint8, np.uint16, np.uint32, np.uint64]
+    for dtype in dtypes:
+        if (vmin >= np.iinfo(dtype).min) and (vmax <= np.iinfo(dtype).max):
+            return np.dtype(dtype)
+    else:
+        raise ValueError(f"Cannot store the range {vmin}-{vmax} inside an uint64/int64")
+
+
 def required_dtype_for_int(value, signed=True):
     if signed or value < 0:
         dtypes = [np.int8, np.int16, np.int32, np.int64]

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -772,3 +772,10 @@ def test_groupby_empty(df_factory):
     assert dfg["count"].tolist() == [6]
     assert dfg["first_x"].tolist() == [1]
     assert dfg["s"].tolist() == [df.s.tolist()]
+
+
+def test_groupby_int_overflow():
+    x = np.array([-129,-120,15,30,40])
+    df = vaex.from_arrays(x=x)
+    gdf = df.groupby(['x'], assume_sparse=True, agg={'cnt': 'count'})
+    assert set(gdf.x.tolist()) == set(x)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -15,6 +15,27 @@ def test_required_dtype_for_max():
         assert vaex.utils.required_dtype_for_max(2**63, signed=True) == np.int64
 
 
+
+def test_required_dtype_for_range():
+    assert vaex.utils.required_dtype_for_range(-100, 127, signed=True) == np.int8
+    assert vaex.utils.required_dtype_for_range(-129, 127, signed=True) == np.int16
+    assert vaex.utils.required_dtype_for_range(0, 128, signed=True) == np.int16
+    assert vaex.utils.required_dtype_for_range(0, 127, signed=False) == np.uint8
+    assert vaex.utils.required_dtype_for_range(0, 128, signed=False) == np.uint8
+    with pytest.raises(ValueError):
+        assert vaex.utils.required_dtype_for_range(-1, 128, signed=False) == np.int16
+    assert vaex.utils.required_dtype_for_range(-1, 128, signed=True) == np.int16
+
+    assert vaex.utils.required_dtype_for_range(0, 2**63-1, signed=True) == np.int64
+    assert vaex.utils.required_dtype_for_range(-1, 2**63-1, signed=True) == np.int64
+    assert vaex.utils.required_dtype_for_range(-2**63, 0, signed=True) == np.int64
+    assert vaex.utils.required_dtype_for_range(0, 2**63, signed=False) == np.uint64
+    with pytest.raises(ValueError):
+        assert vaex.utils.required_dtype_for_range(-1, 2**63, signed=True) == np.int64
+    with pytest.raises(ValueError):
+        assert vaex.utils.required_dtype_for_range(-2**64-1, 0, signed=True) == np.int64
+
+
 def test_dict_replace_key():
     d = {'a': 1, 'b': 2}
     result = vaex.utils.dict_replace_key(d, 'a', 'z')


### PR DESCRIPTION
This fixes https://github.com/vaexio/vaex/issues/2136

Base on the discussion: https://github.com/vaexio/vaex/discussions/2131

- [x] make unit test
- [ ] make unit test pass