### PR TITLE
#1970 Improve Error Handling in `to_dask_array` for Non-Numeric Columns

### DIFF
--- a/packages/vaex-core/vaex/dataframe.py
+++ b/packages/vaex-core/vaex/dataframe.py
@@ -3417,6 +3417,13 @@ class DataFrame(object):
         """
         import dask.array as da
         import uuid
+        import numpy as np
+
+        #Check for non-numeric columns
+        non_numeric_columns= [col for col in self.columns if not np.issubdtype(self[col].dtype, np.number)]
+        if non_numeric_columns:
+            raise TypeError(f"Cannot Convert non-numeric columns to Dask array. Non-numeric columns: {non_numeric_columns}")
+        
         dtype = self._dtype
         chunks = da.core.normalize_chunks(chunks, shape=self.shape, dtype=dtype.numpy)
         name = 'vaex-df-%s' % str(uuid.uuid1())


### PR DESCRIPTION
This PR enhances the `to_dask_array` function in Vaex by adding robust error handling for cases where the DataFrame contains non-numeric columns. Previously, attempting to convert a DataFrame with non-numeric data to a Dask array would lead to ambiguous errors or failures during execution.

Example:

` type error: Cannot convert non-numeric columns to Dask array. Non-numeric columns: ['B'] `