### PR TITLE
Drop python 3.8, add python 3.13, allow numpy 2.x

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,10 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:
-          - {os: windows-latest, python-version: "3.8"}
-          - {os: macos-latest, python-version: "3.8"}
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/packages/vaex-core/pyproject.toml
+++ b/packages/vaex-core/pyproject.toml
@@ -1,8 +1,10 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "oldest-supported-numpy; python_version=='3.8'", # deprecated ref https://github.com/scipy/oldest-supported-numpy
-    "numpy~=1.25; python_version>'3.8'",  # numpy~=2.0 fails, backward compatible build-system as of v1.25 ref https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency
+    # pythohn 3.9 supported in numpy v2.0
+    # python 3.13 supported as of numpy v2.1
+    # ref https://github.com/scipy/oldest-supported-numpy/pull/86
+    "numpy~=2.0",
     "scikit-build",
     "cmake",
     "ninja"

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -23,14 +23,12 @@ author_email = "maartenbreddels@gmail.com"
 license = "MIT"
 version = version.__version__
 url = "https://www.github.com/maartenbreddels/vaex"
-# TODO: after python2 supports frops, future and futures can also be dropped
-setup_requires = ["numpy~=1.17"]
+setup_requires = ["numpy~=2.0"] # see vaex-core pyproject.toml
 install_requires_core = [
-    "numpy~=1.17",
+    "numpy>=1.19.3,<3", # 1.19.3 is the first version with 3.9 wheels
     "aplus",
     "tabulate>=0.8.3",
     "dask!=2022.4.0,<2024.9",  # fingerprinting in no longer deterministic as of 2024.9.0
-    "future>=0.15.2",
     "pyyaml",
     "six",
     "cloudpickle",
@@ -271,13 +269,15 @@ setup(
     if not use_skbuild
     else [],
     zip_safe=False,
-    python_requires=">=3.8,<3.13",  # 3.13 needs numpy 2.1 support ref https://github.com/vaexio/vaex/pull/2434
+    # 3.9 is the oldest python version that the new numpy build system supports
+    # ref https://github.com/scipy/oldest-supported-numpy/pull/86
+    python_requires=">=3.9,<3.14",
     classifiers=[
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     extras_require=extras_require_core,
     entry_points={


### PR DESCRIPTION
## help wanted! this is failing and I don't have time to debug.
for python 3.13 support, the build system needs to be compatible with numpy 2.1

despite buildtime needing numpy 2.x, the runtime dependency can theoretically still allow numpy 1.x (see diff).

close https://github.com/vaexio/vaex/issues/2425


> - python 3.7 - 3.12 can be supported with numpy v1 build-system
> - python 3.9 - 3.13 can be supported with numpy v2 build-system

ref https://github.com/scipy/oldest-supported-numpy/pull/86

