### PR TITLE
fix: heatmap colorbars are not displayed when using slices

### DIFF
--- a/packages/vaex-viz/vaex/viz/mpl.py
+++ b/packages/vaex-viz/vaex/viz/mpl.py
@@ -806,7 +806,7 @@ def heatmap(self, x=None, y=None, z=None, what="count(*)", vwhat=None, reduce=["
                 label = labels["what"][what_index]
                 colorbar.ax.set_ylabel(colorbar_label or label)
 
-            if facets > 1:
+            if facets > 1 and colorbar_location != "individual":
                 ax = plt.subplot(gs[row_offset + row * row_scale:row_offset + (row + 1) * row_scale, column * column_scale:(column + 1) * column_scale])
             else:
                 ax = plt.gca()


### PR DESCRIPTION
The `ax` is already created if multiple facets are present. Re-creating it prevents the colorbars to be correctly displayed in the figure to the side of their axes.

See also [this issue](https://github.com/vaexio/vaex/issues/2303) on the `vaex` repository.