### PR TITLE
CI: Do not run the notebooks on p36

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -242,16 +242,19 @@ jobs:
         vaex settings md
 
     - name: Test server
+      if: matrix.os != 'windows-latest'
       run: |
         vaex server --add-example --port 9999&
 
     - name: Wait for Vaex server
+      if: matrix.os != 'windows-latest'
       uses: ifaxity/wait-on-action@v1
       with:
         resource: http-get://localhost:9999/hello
         timeout: 5000
 
     - name: Use the Vaex server
+      if: matrix.os != 'windows-latest'
       run: |
         python -c "import vaex; df = vaex.open('ws://localhost:9999/example'); df.x.sum()"
         curl -i http://localhost:9999/histogram/example/x

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -156,7 +156,7 @@ jobs:
 #      run: |
 #        py.test vaex-enterprise/tests --timeout=1000
     - name: Test notebooks
-      if: matrix.os != 'windows-latest' && matrix.python-version == '3.6'
+      if: matrix.os != 'windows-latest' && matrix.python-version != '3.6'
       run: |
         ./ci/05-run-notebooks.sh
     - name: Authenticate Google Cloud Platform


### PR DESCRIPTION
We want to run the notebooks in CI on every python version save for 3.6

