### PR TITLE
Fix: more stable std computation

### DIFF
--- a/packages/vaex-core/vaex/agg.py
+++ b/packages/vaex-core/vaex/agg.py
@@ -520,7 +520,7 @@ class AggregatorDescriptorKurtosis(AggregatorDescriptorMulti):
 
 class AggregatorDescriptorStd(AggregatorDescriptorVar):
     def finish(self, value):
-        return value**0.5
+        return np.abs(value)**0.5
 
 @register
 def count(expression='*', selection=None, edges=False):

--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -1164,7 +1164,7 @@ class DataFrame(object):
         """
         @delayed
         def finish(var):
-            return var**0.5
+            return np.abs(var)**0.5
         return self._delay(delay, finish(self.var(expression, binby=binby, limits=limits, shape=shape, selection=selection, delay=True, progress=progress)))
 
     @docsubst


### PR DESCRIPTION
`std` would give `nan` for cases were the variance is veeeery close to 0 (due to numerical inaccuracies). 

Raised by: https://github.com/vaexio/vaex/issues/2291