### PR TITLE
fix: convert options for lazy from_csv_arrow did not work

### DIFF
--- a/packages/vaex-core/vaex/csv.py
+++ b/packages/vaex-core/vaex/csv.py
@@ -102,9 +102,10 @@ def _copy_or_create(cls, obj, **kwargs):
         # take default from obj, buy kwargs have precendence
         kwargs = kwargs.copy()
         for name in dir(obj):
-            if not name.startswith('__'):
+            value = getattr(obj, name)
+            if not name.startswith('__') and not callable(value):
                 if name not in kwargs:
-                    kwargs[name] = getattr(obj, name)
+                    kwargs[name] = value
     return cls(**kwargs)
 
 

--- a/tests/csv_test.py
+++ b/tests/csv_test.py
@@ -138,3 +138,12 @@ def test_gz():
     with pytest.raises(NotImplementedError):
         df = vaex.from_csv_arrow(HERE / "data" / "small2.csv.gz", lazy=True)
         assert df.x.tolist() == [1, 3]
+
+
+def test_convert_options():
+    import vaex
+    import pyarrow.csv
+
+    df = vaex.from_csv_arrow(HERE / "data" / "small2.csv", convert_options=pyarrow.csv.ConvertOptions(column_types={'x': pyarrow.float64()}), lazy=True)
+    assert df.x.dtype == float
+    assert df.x.tolist() == [1, 3]


### PR DESCRIPTION
We have to recreate the object, but were passing it it's own function as ctor arguments.