### PR TITLE
Fix: names with math symbols should work consistently

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -5050,7 +5050,7 @@ class DataFrame(object):
         column_names = column_names or self.get_column_names(virtual=False)
 
         def create(current):
-            return selections.SelectionDropNa(drop_nan, drop_masked, column_names, current, mode)
+            return selections.SelectionDropNa(drop_nan, drop_masked, [str(self[k]) for k in column_names], current, mode)
         self._selection(create, name)
 
     def dropmissing(self, column_names=None, how="any"):

--- a/packages/vaex-core/vaex/selections.py
+++ b/packages/vaex-core/vaex/selections.py
@@ -59,22 +59,21 @@ class Selection(object):
 
 
 class SelectionDropNa(Selection):
-    def __init__(self, drop_nan, drop_masked, column_names, previous_selection, mode):
+    def __init__(self, drop_nan, drop_masked, expressions, previous_selection, mode):
         super(SelectionDropNa, self).__init__(previous_selection, mode)
         self.drop_nan = drop_nan
         self.drop_masked = drop_masked
-        self.column_names = column_names
-        self.expressions = self.column_names
+        self.expressions = expressions
 
     def to_dict(self):
         previous = None
         if self.previous_selection:
             previous = self.previous_selection.to_dict()
-        return dict(type="dropna", drop_nan=self.drop_nan, drop_masked=self.drop_masked, column_names=self.column_names,
+        return dict(type="dropna", drop_nan=self.drop_nan, drop_masked=self.drop_masked, expressions=self.expressions,
                     mode=self.mode, previous_selection=previous)
 
     def _rename(self, df, old, new):
-        pass  # TODO: do we need to rename the column_names?
+        pass  # TODO: do we need to rename the expressions?
 
     def evaluate(self, df, name, i1, i2, scope):
         if self.previous_selection:
@@ -82,8 +81,8 @@ class SelectionDropNa(Selection):
         else:
             previous_mask = None
         mask = None
-        for name in self.column_names:
-            data = scope.evaluate(name)
+        for expressions in self.expressions:
+            data = scope.evaluate(expressions)
             if mask is None:
                 mask = np.full(len(data), True)
             if self.drop_nan and self.drop_masked:

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -110,12 +110,7 @@ def test_special_names():
     assert df['col'].tolist() == [1, 2]
 
 
-def test_names_with_math_symbols():
-    d = {'phigh-10': [2, 3, 4], 'phigh-1n': [5, 6, 7]}
-    df = vaex.from_dict(d)
-    assert df.values.tolist() == [[2, 5], [3, 6], [4, 7]]
-
-    df2 = df[df['phigh-10'] > 2]
-    df2.select_non_missing()
-    assert df2.values.tolist() == [[3, 6], [4, 7]]
-    assert repr(df2) == '  #    phigh-10    phigh-1n\n  0           3           6\n  1           4           7'
+def test_select_na():
+    df = vaex.from_dict({'A-B': [None, 1, 2]})
+    df.select_non_missing()
+    assert df.count(selection=True) == 2

--- a/tests/column_names_test.py
+++ b/tests/column_names_test.py
@@ -108,3 +108,14 @@ def test_special_names():
 
     df = vaex.from_arrays(col=[1, 2])
     assert df['col'].tolist() == [1, 2]
+
+
+def test_names_with_math_symbols():
+    d = {'phigh-10': [2, 3, 4], 'phigh-1n': [5, 6, 7]}
+    df = vaex.from_dict(d)
+    assert df.values.tolist() == [[2, 5], [3, 6], [4, 7]]
+
+    df2 = df[df['phigh-10'] > 2]
+    df2.select_non_missing()
+    assert df2.values.tolist() == [[3, 6], [4, 7]]
+    assert repr(df2) == '  #    phigh-10    phigh-1n\n  0           3           6\n  1           4           7'


### PR DESCRIPTION
Credit to Hotaru which discovered this problem and alerted us via Slack. 

If a name has a math symbol (like a minus sigh) it sometimes causes problems.  This PR exposes the problem and addresses that.

- [x] make unit test (to fail consistently in the initial stages)
- [ ] make the test pass (consistently)

