### PR TITLE
Remove pkg_resources from direct imports

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -66,7 +66,9 @@ try:
     if version_info[:2] >= (3, 10):
         from importlib.metadata import entry_points
     else:
-        from importlib_metadata import entry_points
+        from importlib_metadata import entry_points, __version__ as importlib_metadata_version
+        if int(importlib_metadata_version.split(".")[0]) < 4.0:
+            raise ImportError("vaex requires importlib_metadata >= 4.0 when installed")
 except ImportError:
     import pkg_resources
     entry_points = pkg_resources.iter_entry_points

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -801,7 +801,11 @@ for entry in entry_points(group='vaex.expression.accessor'):
 
 
 for entry in entry_points(group='vaex.plugin'):
-    if entry.module_name == 'vaex_arrow.opener':
+    try:
+        module_name = entry.module 
+    except AttributeError:
+        module_name = entry.module_name
+    if module_name == 'vaex_arrow.opener':
         # if vaex_arrow package is installed, we ignore it
         continue
     logger.debug('adding vaex plugin: ' + entry.name)

--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -34,7 +34,6 @@ Follow the tutorial at https://docs.vaex.io/en/latest/tutorial.html to learn how
 """  # -*- coding: utf-8 -*-
 import logging as root_logging
 import os
-import pkg_resources
 from typing import Dict, List
 from urllib.parse import urlparse, parse_qs
 
@@ -60,9 +59,17 @@ import vaex.datasets
 from vaex.dataframe import DataFrame as DataFrame
 from vaex.expression import Expression as Expression
 
-
-
 import vaex.progress
+
+try:
+    from sys import version_info
+    if version_info[:2] >= (3, 10):
+        from importlib.metadata import entry_points
+    else:
+        from importlib_metadata import entry_points
+except ImportError:
+    import pkg_resources
+    entry_points = pkg_resources.iter_entry_points
 
 try:
     from . import version
@@ -725,7 +732,7 @@ def register_dataframe_accessor(name, cls=None, override=False):
         return wrapper(cls)
 
 
-for entry in pkg_resources.iter_entry_points(group='vaex.namespace'):
+for entry in entry_points(group='vaex.namespace'):
     logger.warning('(DEPRECATED, use vaex.dataframe.accessor) adding vaex namespace: ' + entry.name)
     try:
         add_namespace = entry.load()
@@ -779,21 +786,21 @@ def _add_lazy_accessor(name, loader, target_class=vaex.dataframe.DataFrame):
         lazy_accessors[scope].append((parts[-1], scope, loader, lazy_accessors))
 
 
-for entry in pkg_resources.iter_entry_points(group='vaex.dataframe.accessor'):
+for entry in entry_points(group='vaex.dataframe.accessor'):
     logger.debug('adding vaex accessor: ' + entry.name)
     def loader(entry=entry):
         return entry.load()
     _add_lazy_accessor(entry.name, loader)
 
 
-for entry in pkg_resources.iter_entry_points(group='vaex.expression.accessor'):
+for entry in entry_points(group='vaex.expression.accessor'):
     logger.debug('adding vaex expression accessor: ' + entry.name)
     def loader(entry=entry):
         return entry.load()
     _add_lazy_accessor(entry.name, loader, vaex.expression.Expression)
 
 
-for entry in pkg_resources.iter_entry_points(group='vaex.plugin'):
+for entry in entry_points(group='vaex.plugin'):
     if entry.module_name == 'vaex_arrow.opener':
         # if vaex_arrow package is installed, we ignore it
         continue

--- a/packages/vaex-core/vaex/dataset.py
+++ b/packages/vaex-core/vaex/dataset.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 import collections.abc
 import logging
-import pkg_resources
 import uuid
 from urllib.parse import urlparse
 from typing import Set, List
@@ -22,7 +21,15 @@ from vaex.array_types import data_type
 from .column import Column, ColumnIndexed, supported_column_types
 from . import array_types
 from vaex import encoding
-
+try:
+    from sys import version_info
+    if version_info[:2] >= (3, 10):
+        from importlib.metadata import entry_points
+    else:
+        from importlib_metadata import entry_points
+except ImportError:
+    import pkg_resources
+    entry_points = pkg_resources.iter_entry_points
 
 logger = logging.getLogger('vaex.dataset')
 
@@ -58,7 +65,7 @@ def open(path, fs_options={}, fs=None, *args, **kwargs):
     failures = []
     with lock:  # since we cache, make this thread save
         if not opener_classes:
-            for entry in pkg_resources.iter_entry_points(group='vaex.dataset.opener'):
+            for entry in entry_points(group='vaex.dataset.opener'):
                 logger.debug('trying opener: ' + entry.name)
                 try:
                     opener = entry.load()

--- a/packages/vaex-core/vaex/file/__init__.py
+++ b/packages/vaex-core/vaex/file/__init__.py
@@ -8,13 +8,22 @@ import re
 import sys
 from urllib.parse import parse_qs
 import warnings
-import pkg_resources
 
 import pyarrow as pa
 import pyarrow.fs
 
 import vaex.file.cache
 
+
+try:
+    from sys import version_info
+    if version_info[:2] >= (3, 10):
+        from importlib.metadata import entry_points
+    else:
+        from importlib_metadata import entry_points
+except ImportError:
+    import pkg_resources
+    entry_points = pkg_resources.iter_entry_points
 
 normal_open = open
 logger = logging.getLogger("vaex.file")
@@ -186,7 +195,7 @@ def exists(path, fs_options={}, fs=None):
 
 def _get_scheme_handler(path):
     scheme, _ = split_scheme(path)
-    for entry in pkg_resources.iter_entry_points(group='vaex.file.scheme'):
+    for entry in entry_points(group='vaex.file.scheme'):
         if entry.name == scheme:
             return entry.load()
     raise ValueError(f'Do not know how to open {path}, no handler for {scheme} is known')

--- a/packages/vaex-core/vaex/memory.py
+++ b/packages/vaex-core/vaex/memory.py
@@ -2,8 +2,17 @@ import os
 import math
 import threading
 
-import pkg_resources
 import vaex.settings
+
+try:
+    from sys import version_info
+    if version_info[:2] >= (3, 10):
+        from importlib.metadata import entry_points
+    else:
+        from importlib_metadata import entry_points
+except ImportError:
+    import pkg_resources
+    entry_points = pkg_resources.iter_entry_points
 
 # thread local variable, where 'global' tracker go
 local = threading.local()
@@ -29,7 +38,7 @@ def create_tracker():
     if not _memory_tracker_types:
         with lock:
             if not _memory_tracker_types:
-                for entry in pkg_resources.iter_entry_points(group="vaex.memory.tracker"):
+                for entry in entry_points(group="vaex.memory.tracker"):
                     _memory_tracker_types[entry.name] = entry.load()
     cls = _memory_tracker_types.get(memory_tracker_type)
     if cls is not None:

--- a/packages/vaex-core/vaex/tasks.py
+++ b/packages/vaex-core/vaex/tasks.py
@@ -4,7 +4,6 @@ import os
 import operator
 from functools import reduce
 import threading
-import pkg_resources
 
 import numpy as np
 
@@ -13,6 +12,16 @@ import vaex.settings
 import vaex.encoding
 from .utils import _expand_shape
 from .datatype import DataType
+
+try:
+    from sys import version_info
+    if version_info[:2] >= (3, 10):
+        from importlib.metadata import entry_points
+    else:
+        from importlib_metadata import entry_points
+except ImportError:
+    import pkg_resources
+    entry_points = pkg_resources.iter_entry_points
 
 
 logger = logging.getLogger('vaex.tasks')
@@ -36,7 +45,7 @@ def create_checkers():
     if not _task_checker_types:
         with _lock:
             if not _task_checker_types:
-                for entry in pkg_resources.iter_entry_points(group="vaex.task.checker"):
+                for entry in entry_points(group="vaex.task.checker"):
                     _task_checker_types[entry.name] = entry.load()
     names = list(_task_checker_types.keys())
     task_checkers_type = vaex.settings.main.task_tracker.type

--- a/packages/vaex-core/vaex/utils.py
+++ b/packages/vaex-core/vaex/utils.py
@@ -18,7 +18,6 @@ import warnings
 import numbers
 import keyword
 from filelock import FileLock
-import pkg_resources
 
 import blake3
 import dask.utils
@@ -30,6 +29,15 @@ import yaml
 from .json import VaexJsonEncoder, VaexJsonDecoder
 import vaex.file
 
+try:
+    from sys import version_info
+    if version_info[:2] >= (3, 10):
+        from importlib.metadata import entry_points
+    else:
+        from importlib_metadata import entry_points
+except ImportError:
+    import pkg_resources
+    entry_points = pkg_resources.iter_entry_points
 
 is_frozen = getattr(sys, 'frozen', False)
 PY2 = sys.version_info[0] == 2
@@ -68,7 +76,7 @@ class RegistryCallable(MutableMapping):
         with self.lock:
             if name in self.registry:
                 return self.registry[name]
-            for entry in pkg_resources.iter_entry_points(group=self.entry_points):
+            for entry in entry_points(group=self.entry_points):
                 self.registry[entry.name] = entry.load()
 
         if name not in self.registry:


### PR DESCRIPTION
This is a hot fix for the IO read issues caused by using the legacy pkg_resources.iter_entry_points

legacy `pkg_resources.iter_entry_points` is replaced with `importlib.metadata.entry_points`
```python
try:
  if sys.version_info[:2] >= (3, 10):
      # pylint: disable=no-name-in-module
      from importlib.metadata import entry_points
  else:
      from importlib_metadata import entry_points
except ImportError:
  import pkg_resources
  entry_points = pkg_resources.iter_entry_points
```