### PR TITLE
Build using backward-compatible numpy API

### DIFF
--- a/packages/vaex-core/pyproject.toml
+++ b/packages/vaex-core/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "oldest-supported-numpy",
+    "numpy~=1.25",  # backward compatible build-system as of v1.25 ref https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency#
     "scikit-build",
     "cmake",
     "ninja"


### PR DESCRIPTION
deprecate oldest-supported-numpy ([deprecation notice](https://github.com/scipy/oldest-supported-numpy/blob/23ece5a161d5957f5142991393d2ae689ee45b9d/README.rst)) 