### PR TITLE
fix: df.extract() was not thread safe

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4481,9 +4481,12 @@ class DataFrame(object):
         :rtype: DataFrame
         '''
         df = self.trim()
-        if df.filtered:
-            df._push_down_filter()
-            df._invalidate_caches()
+        with self._state_lock:
+            # df.filtered gets changed in push_down_filter so use a lock
+            # to make it thread safe
+            if df.filtered:
+                df._push_down_filter()
+                df._invalidate_caches()
         return df
 
     def _push_down_filter(self):

--- a/tests/extract_test.py
+++ b/tests/extract_test.py
@@ -1,3 +1,6 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+import time
 from common import *
 
 def test_extract(ds_local, ds_trimmed):
@@ -16,3 +19,17 @@ def test_extract(ds_local, ds_trimmed):
     assert ds_extracted2.length_original() == 5
     assert ds_extracted2.length_unfiltered() == 5
     assert ds_extracted2.filtered is False
+
+
+
+def test_thread_safe():
+    df = vaex.from_arrays(x=np.arange(int(1e5)))
+    dff = df[df.x < 100]
+
+    barrier = Barrier(100)
+    def run(_ignore):
+        barrier.wait()
+        # now we all do the extract at the same time
+        dff.extract()
+    pool = ThreadPoolExecutor(max_workers=100)
+    _values = list(pool.map(run, range(100)))


### PR DESCRIPTION
This caused errors like:
    "NameError: name '__filter__' is not defined"

This happened before we checked in we had a filter, and then removed
the filter in a non-atomic way.