### PR TITLE
fix: add missing include to fix vaex-core build with gcc-13

### DIFF
--- a/packages/vaex-core/src/string_utils.hpp
+++ b/packages/vaex-core/src/string_utils.hpp
@@ -1,4 +1,5 @@
 /* regex match/search using string_view */
+#include <cstdint>
 #include <nonstd/string_view.hpp>
 #include <regex>
 


### PR DESCRIPTION
Fixes #2382