### PR TITLE
Better handle empty extract

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4483,7 +4483,8 @@ class DataFrame(object):
         df = self.trim()
         with self._state_lock:
             if len(df) == 0 and len(self.virtual_columns):
-                raise ValueError("Cannot extract a DataFrame with virtual columns when there are 0 rows. See https://github.com/vaexio/vaex/issues/2232 for more information.\n\tWorkaround suggestion: df = df.extract() if len(df) else df")
+                logger.warn("Cannot extract a DataFrame with virtual columns when there are 0 rows. See https://github.com/vaexio/vaex/issues/2232 for more information.\n\tReturning df")
+                return df
             # df.filtered gets changed in push_down_filter so use a lock
             # to make it thread safe
             if df.filtered:

--- a/tests/extract_test.py
+++ b/tests/extract_test.py
@@ -45,5 +45,6 @@ def test_extract_empty():
     assert df_extracted.filtered is False
 
     df['z'] = df.x + 1
-    with pytest.raises(ValueError, match='Cannot extract a DataFrame with.*'):
+    with pytest.warns(Warning):
         df_extracted = df.extract()
+    assert len(df_extracted) == 0


### PR DESCRIPTION
I think this is a better way to handle extracting an empty dataframe than https://github.com/vaexio/vaex/pull/2267

relates to https://github.com/vaexio/vaex/issues/2232