### PR TITLE
Fix: histogram sometimes does not obey selections

### DIFF
--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 
 import vaex
 import vaex.encoding
+import vaex.array_types
 from vaex.hash import counter_type_from_dtype
 from .utils import as_flat_float, as_flat_array, _issequence, _ensure_list
 from .array_types import filter
@@ -548,6 +549,8 @@ class TaskPartStatistic(TaskPart):
                 selection_mask = selection_masks[i]
                 if selection_mask is None:
                     raise ValueError("performing operation on selection while no selection present")
+                selection_mask = vaex.array_types.to_numpy(selection_mask)
+                selection_mask = vaex.utils.unmask_selection_mask(selection_mask)
                 if mask is not None:
                     selection_mask = selection_mask[~mask]
                 selection_blocks = [block[selection_mask] for block in blocks]
@@ -734,7 +737,9 @@ class TaskPartAggregation(TaskPart):
                     selection_mask = selection_masks[selection_index_global] # self.df.evaluate_selection_mask(selection, i1=i1, i2=i2, cache=True)  # TODO
                     # TODO: we probably want a way to avoid a to numpy conversion?
                     assert selection_mask is not None
-                    selection_mask = np.asarray(selection_mask)
+                    selection_mask = vaex.array_types.to_numpy(selection_mask)
+                    selection_mask = vaex.utils.unmask_selection_mask(selection_mask)
+
                     references.append(selection_mask)
                     # some aggregators make a distiction between missing value and no value
                     # like nunique, they need to know if they should take the value into account or not

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -737,8 +737,11 @@ class TaskPartAggregation(TaskPart):
                     selection_mask = selection_masks[selection_index_global] # self.df.evaluate_selection_mask(selection, i1=i1, i2=i2, cache=True)  # TODO
                     # TODO: we probably want a way to avoid a to numpy conversion?
                     assert selection_mask is not None
+                    references.append(selection_mask)
                     selection_mask = vaex.array_types.to_numpy(selection_mask)
                     selection_mask = vaex.utils.unmask_selection_mask(selection_mask)
+                    if selection_mask.strides != (1,):
+                        selection_mask = selection_mask.copy()
 
                     references.append(selection_mask)
                     # some aggregators make a distiction between missing value and no value

--- a/tests/count_test.py
+++ b/tests/count_test.py
@@ -55,3 +55,16 @@ def test_count_1d_verify_against_numpy(ds_local, limits):
 #     # same, but now with a masked value
 #     assert ds.count(binby=ds.x, limits=[0.5, 1.5], shape=1, edges=True).tolist() == [1, 3, 1, 2]
 #     # assert ds.count(ds.x, limits=[0.5, 1.5], shape=2, edges=True).tolist() == [1, 3, 1, 2]
+
+
+def test_count_selection_w_missing_values():
+    x = np.random.normal(size=10_000)
+    fraction_missing = 0.7
+    missing_mask = np.random.binomial(1, fraction_missing, size=x.shape).astype(bool)
+
+    x_numpy = np.ma.array(x, mask=missing_mask)
+    x_arrow = pa.array(x, mask=missing_mask)
+    df = vaex.from_arrays(x_numpy=x_numpy, x_arrow=x_arrow)
+
+    assert all(df.count(binby='x_numpy') == df.count(binby='x_arrow'))
+    assert all(df.count(binby='x_numpy', selection='x_numpy > 0') == df.count(binby='x_arrow', selection='x_arrow > 0'))

--- a/tests/count_test.py
+++ b/tests/count_test.py
@@ -58,13 +58,13 @@ def test_count_1d_verify_against_numpy(ds_local, limits):
 
 
 def test_count_selection_w_missing_values():
-    x = np.random.normal(size=10_000)
-    fraction_missing = 0.7
-    missing_mask = np.random.binomial(1, fraction_missing, size=x.shape).astype(bool)
+    x = np.arange(10)
+    missing_mask = (x % 3) == 0
 
     x_numpy = np.ma.array(x, mask=missing_mask)
     x_arrow = pa.array(x, mask=missing_mask)
     df = vaex.from_arrays(x_numpy=x_numpy, x_arrow=x_arrow)
 
     assert all(df.count(binby='x_numpy') == df.count(binby='x_arrow'))
-    assert all(df.count(binby='x_numpy', selection='x_numpy > 0') == df.count(binby='x_arrow', selection='x_arrow > 0'))
+    assert all(df.count(binby='x_numpy', shape=2, limits=[0, 10], selection='x_numpy > 0') == df.count(binby='x_arrow', shape=2, limits=[0, 10], selection='x_arrow > 0'))
+    assert all(df.count(binby='x_numpy', shape=2, selection='x_numpy > 0') == df.count(binby='x_arrow', shape=2, selection='x_arrow > 0'))

--- a/tests/viz_test.py
+++ b/tests/viz_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pyarrow as pa
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -31,7 +32,30 @@ def test_histogram_with_what(df):
     df.viz.histogram(df.x, what=np.clip(np.log(-vaex.stat.mean(df.z)), 0, 10), limits='99.7%');
     return fig
 
+
 @pytest.mark.mpl_image_compare(filename='test_heatmap_with_what.png')
 def test_heatmap_with_what(df):
     df.viz.heatmap(df.x, df.y, what=np.log(vaex.stat.count()+1), limits='99.7%',
         selection=[None, df.x < df.y, df.x < -10])
+
+
+def test_histogram_with_selection(df):
+    x = np.random.normal(size=10_000)
+    fraction_missing = 0.7
+    missing_mask = np.random.binomial(1, fraction_missing, size=x.shape).astype(bool)
+
+    x_numpy = np.ma.array(x, mask=missing_mask)
+    x_arrow = pa.array(x, mask=missing_mask)
+    df = vaex.from_arrays(x_numpy=x_numpy, x_arrow=x_arrow)
+
+    # Test with selections
+    fig_numpy = df.x_numpy.viz.histogram(selection='x_numpy > 0')[0];
+    fig_arrow = df.x_arrow.viz.histogram(selection='x_arrow > 0')[0];
+    assert all(fig_numpy.get_xdata() == fig_arrow.get_xdata())
+    assert all(fig_numpy.get_ydata() == fig_arrow.get_ydata())
+
+    # Test with selections and limits
+    fig_numpy = df.x_numpy.viz.histogram(selection='x_numpy > 0', limits='90%')[0];
+    fig_arrow = df.x_arrow.viz.histogram(selection='x_arrow > 0', limits='90%')[0];
+    assert all(fig_numpy.get_xdata() == fig_arrow.get_xdata())
+    assert all(fig_numpy.get_ydata() == fig_arrow.get_ydata())


### PR DESCRIPTION
This issue could in partly due to `count` something being buggy when handling arrow data that has missing values. Not sure tho, but there are tests implemented that cover these things in both sides for safety (asserting the histogram output and the `count` output). 

_Workaround:_
If somebody is struggling with this issue, there is a simple workaround. Say column `x` is arrow column with missing values. All you need to do is:
```python
df['x'] = df.x.as_numpy()
```
and everything should work as expected.

_Checklist:_
 - [x] Make unit-tests exposing the issues
 - [x] Make unit-tests pass
 - [x] Party 🎉 