### PR TITLE
Fix: export to hdf5 when there are numeric missing values

### DIFF
--- a/ci/04-run-test-suite.sh
+++ b/ci/04-run-test-suite.sh
@@ -7,13 +7,13 @@ else
     source ${HOME}/.bash_profile
 fi
 export VAEX_SERVER_OVERRIDE='{"dataframe.vaex.io":"dataframe-dev.vaex.io"}'
-py.test tests\
+pytest tests\
         packages/vaex-core/vaex/datatype_test.py\
         packages/vaex-core/vaex/file/\
         packages/vaex-core/vaex/test/dataset.py::TestDataset\
         --doctest-modules\
-          packages/vaex-core/vaex/datatype.py\
-          packages/vaex-core/vaex/utils.py\
-          packages/vaex-core/vaex/struct.py\
-          packages/vaex-core/vaex/groupby.py\
+            packages/vaex-core/vaex/datatype.py\
+            packages/vaex-core/vaex/utils.py\
+            packages/vaex-core/vaex/struct.py\
+            packages/vaex-core/vaex/groupby.py\
         --timeout=1000

--- a/packages/vaex-core/vaex/cpu.py
+++ b/packages/vaex-core/vaex/cpu.py
@@ -676,10 +676,16 @@ class TaskPartAggregation(TaskPart):
             if vaex.array_types.is_string_type(dtype):
                 x = vaex.column._to_string_sequence(x)
             else:
-                x = vaex.utils.as_contiguous(x)
-                if x.dtype.kind in "mM":
-                    # we pass datetime as int
-                    x = x.view('uint64')
+                if vaex.array_types.is_arrow_array(x):
+                    x = vaex.arrow.convert.ensure_not_chunked(x)
+                    if vaex.dtype_of(x).is_encoded:
+                        x = x.indices
+                    x = vaex.array_types.to_numpy(x)
+                else:
+                    x = vaex.utils.as_contiguous(x)
+                    if x.dtype.kind in "mM":
+                        # we pass datetime as int
+                        x = x.view('uint64')
             return x
 
         N = i2 - i1

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -765,7 +765,9 @@ class DatasetConcatenated(Dataset):
     def is_masked(self, column):
         for dataset in self.datasets:
             if column not in dataset:
-                return True
+                # if the column is not in the dataset, we assume it is not masked
+                # since we ues arrow in that case
+                return False
         return any(k.is_masked(column) for k in self.datasets)
 
     def shape(self, column):

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -270,8 +270,8 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
                     null_bitmap = pa.py_buffer(self._map_hdf5_array(mask))
                     ar = pa.Array.from_buffers(array.type, len(array), [null_bitmap] + buffers[1:])
                 else:
-                    ar = vaex.column.ColumnMaskedNumpy(array, mask_array)
                     mask_array = self._map_hdf5_array(mask)
+                    ar = vaex.column.ColumnMaskedNumpy(array, mask_array)
                     if isinstance(array, np.ndarray):
                         ar = np.ma.array(array, mask=mask_array, shrink=False)
                     else:

--- a/packages/vaex-hdf5/vaex/hdf5/dataset.py
+++ b/packages/vaex-hdf5/vaex/hdf5/dataset.py
@@ -266,13 +266,16 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
                     array = vaex.column.ColumnArrowLazyCast(array, vaex.dtype_of(array).arrow)
             if mask is not None:
                 if as_arrow:
-                    raise TypeError('Arrow does not support byte masks')
-                mask_array = self._map_hdf5_array(mask)
-                if isinstance(array, np.ndarray):
-                    ar = np.ma.array(array, mask=mask_array, shrink=False)
-                    # assert ar.mask is mask_array, "masked array was copied"
+                    buffers = array.buffers()
+                    null_bitmap = pa.py_buffer(self._map_hdf5_array(mask))
+                    ar = pa.Array.from_buffers(array.type, len(array), [null_bitmap] + buffers[1:])
                 else:
                     ar = vaex.column.ColumnMaskedNumpy(array, mask_array)
+                    mask_array = self._map_hdf5_array(mask)
+                    if isinstance(array, np.ndarray):
+                        ar = np.ma.array(array, mask=mask_array, shrink=False)
+                    else:
+                        ar = vaex.column.ColumnMaskedNumpy(array, mask_array)
                 return ar
             else:
                 return array
@@ -404,7 +407,10 @@ class Hdf5MemoryMapped(DatasetMemoryMapped):
             if self._version > 1 and 'mask' in column:
                 return self._map_hdf5_array(data, column['mask'], as_arrow=as_arrow)
             else:
-                return self._map_hdf5_array(data, as_arrow=as_arrow)
+                if 'null_bitmap' in column:
+                    return self._map_hdf5_array(data, column['null_bitmap'], as_arrow=True)
+                else:
+                    return self._map_hdf5_array(data, as_arrow=as_arrow)
 
 
     def close(self):

--- a/packages/vaex-hdf5/vaex/hdf5/writer.py
+++ b/packages/vaex-hdf5/vaex/hdf5/writer.py
@@ -59,22 +59,23 @@ class Writer:
         self.column_writers = {}
         dtypes = df.schema()
         str_byte_length = {name:df[name].str.byte_length().sum(delay=True, progress=progressbar_strings) for name, dtype in dtypes.items() if dtype.is_string}
-        str_count = {name:df.count(df[name], delay=True, progress=progressbar_count) for name, dtype in dtypes.items() if dtype.is_string}
+        # arrow types can contain nulls even when they don't have a mask
+        arrow_null_count = {name: df.count(df[name], delay=True, progress=progressbar_count) for name, dtype in dtypes.items() if dtype.is_arrow or df.is_string}
         df.execute()
         progressbar_count(1)
         progressbar_strings(1)
 
         str_byte_length = {k: v.get() for k, v in str_byte_length.items()}
-        has_null_str = {k: N != v.get() for k, v in str_count.items()}
-        has_null = {name:df.is_masked(name) for name, dtype in dtypes.items() if not dtype.is_string}
+        has_null = {k: N != v.get() for k, v in arrow_null_count.items()}
+        has_mask = {name: df.is_masked(name) for name, dtype in dtypes.items() if not dtype.is_string}
 
         for i, name in enumerate(list(column_names)):
             dtype = dtypes[name]
             shape = (N, ) + df._shape_of(name)[1:]
             if dtype.is_string:
-                self.column_writers[name] = ColumnWriterString(self.columns, name, dtypes[name], shape, str_byte_length[name], has_null_str[name])
+                self.column_writers[name] = ColumnWriterString(self.columns, name, dtypes[name], shape, str_byte_length[name], has_null[name])
             elif dtype.is_primitive or dtype.is_temporal:
-                self.column_writers[name] = ColumnWriterPrimitive(self.columns, name, dtypes[name], shape, has_null[name], self.byteorder)
+                self.column_writers[name] = ColumnWriterPrimitive(self.columns, name, dtypes[name], shape, has_mask[name], has_null[name], self.byteorder)
             elif dtype.is_encoded:
                 labels = df.category_labels(name)
                 self.column_writers[name] = ColumnWriterDictionaryEncoded(self.columns, name, dtypes[name], labels, shape, has_null[name], self.byteorder, df)
@@ -118,7 +119,7 @@ class Writer:
                 pool = concurrent.futures.ThreadPoolExecutor(export_threads)
             for column_names_subgroup in vaex.itertools.chunked(column_names, column_count):
                 expressions = [self.column_writers[name].expression for name in column_names_subgroup]
-                for _i1, _i2, values in df.evaluate(expressions, chunk_size=chunk_size, filtered=True, parallel=parallel, array_type="numpy-arrow", progress=progressbar.hidden()):
+                for _i1, _i2, values in df.evaluate(expressions, chunk_size=chunk_size, filtered=True, parallel=parallel, progress=progressbar.hidden()):
                     pass
                     def write(arg):
                         i, name = arg
@@ -176,7 +177,7 @@ class ColumnWriterDictionaryEncoded:
 
 
 class ColumnWriterPrimitive:
-    def __init__(self, h5parent, name, dtype, shape, has_null, byteorder="="):
+    def __init__(self, h5parent, name, dtype, shape, has_mask, has_null, byteorder="="):
         self.h5parent = h5parent
         self.name = name
         self.shape = shape
@@ -185,6 +186,10 @@ class ColumnWriterPrimitive:
         self.to_offset = 0
         self.to_array = None
         self.expression = name
+        self.has_mask = has_mask
+        self.has_null = has_null
+        if self.has_mask and self.has_null:
+            raise ValueError("Cannot have both mask and null")
 
         self.h5group = h5parent.require_group(name)
         if dtype.kind in 'mM':
@@ -201,7 +206,11 @@ class ColumnWriterPrimitive:
             self.array = self.h5group.require_dataset('data', shape=shape, dtype=dtype.numpy.newbyteorder(byteorder), track_times=False)
         self.array[0] = self.array[0]  # make sure the array really exists
 
-        if has_null:
+        if self.has_null:
+            null_shape = ((self.count + 7) // 8,)  # TODO: arrow requires padding right?
+            self.null_bitmap_array = self.h5group.require_dataset("null_bitmap", shape=null_shape, dtype="u1", track_times=False)
+            self.null_bitmap_array[0] = self.null_bitmap_array[0]  # make sure the array really exists
+        if self.has_mask:
             self.mask = self.h5group.require_dataset('mask', shape=shape, dtype=bool, track_times=False)
             self.mask[0] = self.mask[0]  # make sure the array really exists
         else:
@@ -213,6 +222,8 @@ class ColumnWriterPrimitive:
 
     def mmap(self, mmap, file):
         self.to_array = h5mmap(mmap if USE_MMAP else None, file, self.array, self.mask)
+        if self.null_bitmap_array is not None:
+            self.null_bitmap_array = h5mmap(mmap, file, self.null_bitmap_array)
 
     def write(self, values):
         no_values = len(values)
@@ -221,7 +232,14 @@ class ColumnWriterPrimitive:
             target_set_item = slice(self.to_offset, self.to_offset + no_values)
             if self.dtype.kind in 'mM':
                 values = values.view(np.int64)
+            if self.has_null:
+                byte_index1 = self.to_offset // 8  # floor it
+                byte_index2 = (self.to_offset + len(values) + 7) // 8  # ceil it
+                if self.to_offset != byte_index1 * 8:
+                    raise ValueError("Cannot write to non-byte aligned offset")
+                self.null_bitmap_array[byte_index1:byte_index2] = memoryview(values.buffers()[0])
             if np.ma.isMaskedArray(self.to_array) and np.ma.isMaskedArray(values):
+                assert self.has_mask
                 self.to_array.data[target_set_item] = values.filled(fill_value)
                 self.to_array.mask[target_set_item] = values.mask
             elif not np.ma.isMaskedArray(self.to_array) and np.ma.isMaskedArray(values):

--- a/packages/vaex-hdf5/vaex/hdf5/writer.py
+++ b/packages/vaex-hdf5/vaex/hdf5/writer.py
@@ -146,7 +146,7 @@ class ColumnWriterDictionaryEncoded:
         self.expression = df[name].index_values()
         self.h5group = h5parent.require_group(name)
         self.h5group.attrs["type"] = "dictionary_encoded"
-        self.index_writer = ColumnWriterPrimitive(self.h5group, name="indices", dtype=self.dtype.index_type, shape=shape, has_null=has_null, byteorder=byteorder)
+        self.index_writer = ColumnWriterPrimitive(self.h5group, name="indices", dtype=self.dtype.index_type, shape=shape, has_null=has_null, has_mask=False, byteorder=byteorder)
         self._prepare_values()
 
     def _prepare_values(self):

--- a/tests/concat_test.py
+++ b/tests/concat_test.py
@@ -238,8 +238,8 @@ def test_concat_unaligned_schema(arrow):
     df = df1.concat(df2)
     assert df.x.tolist() == [1, 2, None, None]
     assert df.y.tolist() == [None, None, 'd', 'e']
-    assert df.is_masked('x')
-    assert df.is_masked('y')
+    assert not df.is_masked('x')
+    assert not df.is_masked('y')
     # always 'upcast' to Arrow arrays
     # # rationale: Arrow will use use less memory, numpy has no efficient way to represent all missing data
     assert df.x.data_type() == pa.float32()

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -298,3 +298,16 @@ def test_export_csv_badnames(tmpdir):
     df2 = vaex.open(output_path)
     assert df.get_column_names() == df2.get_column_names()
     assert df.shape == df2.shape
+
+
+def test_export_hdf5_missing_values(tmpdir):
+    df = vaex.from_dict({'x': pa.array([1, None, 5, None, 10]),
+                          'y': pa.array([1.1, None, 5.5, None, 10.10]),
+                          'z': ['Yes', None, 'No', None, 'Maybe']})
+    export_path = str(tmpdir.join('tmp.hdf5'))
+    df.export_hdf5(export_path)
+    df2 = vaex.open(export_path)
+    assert df2.shape == (5, 3)
+    assert df2.x.tolist() == [1, None, 5, None, 10]
+    assert df2.y.tolist() == [1.1, None, 5.5, None, 10.10]
+    assert df2.z.tolist() == ['Yes', None, 'No', None, 'Maybe']


### PR DESCRIPTION
When we have pyarrow numeric data with missing values, the missing data are not correctly exported to hdf5.

- [x] Make unit-test
- [x] Make test pass
- [x] Party