### PR TITLE
Bump wheel-universal.yml

### DIFF
--- a/.github/workflows/wheel-universal.yml
+++ b/.github/workflows/wheel-universal.yml
@@ -80,7 +80,7 @@ jobs:
 
     # https://github.com/pypa/gh-action-pypi-publish#trusted-publishing
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.10.2
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       if: startsWith(github.ref, 'refs/tags')
       with:
         skip-existing: true

--- a/packages/vaex-core/setup.py
+++ b/packages/vaex-core/setup.py
@@ -55,7 +55,7 @@ extras_require_core = {
         "httpx",
         "ipyvolume",
         "psutil",
-        "s3fs",
+        "s3fs>=2024",
     ],
 }
 


### PR DESCRIPTION
a different error in `wheel-universal.yml` -- looks like this yml file has not yet been added to the PyPA trusted publishing settings. can you double check?