### PR TITLE
Fix object dtype to string conversion

### DIFF
--- a/packages/vaex-core/vaex/functions.py
+++ b/packages/vaex-core/vaex/functions.py
@@ -2407,8 +2407,14 @@ def to_string(x):
     # don't change the dtype, otherwise for each block the dtype may be different (string length)
     ar = vaex.array_types.to_numpy(x)
     if np.ma.isMaskedArray(ar):
+        # Handle object dtype by converting to string array first
+        if ar.dtype == object:
+            ar = ar.astype(str)
         sl = vaex.strings.to_string(ar.data, ar.mask)
     else:
+        # Handle object dtype by converting to string array first
+        if ar.dtype == object:
+            ar = ar.astype(str)
         sl = vaex.strings.to_string(ar)
     return column.ColumnStringArrow.from_string_sequence(sl)
 


### PR DESCRIPTION
## Description

This PR fixes the issue where converting object dtype columns to string fails with a TypeError.

When calling `.astype('str')` on an object dtype column (e.g., numpy arrays with mixed types like `[123, "test", None]`), the `to_string()` function would fail because `vaex.strings.to_string()` doesn't have an overload for object dtype arrays.

## Fix

Modified the `to_string()` function in `packages/vaex-core/vaex/functions.py` to handle object dtype arrays by converting them to string arrays using `ar.astype(str)` before passing to `vaex.strings.to_string()`.

## Changes

- Added dtype check for object arrays in `to_string()`
- Convert object arrays to string arrays before processing
- Handles both regular and masked arrays

## Example

```python
import vaex
import numpy as np

# This now works correctly
arr = np.array([123, "test", None], dtype=object)
df = vaex.from_arrays(test=arr)
df['test'] = df['test'].astype('str')  # No longer raises TypeError
```

Fixes #1686
