### PR TITLE
Bump pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -131,6 +131,6 @@ jobs:
 
     # https://github.com/pypa/gh-action-pypi-publish#trusted-publishing
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.10.2
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         skip-existing: true

--- a/packages/vaex-core/vaex/core/_version.py
+++ b/packages/vaex-core/vaex/core/_version.py
@@ -1,2 +1,2 @@
-__version_tuple__ = (4, 18, 1)
-__version__ = '4.18.1'
+__version_tuple__ = (4, 19, 0)
+__version__ = '4.19.0'

--- a/packages/vaex/setup.py
+++ b/packages/vaex/setup.py
@@ -16,7 +16,7 @@ version = version.__version__
 url = 'https://www.github.com/vaexio/vaex'
 
 install_requires = [
-      'vaex-core~=4.18.1',
+      'vaex-core~=4.19.0',
       'vaex-astro>=0.9.3,<0.10',
       'vaex-hdf5>=0.13.0,<0.15',
       'vaex-viz>=0.5.4,<0.6',


### PR DESCRIPTION
cibuildwheel now creates wheels with Metadata 2.4, whereas current pypa/gh-action-pypi-publish only allows up until 2.3