### PR TITLE
Fix: allow single columns or expressions in materialize

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4902,6 +4902,7 @@ class DataFrame(object):
             df[name] = df.func.fillna(df[name], value)
         return df
 
+    @docsubst
     def materialize(self, column=None, inplace=False, virtual_column=None):
         '''Turn columns into native CPU format for optimal performance at cost of memory.
 
@@ -4926,8 +4927,8 @@ class DataFrame(object):
         >>> df.x.sum()  # as fast as possible, will use memory
 
         :param column: string or list of strings with column names to materialize, all columns when None
-        :param virtual_column: for backward compatibility
         :param inplace: {inplace}
+        :param virtual_column: for backward compatibility
         '''
         if virtual_column is not None:
             warnings.warn("virtual_column argument is deprecated, please use column")
@@ -4937,6 +4938,7 @@ class DataFrame(object):
             columns = df.get_column_names(hidden=True)
         else:
             columns = _ensure_strings_from_expressions(column)
+            columns = _ensure_list(columns)
         virtual = []
         cache = []
         for column in columns:

--- a/tests/materialize_test.py
+++ b/tests/materialize_test.py
@@ -3,14 +3,14 @@ from common import *
 def test_materialize_virtual(ds_local):
     ds = ds_local
     print(ds)
-    ds['r'] = np.sqrt(ds.x**2 + ds.y**2)
-    assert 'r' in ds.virtual_columns
-    assert hasattr(ds, 'r')
-    ds = ds.materialize(ds.r)
-    assert 'r' not in ds.virtual_columns
-    assert 'r' in ds.columns
-    assert hasattr(ds, 'r')
-    assert ds.r.evaluate().tolist() == np.sqrt(ds.x.to_numpy()**2 + ds.y.to_numpy()**2).tolist()
+    ds['new_r'] = np.sqrt(ds.x**2 + ds.y**2)
+    assert 'new_r' in ds.virtual_columns
+    assert hasattr(ds, 'new_r')
+    ds = ds.materialize(ds.new_r)
+    assert 'new_r' not in ds.virtual_columns
+    assert 'new_r' in ds.columns
+    assert hasattr(ds, 'new_r')
+    assert ds.new_r.evaluate().tolist() == np.sqrt(ds.x.to_numpy()**2 + ds.y.to_numpy()**2).tolist()
 
 def test_materialize_dataset():
     df = vaex.from_scalars(x=1)


### PR DESCRIPTION
`df.materialize()` expects a list of columns / expressions. This PR allows for users to put in a single column/expression. 
Raised by https://github.com/vaexio/vaex/issues/2247

- [x] Update unit-test to expose the issue
- [x] Simple fix
- [ ] Review 