### PR TITLE
fix: uuid4 function was not always restored properly

### DIFF
--- a/packages/vaex-core/vaex/cache.py
+++ b/packages/vaex-core/vaex/cache.py
@@ -387,6 +387,8 @@ def _explain(*args):
 def fingerprint(*args, **kwargs):
     try:
         original = uuid.uuid4
+        if isinstance(original, _ThreadLocalCallablePatch):
+            original = original.original
         uuid.uuid4 = _ThreadLocalCallablePatch(original, _explain)
         try:
             return dask.base.tokenize(*args, **kwargs)


### PR DESCRIPTION
This led to a lot of error:
 "You have passed in an object for which we cannot determine a fingerprint"