### PR TITLE
Fix: filtering with an arrow string scalar

### DIFF
--- a/packages/vaex-core/vaex/expression.py
+++ b/packages/vaex-core/vaex/expression.py
@@ -21,6 +21,7 @@ import pyarrow as pa
 import vaex.cache
 import vaex.hash
 import vaex.tasks
+import vaex.array_types
 import vaex.serialize
 from vaex.utils import _ensure_strings_from_expressions, _ensure_string_from_expression
 from vaex.column import ColumnString, _to_string_sequence
@@ -101,6 +102,10 @@ class Meta(type):
         for op in _binary_ops:
             def wrap(op=op):
                 def f(a, b):
+                    if isinstance(a, pa.Scalar):
+                        a = a.as_py()
+                    if isinstance(b, pa.Scalar):
+                        b = b.as_py()
                     self = a
                     # print(op, a, b)
                     if isinstance(b, str) and self.dtype.is_datetime:
@@ -152,6 +157,10 @@ class Meta(type):
                 attrs['__%s__' % op['name']] = f
                 if op['name'] in reversable:
                     def f(a, b):
+                        if isinstance(a, pa.Scalar):
+                            a = a.as_py()
+                        if isinstance(b, pa.Scalar):
+                            b = b.as_py()
                         self = a
                         if isinstance(b, str):
                             if op['code'] == '+':
@@ -171,6 +180,8 @@ class Meta(type):
         for op in _unary_ops:
             def wrap(op=op):
                 def f(a):
+                    if isinstance(a, pa.Scalar):
+                        a = a.as_py()
                     self = a
                     expression = '{0}({1})'.format(op['code'], a.expression)
                     return Expression(self.ds, expression=expression)

--- a/tests/filter_test.py
+++ b/tests/filter_test.py
@@ -79,3 +79,9 @@ def test_filter_after_dropna(df_factory):
     dd = df[df.x > 10]
     assert dd.x.tolist() == [20, 30]
     assert dd.y.tolist() == [2, 3]
+
+def test_filter_arrow_string_scalar():
+    df = vaex.from_arrays(x=['red', 'green', 'blue'])
+    assert df[df.x == pa.scalar('red')].x.tolist() == ['red']
+    assert df[df.x == pa.scalar('green')].shape == (1, 1)
+    assert df[df.x != pa.scalar('blue')].shape


### PR DESCRIPTION
Allow to create a filter via a `pyarrow.StringScalar`. Raised by: https://github.com/vaexio/vaex/issues/2242

- [x] Make unit-test
- [ ] Make test pass