### PR TITLE
Update vaex version ranges

### DIFF
--- a/packages/vaex/setup.py
+++ b/packages/vaex/setup.py
@@ -17,13 +17,13 @@ url = 'https://www.github.com/vaexio/vaex'
 
 install_requires = [
       'vaex-core~=4.18.0',
-      'vaex-astro>=0.9.3,<0.10',
-      'vaex-hdf5>=0.13.0,<0.15',
-      'vaex-viz>=0.5.4,<0.6',
-      'vaex-server~=0.9.0',
-      'vaex-jupyter>=0.8.2,<0.9',
-      'vaex-ml>=0.18.3,<0.19',
-      # vaex-graphql is not on conda-forge yet
+      'vaex-astro~=0.10.0',
+      'vaex-hdf5~=0.15.0',
+      'vaex-viz~=0.6.0',
+      'vaex-server~=0.10.0',
+      'vaex-jupyter~=0.9.0',
+      'vaex-ml~=0.19.0',
+      'vaex-graphql~=0.3.0',
 ]
 
 setup(name=name,


### PR DESCRIPTION
awaiting upcoming cp312 support releases ref https://github.com/vaexio/vaex/pull/2331#discussion_r1778800199

this PR also prevents dephell for users who go `pip install vaex` into an existing environment, leading pip to potentially choose older versions of the universal packages