### PR TITLE
Bump numpy~=1.26.4

### DIFF
--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -26,7 +26,7 @@ url = "https://www.github.com/maartenbreddels/vaex"
 # TODO: after python2 supports frops, future and futures can also be dropped
 setup_requires = ["numpy~=1.17"]
 install_requires_core = [
-    "numpy~=1.17",
+    "numpy~=1.26.4",
     "aplus",
     "tabulate>=0.8.3",
     "dask!=2022.4.0",

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -24,7 +24,7 @@ license = "MIT"
 version = version.__version__
 url = "https://www.github.com/maartenbreddels/vaex"
 # TODO: after python2 supports frops, future and futures can also be dropped
-setup_requires = ["numpy~=1.17"]
+setup_requires = ["numpy~=1.26.4"]
 install_requires_core = [
     "numpy~=1.26.4",
     "aplus",


### PR DESCRIPTION
fix flaky timeout on master by requiring recent numpy which has wheels available for musllinux_aarch64