### PR TITLE
Fix: sorting of an empty df returns an empty df with a warning

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4709,7 +4709,6 @@ class DataFrame(object):
         '''
 
         if len(self) == 0:
-            warnings.warn('Cannot sort empty DataFrame, returning empty DataFrame.')
             return self.copy()
         self = self.trim()
         # Ensure "by" is in the proper format

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -4707,31 +4707,28 @@ class DataFrame(object):
         :param str or expression or list of str/expressions by: expression to sort by.
         :param bool or list of bools ascending: ascending (default, True) or descending (False).
         '''
-        try:
-            self = self.trim()
-            # Ensure "by" is in the proper format
-            by = vaex.utils._ensure_list(by)
-            by = vaex.utils._ensure_strings_from_expressions(by)
 
-            # Ensure "ascending is in the proper format"
-            if isinstance(ascending, list):
-                assert len(ascending) == len(by), 'If "ascending" is a list, it must have the same number of elements as "by".'
-            else:
-                ascending = vaex.utils._ensure_list(ascending) * len(by)
+        if len(self) == 0:
+            warnings.warn('Cannot sort empty DataFrame, returning empty DataFrame.')
+            return self.copy()
+        self = self.trim()
+        # Ensure "by" is in the proper format
+        by = vaex.utils._ensure_list(by)
+        by = vaex.utils._ensure_strings_from_expressions(by)
 
-            sort_keys = [(key, 'ascending') if order is True else (key, 'descending') for key, order in zip(by, ascending)]
-            pa_table = self[by].to_arrow_table()
-            indices = pa.compute.sort_indices(pa_table, sort_keys=sort_keys)
+        # Ensure "ascending is in the proper format"
+        if isinstance(ascending, list):
+            assert len(ascending) == len(by), 'If "ascending" is a list, it must have the same number of elements as "by".'
+        else:
+            ascending = vaex.utils._ensure_list(ascending) * len(by)
 
-            # if we don't cast to int64, we get uint64 scalars, which when adding numbers to will auto case to float (numpy)
-            indices = vaex.array_types.to_numpy(indices).astype('int64')
-            return self.take(indices)
-        except ValueError as e:
-            if len(self) == 0:
-                warnings.warn('Cannot sort empty DataFrame, returning empty DataFrame.')
-                return self
-            else:
-                raise e
+        sort_keys = [(key, 'ascending') if order is True else (key, 'descending') for key, order in zip(by, ascending)]
+        pa_table = self[by].to_arrow_table()
+        indices = pa.compute.sort_indices(pa_table, sort_keys=sort_keys)
+
+        # if we don't cast to int64, we get uint64 scalars, which when adding numbers to will auto case to float (numpy)
+        indices = vaex.array_types.to_numpy(indices).astype('int64')
+        return self.take(indices)
 
 
     @docsubst

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,5 +1,4 @@
 from common import *
-import pytest
 
 
 def test_sort(ds_local):
@@ -64,6 +63,5 @@ def test_sort_empty():
     df = vaex.from_arrays(x=[5, 1, 4], y=[1, 2, 3])
     dff = df[df.y > 10]
     assert len(dff) == 0
-    with pytest.warns(UserWarning):
-        dff_sorted = dff.sort(by='x')
+    dff_sorted = dff.sort(by='x')
     assert len(dff_sorted) == 0

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,4 +1,5 @@
 from common import *
+import pytest
 
 
 def test_sort(ds_local):
@@ -57,3 +58,12 @@ def test_sort_strings_masked():
     df = vaex.from_arrays(x=['Groningen', 'Skopje', None, 'Amsterdam', 'Ohrid'])
     assert df.sort('x').x.tolist() == ['Amsterdam', 'Groningen', 'Ohrid', 'Skopje', None]
     assert df.sort('x', ascending=False).x.tolist() == ['Skopje', 'Ohrid', 'Groningen', 'Amsterdam', None]
+
+
+def test_sort_empty():
+    df = vaex.from_arrays(x=[5, 1, 4], y=[1, 2, 3])
+    dff = df[df.y > 10]
+    assert len(dff) == 0
+    with pytest.warns(UserWarning):
+        dff_sorted = dff.sort(by='x')
+    assert len(dff_sorted) == 0


### PR DESCRIPTION
Addresses https://github.com/vaexio/vaex/issues/2287

@maartenbreddels I wrapped this up in `try/expect` block as to now check for length every time a df is sorted. If you think this should be done the other way around (i.e. first check length) then try to sort, lemme know!

Thanks to @NickCrews for bringing this up.

- [x] Unit test
- [x] Tests pass
- [ ] Review