### PR TITLE
Broken Graphql Query conditions

### DIFF
--- a/packages/vaex-graphql/vaex/graphql/__init__.py
+++ b/packages/vaex-graphql/vaex/graphql/__init__.py
@@ -72,9 +72,9 @@ def map_to_field(df, name):
 class Compare(graphene.InputObjectType):
     def filter(self, df, name):
         expression = vaex.expression.Expression(df, '(1==1)')
-        if self._eq:
+        if self._eq is not None:
             expression = expression & (df[name] == self._eq)
-        if self._neq:
+        if self._neq is not None:
             expression = expression & (df[name] != self._neq)
         return expression
 
@@ -108,7 +108,7 @@ class FloatCompare(NumberCompare):
     _gte = graphene.Field(graphene.Float)
     _lte = graphene.Field(graphene.Float)
 
-class BooleanCompare(NumberCompare):
+class BooleanCompare(Compare):
     _eq = graphene.Field(graphene.Boolean)
     _neq = graphene.Field(graphene.Boolean)
 


### PR DESCRIPTION
## Overview
graphQL queries with conditions that have an equal or not equal comparison with 0 as operand value are not evaluated properly. 

## Reproduce
```python

import vaex
import pandas as pd
from decimal import Decimal

df = vaex.from_pandas(pd.Dataframe(data=[[7]], columns=['dummy'] ))

query = """
query($where: BoolExp!, $limit: Int!){
          df(where: $where) { row(limit: $limit){
                               dummy
                               }
                        }
                  }
"""
variables = {'limit': Decimal('10'), 'where': {'dummy': {'_eq': Decimal('0')}}}
output = df.graphql.execute(query, variable_values=variables)

print(output.errors)
```

## Changes
1. Added null check to Compare class _eq and _neq checks.
2. Fixed BooleanCompare class to inherit from Compare class rather than NumberCompare.