### PR TITLE
fix: avoid cp39-musllinux_aarch64 timeout

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -38,8 +38,13 @@ jobs:
 
       - id: set-matrix
         env:
-          # skipping pypy for now, cp38-win was segfaulting on CI, numpy has no wheels for cp38-musllinux_aarch64 -> build from source -> CI timeouts
-          CIBW_SKIP: pp* cp38-win* cp38-musllinux_aarch64
+          # skipping pypy for now
+          # cp38-win was segfaulting on CI -> skipping for now
+          # oldest-supported-numpy has no wheels for musllinux_aarch64 -> build numpy from source on QEMU -> CI timeouts -> skipping for now
+          CIBW_SKIP: >
+            pp*
+            cp38-win*
+            *musllinux_aarch64
         run: |
           MATRIX_INCLUDE=$(
             {

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -40,11 +40,11 @@ jobs:
         env:
           # skipping pypy for now
           # cp38-win was segfaulting on CI -> skipping for now
-          # oldest-supported-numpy has no wheels for musllinux_aarch64 -> build numpy from source on QEMU -> CI timeouts -> skipping for now
+          # oldest-supported-numpy has no wheels for cp38-musllinux_aarch64 -> build numpy from source on QEMU -> CI timeouts -> skipping for now
           CIBW_SKIP: >
             pp*
             cp38-win*
-            *musllinux_aarch64
+            cp38-musllinux_aarch64
         run: |
           MATRIX_INCLUDE=$(
             {

--- a/packages/vaex-core/pyproject.toml
+++ b/packages/vaex-core/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version=='3.8'", # deprecated ref https://github.com/scipy/oldest-supported-numpy
+    "numpy~=1.25; python_version>'3.8'",  # backward compatible build-system as of v1.25 ref https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency#
     "scikit-build",
     "cmake",
     "ninja"

--- a/packages/vaex-core/pyproject.toml
+++ b/packages/vaex-core/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "oldest-supported-numpy; python_version=='3.8'", # deprecated ref https://github.com/scipy/oldest-supported-numpy
-    "numpy~=1.25; python_version>'3.8'",  # backward compatible build-system as of v1.25 ref https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency#
+    "numpy~=1.25; python_version>'3.8'",  # numpy~=2.0 fails, backward compatible build-system as of v1.25 ref https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency
     "scikit-build",
     "cmake",
     "ninja"

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -29,7 +29,7 @@ install_requires_core = [
     "numpy~=1.17",
     "aplus",
     "tabulate>=0.8.3",
-    "dask!=2022.4.0",
+    "dask!=2022.4.0,<2024.9",  # fingerprinting in no longer deterministic as of 2024.9.0
     "future>=0.15.2",
     "pyyaml",
     "six",

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -263,7 +263,7 @@ setup(
     if not use_skbuild
     else [],
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.13",  # 3.13 needs numpy 2.1 support ref https://github.com/vaexio/vaex/pull/2434
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tests/fingerprint_test.py
+++ b/tests/fingerprint_test.py
@@ -96,10 +96,10 @@ def test_dataset_arrays():
         'y': '4d48c88e587db8f3855eed9f5d5f51eea769451b7371ecf7bdee4e0258238631',
         'z': 'a4cead13bef1fd1ec5974d1a2f5ceffd243a7aa6c6b08b80e09a7454b7d04293'
     }
-    assert ds.fingerprint in ['dataset-arrays-hashed-88244cf38fe91c6bf435caa6160b089b', 'dataset-arrays-hashed-148c30472b155430f46bfb94d5509cf4', 'dataset-arrays-hashed-ed88ca5523bad737bbdbee53eaba3ca1']
+    assert ds.fingerprint in ['dataset-arrays-hashed-88244cf38fe91c6bf435caa6160b089b', 'dataset-arrays-hashed-148c30472b155430f46bfb94d5509cf4']
 
 
-df_fingerprints_xy = ['dataframe-943761acaa2ff2060d21ef519c77e1b9', 'dataframe-1c2f7e9c53dbd30220792e425418e343', 'dataframe-9f81a4cd8df8f65d5d1ee3368ec8e4ba', 'dataframe-5c6b97012243d0f534be85ed88d4da43', 'dataframe-5c6b97012243d0f534be85ed88d4da43']
+df_fingerprints_xy = ['dataframe-943761acaa2ff2060d21ef519c77e1b9', 'dataframe-1c2f7e9c53dbd30220792e425418e343']
 
 
 def test_df():
@@ -114,10 +114,10 @@ def test_df_different_virtual_columns():
     y = x**2
     df1 = vaex.from_arrays(x=x, y=y, z=x+y)
     df1['z'] = df1.x + df1.z
-    assert df1.fingerprint() in ['dataframe-8f2202e2b4e7845c8ace767db5a49bc4', 'dataframe-b72cf197307aa4b9806e6ce3199b2960', 'dataframe-3dccec28d5db6bc592576116ef05d805', 'dataframe-c48e8490b3ddf553a0184967376334c1']
+    assert df1.fingerprint() in ['dataframe-8f2202e2b4e7845c8ace767db5a49bc4', 'dataframe-b72cf197307aa4b9806e6ce3199b2960']
     df2 = vaex.from_arrays(x=x, y=y, z=x+y)
     df2['z'] = df2.x - df2.z
-    assert df2.fingerprint() in ['dataframe-81043a3c5b32eaa4b18bf4a915492e23', 'dataframe-0e9a4e2753715ff592527dcee1f1e8c2', '']
+    assert df2.fingerprint() in ['dataframe-81043a3c5b32eaa4b18bf4a915492e23', 'dataframe-0e9a4e2753715ff592527dcee1f1e8c2']
 
 
 def test_df_with_dependencies():
@@ -137,7 +137,7 @@ def test_df_project():
     df_a = df[['x', 'y']]
     df_b = df[['x', 'y']]
     assert df_a.fingerprint() == df_b.fingerprint()
-    assert df_a.fingerprint() in ['dataframe-c13a4ab588272f03855ae5627731f7e5', 'dataframe-d4565ca8187231a051a9ff888ba16e7c', 'dataframe-2029c62052149fa7a811f4bb6170a2b6', 'dataframe-3eff215820906d4a751eddda1a58a1d7']
+    assert df_a.fingerprint() in ['dataframe-c13a4ab588272f03855ae5627731f7e5', 'dataframe-d4565ca8187231a051a9ff888ba16e7c']
 
 
 def test_df_selection_references_virtual_column():

--- a/tests/fingerprint_test.py
+++ b/tests/fingerprint_test.py
@@ -96,10 +96,10 @@ def test_dataset_arrays():
         'y': '4d48c88e587db8f3855eed9f5d5f51eea769451b7371ecf7bdee4e0258238631',
         'z': 'a4cead13bef1fd1ec5974d1a2f5ceffd243a7aa6c6b08b80e09a7454b7d04293'
     }
-    assert ds.fingerprint in ['dataset-arrays-hashed-88244cf38fe91c6bf435caa6160b089b', 'dataset-arrays-hashed-148c30472b155430f46bfb94d5509cf4']
+    assert ds.fingerprint in ['dataset-arrays-hashed-88244cf38fe91c6bf435caa6160b089b', 'dataset-arrays-hashed-148c30472b155430f46bfb94d5509cf4', 'dataset-arrays-hashed-ed88ca5523bad737bbdbee53eaba3ca1']
 
 
-df_fingerprints_xy = ['dataframe-943761acaa2ff2060d21ef519c77e1b9', 'dataframe-1c2f7e9c53dbd30220792e425418e343']
+df_fingerprints_xy = ['dataframe-943761acaa2ff2060d21ef519c77e1b9', 'dataframe-1c2f7e9c53dbd30220792e425418e343', 'dataframe-9f81a4cd8df8f65d5d1ee3368ec8e4ba']
 
 
 def test_df():
@@ -114,7 +114,7 @@ def test_df_different_virtual_columns():
     y = x**2
     df1 = vaex.from_arrays(x=x, y=y, z=x+y)
     df1['z'] = df1.x + df1.z
-    assert df1.fingerprint() in ['dataframe-8f2202e2b4e7845c8ace767db5a49bc4', 'dataframe-b72cf197307aa4b9806e6ce3199b2960']
+    assert df1.fingerprint() in ['dataframe-8f2202e2b4e7845c8ace767db5a49bc4', 'dataframe-b72cf197307aa4b9806e6ce3199b2960', 'dataframe-3dccec28d5db6bc592576116ef05d805']
     df2 = vaex.from_arrays(x=x, y=y, z=x+y)
     df2['z'] = df2.x - df2.z
     assert df2.fingerprint() in ['dataframe-81043a3c5b32eaa4b18bf4a915492e23', 'dataframe-0e9a4e2753715ff592527dcee1f1e8c2']
@@ -137,7 +137,7 @@ def test_df_project():
     df_a = df[['x', 'y']]
     df_b = df[['x', 'y']]
     assert df_a.fingerprint() == df_b.fingerprint()
-    assert df_a.fingerprint() in ['dataframe-c13a4ab588272f03855ae5627731f7e5', 'dataframe-d4565ca8187231a051a9ff888ba16e7c']
+    assert df_a.fingerprint() in ['dataframe-c13a4ab588272f03855ae5627731f7e5', 'dataframe-d4565ca8187231a051a9ff888ba16e7c', 'dataframe-2029c62052149fa7a811f4bb6170a2b6']
 
 
 def test_df_selection_references_virtual_column():

--- a/tests/fingerprint_test.py
+++ b/tests/fingerprint_test.py
@@ -99,7 +99,7 @@ def test_dataset_arrays():
     assert ds.fingerprint in ['dataset-arrays-hashed-88244cf38fe91c6bf435caa6160b089b', 'dataset-arrays-hashed-148c30472b155430f46bfb94d5509cf4', 'dataset-arrays-hashed-ed88ca5523bad737bbdbee53eaba3ca1']
 
 
-df_fingerprints_xy = ['dataframe-943761acaa2ff2060d21ef519c77e1b9', 'dataframe-1c2f7e9c53dbd30220792e425418e343', 'dataframe-9f81a4cd8df8f65d5d1ee3368ec8e4ba']
+df_fingerprints_xy = ['dataframe-943761acaa2ff2060d21ef519c77e1b9', 'dataframe-1c2f7e9c53dbd30220792e425418e343', 'dataframe-9f81a4cd8df8f65d5d1ee3368ec8e4ba', 'dataframe-5c6b97012243d0f534be85ed88d4da43', 'dataframe-5c6b97012243d0f534be85ed88d4da43']
 
 
 def test_df():
@@ -114,10 +114,10 @@ def test_df_different_virtual_columns():
     y = x**2
     df1 = vaex.from_arrays(x=x, y=y, z=x+y)
     df1['z'] = df1.x + df1.z
-    assert df1.fingerprint() in ['dataframe-8f2202e2b4e7845c8ace767db5a49bc4', 'dataframe-b72cf197307aa4b9806e6ce3199b2960', 'dataframe-3dccec28d5db6bc592576116ef05d805']
+    assert df1.fingerprint() in ['dataframe-8f2202e2b4e7845c8ace767db5a49bc4', 'dataframe-b72cf197307aa4b9806e6ce3199b2960', 'dataframe-3dccec28d5db6bc592576116ef05d805', 'dataframe-c48e8490b3ddf553a0184967376334c1']
     df2 = vaex.from_arrays(x=x, y=y, z=x+y)
     df2['z'] = df2.x - df2.z
-    assert df2.fingerprint() in ['dataframe-81043a3c5b32eaa4b18bf4a915492e23', 'dataframe-0e9a4e2753715ff592527dcee1f1e8c2']
+    assert df2.fingerprint() in ['dataframe-81043a3c5b32eaa4b18bf4a915492e23', 'dataframe-0e9a4e2753715ff592527dcee1f1e8c2', '']
 
 
 def test_df_with_dependencies():
@@ -137,7 +137,7 @@ def test_df_project():
     df_a = df[['x', 'y']]
     df_b = df[['x', 'y']]
     assert df_a.fingerprint() == df_b.fingerprint()
-    assert df_a.fingerprint() in ['dataframe-c13a4ab588272f03855ae5627731f7e5', 'dataframe-d4565ca8187231a051a9ff888ba16e7c', 'dataframe-2029c62052149fa7a811f4bb6170a2b6']
+    assert df_a.fingerprint() in ['dataframe-c13a4ab588272f03855ae5627731f7e5', 'dataframe-d4565ca8187231a051a9ff888ba16e7c', 'dataframe-2029c62052149fa7a811f4bb6170a2b6', 'dataframe-3eff215820906d4a751eddda1a58a1d7']
 
 
 def test_df_selection_references_virtual_column():


### PR DESCRIPTION
Supersedes https://github.com/vaexio/vaex/pull/2433, see also https://github.com/scipy/oldest-supported-numpy/pull/86

on master there is only one failing wheel build: https://github.com/vaexio/vaex/actions/runs/10835977160/job/30068700570

due to oldest-supported-numpy selecting a version of numpy for which no wheels are available. building numpy from source under QEMU takes forever, so we're hitting the builtin github actions 6 hour timeout (which can't be increased)