### PR TITLE
fix: use settings for thread counts

### DIFF
--- a/packages/vaex-core/vaex/csv.py
+++ b/packages/vaex-core/vaex/csv.py
@@ -9,10 +9,11 @@ from dask.utils import parse_bytes
 from frozendict import frozendict
 
 import vaex.dataset
+import vaex.settings
 import vaex.file
 from vaex.dataset import Dataset, DatasetFile
 from .itertools import pmap, pwait, buffer, consume, filter_none
-from .multithreading import thread_count_default_io, get_main_io_pool
+from .multithreading import get_main_io_pool
 
 
 MB = 1024**2
@@ -406,7 +407,7 @@ class DatasetCsvLazy(DatasetFile):
         for column in columns:
             if column not in self._columns:
                 self._check_existence(column)
-        for c1, c2, chunks in filter_none(pwait(buffer(chunk_generator, thread_count_default_io//2+3))):
+        for c1, c2, chunks in filter_none(pwait(buffer(chunk_generator, vaex.settings.main.thread_count_io//2+3))):
             chunks_ready_list.append(chunks)
             total_row_count = sum([len(list(k.values())[0]) for k in chunks_ready_list])
             if total_row_count > chunk_size:

--- a/packages/vaex-core/vaex/multithreading.py
+++ b/packages/vaex-core/vaex/multithreading.py
@@ -2,24 +2,18 @@
 from __future__ import division, print_function
 import asyncio
 import threading
-import queue
-import math
 import multiprocessing
-import sys
+from warnings import warn
 import vaex.utils
 import logging
-import traceback
-import cProfile
 import concurrent.futures
 import time
-import os
+import vaex.settings
 
 from .itertools import buffer
 
 logger = logging.getLogger("vaex.multithreading")
 
-thread_count_default = vaex.utils.get_env_type(int, 'VAEX_NUM_THREADS', multiprocessing.cpu_count())
-thread_count_default_io = vaex.utils.get_env_type(int, 'VAEX_NUM_THREADS_IO', thread_count_default + 1)
 main_pool = None
 main_io_pool = None
 
@@ -44,7 +38,7 @@ def get_main_pool():
 def get_main_io_pool():
     global main_io_pool
     if main_io_pool is None:
-        main_io_pool = concurrent.futures.ThreadPoolExecutor(max_workers=thread_count_default_io)
+        main_io_pool = concurrent.futures.ThreadPoolExecutor(max_workers=vaex.settings.main.thread_count_io)
     return main_io_pool
 
 
@@ -59,7 +53,7 @@ class ThreadPoolIndex(concurrent.futures.ThreadPoolExecutor):
 
     def __init__(self, max_workers=None, *args, **kwargs):
         if max_workers is None:
-            max_workers = thread_count_default
+            max_workers = vaex.settings.main.thread_count
         super(ThreadPoolIndex, self).__init__(max_workers, *args, **kwargs)
         self.lock = threading.Lock()
         self.thread_indices = iter(range(1000000))  # enough threads until 2100?


### PR DESCRIPTION
We were still using the environment variables.
Fixes #2231