### PR TITLE
Fix: Typo in __init__ docstring remote connection

### DIFF
--- a/packages/vaex-core/vaex/__init__.py
+++ b/packages/vaex-core/vaex/__init__.py
@@ -14,7 +14,7 @@ Or using :func:`open` to open a file.
 >>> df2 = vaex.open("somedata.arrow")
 >>> df4 = vaex.open("somedata.csv")
 
-Or connecting to a remove server:
+Or connecting to a remote server:
 
 >>> df_remote = vaex.open("http://try.vaex.io/nyc_taxi_2015")
 


### PR DESCRIPTION
In the docstring in the vaex-core/vaex/__init__.py file, there was a small typo in the verbiage for connecting to a remote server. Previously, this docstring showed the word "remove" rather than "remote" which could be misleading, although I am sure most would understand the context here. 

![image](https://user-images.githubusercontent.com/50381805/208323946-874a408b-cb9c-43ef-9281-9ede08906101.png)

This has been corrected. 

![image](https://user-images.githubusercontent.com/50381805/208324036-73ab82e0-fb77-4c4a-bbf1-8a6b3625599d.png)

