### PR TITLE
feat: Add cmake & ninja build requirements only when needed

### DIFF
--- a/packages/vaex-core/pyproject.toml
+++ b/packages/vaex-core/pyproject.toml
@@ -4,6 +4,4 @@ requires = [
     "oldest-supported-numpy; python_version=='3.8'", # deprecated ref https://github.com/scipy/oldest-supported-numpy
     "numpy~=1.25; python_version>'3.8'",  # numpy~=2.0 fails, backward compatible build-system as of v1.25 ref https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency
     "scikit-build",
-    "cmake",
-    "ninja"
 ]

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import shutil
 import sys
 import os
 from importlib.machinery import SourceFileLoader
@@ -25,6 +26,11 @@ version = version.__version__
 url = "https://www.github.com/maartenbreddels/vaex"
 # TODO: after python2 supports frops, future and futures can also be dropped
 setup_requires = ["numpy~=1.17"]
+if use_skbuild:
+    if not shutil.which("cmake"):
+        setup_requires += ["cmake"]
+    if not shutil.which("ninja"):
+        setup_requires += ["ninja"]
 install_requires_core = [
     "numpy~=1.17",
     "aplus",


### PR DESCRIPTION
Rather than listing `cmake` and `ninja` build requirements unconditionally, add them to `setup_requires` when they are necessary -- that is, when using skbuild and when the system installations of these tools are not available.  This avoids installing the packages unnecessarily, and improves portability by using downstream patched CMake version when available.