### PR TITLE
Fix pythonpackage.yml failing on macos-13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,10 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - {os: windows-latest, python-version: "3.8"}
+          - {os: macos-latest, python-version: "3.8"}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - {os: windows-latest, python-version: "3.8"}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - {os: windows-latest, python-version: "3.8"}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - {os: windows-latest, python-version: "3.8"}
@@ -55,6 +55,12 @@ jobs:
     - name: Install OpenMP runtime (Mac-only)
       if: startswith(matrix.os, 'macos')
       run: brew install libomp
+
+    # xcode 15.2 throws compilation errors ref https://github.com/vaexio/vaex/pull/2432
+    # select older xcode from the available versions on the runner ref https://github.com/actions/runner-images/blob/ff9acc6/images/macos/macos-13-Readme.md#xcode
+    - name: Switch to older Xcode (Mac-only)
+      if: startswith(matrix.os, 'macos')
+      run: sudo xcode-select -s "/Applications/Xcode_15.0.1.app"
 
     - name: Copy dll (Windows-only)
       if: (matrix.os == 'windows-latest')

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -42,7 +42,8 @@ jobs:
         run: |
           MATRIX_INCLUDE=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64 | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform linux --arch aarch64 | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | jq -nRc '{"only": inputs, "os": "macos-13"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch arm64 | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows --arch AMD64 | jq -nRc '{"only": inputs, "os": "windows-latest"}'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -42,8 +42,7 @@ jobs:
         run: |
           MATRIX_INCLUDE=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux --arch x86_64 | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform linux --arch aarch64 | jq -nRc '{"only": inputs, "os": "macos-14"}' \
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | jq -nRc '{"only": inputs, "os": "macos-13"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch arm64 | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows --arch AMD64 | jq -nRc '{"only": inputs, "os": "windows-latest"}'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -38,7 +38,7 @@ jobs:
 
       - id: set-matrix
         env:
-          CIBW_SKIP: pp* cp38-win*
+          CIBW_SKIP: pp* cp38-win* *musllinux_aarch64*
         run: |
           MATRIX_INCLUDE=$(
             {

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -38,7 +38,8 @@ jobs:
 
       - id: set-matrix
         env:
-          CIBW_SKIP: pp* cp38-win* *musllinux_aarch64*
+          # skipping pypy for now, cp38-win was segfaulting on CI, numpy has no wheels for cp38-musllinux_aarch64 -> build from source -> CI timeouts
+          CIBW_SKIP: pp* cp38-win* cp38-musllinux_aarch64
         run: |
           MATRIX_INCLUDE=$(
             {

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -85,7 +85,9 @@ jobs:
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v3
 
-    - name: Switch to older Xcode
+    # xcode 15.2 throws compilation errors ref https://github.com/vaexio/vaex/pull/2432
+    # select older xcode from the available versions on the runner ref https://github.com/actions/runner-images/blob/ff9acc6/images/macos/macos-13-Readme.md#xcode
+    - name: Switch to older Xcode (Mac-only)
       if: startswith(matrix.os, 'macos')
       run: sudo xcode-select -s "/Applications/Xcode_15.0.1.app"
 


### PR DESCRIPTION
leftover from #2331, don't know why setup-graphviz started failing for macos-13 on master between the time of last commit in the PR and the time of merge. probably github team changed something in the runner image again...